### PR TITLE
fix: fetch origin main before semantic-release to avoid behind-remote error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,8 @@ jobs:
           git config --global gpg.format ssh
           git config --global user.signingkey ~/.ssh/git.pub
           git config --global commit.gpgsign true
+      - name: fetch
+        run: git fetch origin main
       - name: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
semantic-release was failing with "The local branch main is behind the remote one, therefore a new version won't be published." Adding a `git fetch origin main` step immediately before `semantic-release` ensures the local branch is synced with remote after the build/test steps complete.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hi8o7E99yS1s2XM3YUWc13)_