### PR TITLE
fix: Route mismatching

### DIFF
--- a/modules/util/template.test.ts
+++ b/modules/util/template.test.ts
@@ -26,7 +26,14 @@ describe("matchTemplate()", () => {
 		expect<TemplateMatches | undefined>(matchTemplate("/review/{id}", "/review/30/mdt-view")).toBe(undefined);
 		expect(matchTemplate("/review/{id}", "/review/30")).toEqual({ id: "30" });
 		expect(matchTemplate("/review/{id}/mdt-view", "/review/30/mdt-view")).toEqual({ id: "30" });
-		expect(matchTemplate("/review/*", "/review/30/mdt-view")).toEqual({ "0": "30/mdt-view" });
+		expect(matchTemplate("/review/*", "/review/30")).toEqual({ "0": "30" });
+		expect(matchTemplate("/review/*/mdt-view", "/review/30/mdt-view")).toEqual({ "0": "30" });
+	});
+	test("Double splat placeholders can match multiple path segments", () => {
+		expect(matchTemplate("/review/**", "/review/30/mdt-view")).toEqual({ "0": "30/mdt-view" });
+		expect(matchTemplate("/files/**", "/files/a/b/c/d.txt")).toEqual({ "0": "a/b/c/d.txt" });
+		expect(matchTemplate("/files/**/info", "/files/a/b/c/d/info")).toEqual({ "0": "a/b/c/d" });
+		expect<TemplateMatches | undefined>(matchTemplate("/files/**/info", "/files/a/b/c/d.txt")).toBe(undefined);
 	});
 	test("Correct non-matches", () => {
 		// No params.
@@ -60,6 +67,8 @@ describe("getPlaceholders()", () => {
 		expect(getPlaceholders("/:a/{b}/${c}/{{d}}/")).toEqual(["a", "b", "c", "d"]);
 		expect(getPlaceholders("/*/")).toEqual(["0"]);
 		expect(getPlaceholders("*/*")).toEqual(["0", "1"]);
+		expect(getPlaceholders("**")).toEqual(["0"]);
+		expect(getPlaceholders("**|**")).toEqual(["0", "1"]);
 		expect(getPlaceholders("*/{a}/*/${b}/*")).toEqual(["0", "a", "1", "b", "2"]);
 	});
 	test("Splits correctly using cache", () => {


### PR DESCRIPTION
/review/{id}: Previously matched /review/30/mdt-view and set id="30/mdt-view". 

Now it only matches /review/30 (or any single-segment like /review/foo);

This has likely gone under the radar because it is not noticeable if your handlers are ordered most specific to least, it will match the first one it finds.