### PR TITLE
Support dotted nested keys in renderTemplate (e.g. {a.b})

### DIFF
--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -1,11 +1,11 @@
 import { RequiredError } from "../error/RequiredError.js";
 import { ValueError } from "../error/ValueError.js";
-import type { ImmutableArray } from "./array.js";
+import { isArray, type ImmutableArray } from "./array.js";
 import { getDataProp, isData } from "./data.js";
 import { EMPTY_DICTIONARY, type ImmutableDictionary } from "./dictionary.js";
 import { type AnyCaller, isFunction } from "./function.js";
 import { setMapItem } from "./map.js";
-import { isObject, type Mutable } from "./object.js";
+import { type Mutable } from "./object.js";
 import { getString, type NotString, type PossibleString } from "./string.js";
 
 /** Single template chunk. */
@@ -154,9 +154,9 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 				throw new RequiredError(`Template placeholder "${name}" not found in object`, { received: values, name, caller });
 			output = output.replace(placeholder, v);
 		}
-	} else if (isObject(values)) {
+	} else if (isArray(values)) {
 		for (const { name, placeholder } of chunks) {
-			const v = getString(values[name]);
+			const v = getString(values[Number(name)]);
 			if (v === undefined) throw new RequiredError(`Template placeholder "${name}" not found in array`, { received: values, name, caller });
 			output = output.replace(placeholder, v);
 		}

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -150,7 +150,8 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 	} else if (isData(values)) {
 		for (const { name, placeholder } of chunks) {
 			const v = getString(getDataProp(values, name));
-			if (v === undefined) throw new RequiredError(`Template placeholder "${name}" not found in object`, { received: values, name, caller });
+			if (v === undefined)
+				throw new RequiredError(`Template placeholder "${name}" not found in object`, { received: values, name, caller });
 			output = output.replace(placeholder, v);
 		}
 	} else if (isObject(values)) {

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -1,10 +1,10 @@
 import { RequiredError } from "../error/RequiredError.js";
 import { ValueError } from "../error/ValueError.js";
 import type { ImmutableArray } from "./array.js";
+import { type Data, getDataProp } from "./data.js";
 import { EMPTY_DICTIONARY, type ImmutableDictionary } from "./dictionary.js";
 import { type AnyCaller, isFunction } from "./function.js";
 import { setMapItem } from "./map.js";
-import { getDataProp, type Data } from "./data.js";
 import { isObject, type Mutable } from "./object.js";
 import { getString, type NotString, type PossibleString } from "./string.js";
 

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -1,7 +1,7 @@
 import { RequiredError } from "../error/RequiredError.js";
 import { ValueError } from "../error/ValueError.js";
 import type { ImmutableArray } from "./array.js";
-import { type Data, getDataProp } from "./data.js";
+import { getDataProp, isData } from "./data.js";
 import { EMPTY_DICTIONARY, type ImmutableDictionary } from "./dictionary.js";
 import { type AnyCaller, isFunction } from "./function.js";
 import { setMapItem } from "./map.js";
@@ -150,9 +150,13 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 }
 function _replaceTemplateKey(key: string, values: TemplateValues, caller: AnyCaller): string {
 	if (isFunction(values)) return values(key);
-	if (isObject(values)) {
-		// Dictionary or array of values. Dotted keys (e.g. "a.b") traverse nested objects.
-		const v = getString(getDataProp(values as Data, key));
+	if (isData(values)) {
+		// Plain object: dotted keys (e.g. "a.b") traverse nested objects.
+		const v = getString(getDataProp(values, key));
+		if (v !== undefined) return v;
+	} else if (isObject(values)) {
+		// Array: look up by key directly.
+		const v = getString(values[key]);
 		if (v !== undefined) return v;
 	} else {
 		// Single value for all placeholders.

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -4,6 +4,7 @@ import type { ImmutableArray } from "./array.js";
 import { EMPTY_DICTIONARY, type ImmutableDictionary } from "./dictionary.js";
 import { type AnyCaller, isFunction } from "./function.js";
 import { setMapItem } from "./map.js";
+import { getDataProp, type Data } from "./data.js";
 import { isObject, type Mutable } from "./object.js";
 import { getString, type NotString, type PossibleString } from "./string.js";
 
@@ -150,8 +151,8 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 function _replaceTemplateKey(key: string, values: TemplateValues, caller: AnyCaller): string {
 	if (isFunction(values)) return values(key);
 	if (isObject(values)) {
-		// Dictionary or array of values.
-		const v = getString(values[key]);
+		// Dictionary or array of values. Dotted keys (e.g. "a.b") traverse nested objects.
+		const v = getString(getDataProp(values as Data, key));
 		if (v !== undefined) return v;
 	} else {
 		// Single value for all placeholders.

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -145,23 +145,24 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 	const chunks = _splitTemplateCached(template, caller);
 	if (!chunks.length) return template;
 	let output = template;
-	for (const { name, placeholder } of chunks) output = output.replace(placeholder, _replaceTemplateKey(name, values, caller));
-	return output;
-}
-function _replaceTemplateKey(key: string, values: TemplateValues, caller: AnyCaller): string {
-	if (isFunction(values)) return values(key);
-	if (isData(values)) {
-		// Plain object: dotted keys (e.g. "a.b") traverse nested objects.
-		const v = getString(getDataProp(values, key));
-		if (v !== undefined) return v;
+	if (isFunction(values)) {
+		for (const { name, placeholder } of chunks) output = output.replace(placeholder, values(name));
+	} else if (isData(values)) {
+		for (const { name, placeholder } of chunks) {
+			const v = getString(getDataProp(values, name));
+			if (v === undefined) throw new RequiredError(`Template placeholder "${name}" not found in object`, { received: values, name, caller });
+			output = output.replace(placeholder, v);
+		}
 	} else if (isObject(values)) {
-		// Array: look up by key directly.
-		const v = getString(values[key]);
-		if (v !== undefined) return v;
+		for (const { name, placeholder } of chunks) {
+			const v = getString(values[name]);
+			if (v === undefined) throw new RequiredError(`Template placeholder "${name}" not found in array`, { received: values, name, caller });
+			output = output.replace(placeholder, v);
+		}
 	} else {
-		// Single value for all placeholders.
 		const v = getString(values);
-		if (v !== undefined) return v;
+		if (v === undefined) throw new RequiredError(`Template value must be string`, { received: values, caller });
+		for (const { placeholder } of chunks) output = output.replace(placeholder, v);
 	}
-	throw new RequiredError(`Template value for "${key}" must be string`, { received: values, key, caller });
+	return output;
 }

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -1,11 +1,11 @@
 import { RequiredError } from "../error/RequiredError.js";
 import { ValueError } from "../error/ValueError.js";
-import { isArray, type ImmutableArray } from "./array.js";
+import { type ImmutableArray, isArray } from "./array.js";
 import { getDataProp, isData } from "./data.js";
 import { EMPTY_DICTIONARY, type ImmutableDictionary } from "./dictionary.js";
 import { type AnyCaller, isFunction } from "./function.js";
 import { setMapItem } from "./map.js";
-import { type Mutable } from "./object.js";
+import type { Mutable } from "./object.js";
 import { getString, type NotString, type PossibleString } from "./string.js";
 
 /** Single template chunk. */


### PR DESCRIPTION
Uses getDataProp() from data.ts to traverse nested objects when a
placeholder key contains dots, so renderTemplate("/{a.b}", { a: { b: "x" } })
now works as expected.

https://claude.ai/code/session_01JcXrnT1r6m6dnN2pi5yWTJ