### PR TITLE
Add debounce support to PayloadFetchStore

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "shelving",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.13",
+        "@biomejs/biome": "^2.4.14",
         "@google-cloud/firestore": "^8.5.0",
         "@types/bun": "^1.3.13",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
+        "@typescript/native-preview": "^7.0.0-dev.20260502.1",
         "firebase": "^12.12.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",

--- a/modules/store/PayloadFetchStore.test.ts
+++ b/modules/store/PayloadFetchStore.test.ts
@@ -130,6 +130,79 @@ test("different object payload triggers a re-fetch with the new payload", async 
 	expect(received).toEqual([1, 2]);
 });
 
+// --- Debounce ---
+
+test("debounce: busy is true immediately but fetch is delayed", async () => {
+	const received: string[] = [];
+	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
+		received.push(p);
+		return Promise.resolve(`result:${p}`);
+	}, 20);
+
+	store.payload.value = "B";
+	await runMicrotasks();
+
+	// Busy immediately, but callback not yet called.
+	expect(store.busy.value).toBe(true);
+	expect(received).toEqual([]);
+
+	await new Promise(r => setTimeout(r, 30));
+
+	expect(store.value).toBe("result:B");
+	expect(received).toEqual(["B"]);
+});
+
+test("debounce: rapid payload changes only trigger one fetch with the last payload", async () => {
+	const received: string[] = [];
+	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
+		received.push(p);
+		return Promise.resolve(`result:${p}`);
+	}, 20);
+
+	store.payload.value = "B";
+	await runMicrotasks();
+	store.payload.value = "C";
+	await runMicrotasks();
+	store.payload.value = "D";
+	await runMicrotasks();
+
+	// Still no fetch yet.
+	expect(received).toEqual([]);
+
+	await new Promise(r => setTimeout(r, 30));
+
+	expect(store.value).toBe("result:D");
+	expect(received).toEqual(["D"]);
+});
+
+test("debounce: busy stays true across rapid changes", async () => {
+	const store = new PayloadFetchStore<string, string>("A", NONE, p => Promise.resolve(`result:${p}`), 20);
+
+	store.payload.value = "B";
+	await runMicrotasks();
+	expect(store.busy.value).toBe(true);
+
+	store.payload.value = "C";
+	await runMicrotasks();
+	expect(store.busy.value).toBe(true);
+
+	await new Promise(r => setTimeout(r, 30));
+	expect(store.busy.value).toBe(false);
+});
+
+test("debounce=0: behaves identically to no debounce", async () => {
+	const received: string[] = [];
+	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
+		received.push(p);
+		return Promise.resolve(`result:${p}`);
+	}, 0);
+
+	expect(store.loading).toBe(true);
+	await runMicrotasks();
+	expect(store.value).toBe("result:A");
+	expect(received).toEqual(["A"]);
+});
+
 // --- Dispose ---
 
 test("asyncDispose() cleans up without throwing", async () => {

--- a/modules/store/PayloadFetchStore.test.ts
+++ b/modules/store/PayloadFetchStore.test.ts
@@ -134,10 +134,15 @@ test("different object payload triggers a re-fetch with the new payload", async 
 
 test("debounce: busy is true immediately but fetch is delayed", async () => {
 	const received: string[] = [];
-	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
-		received.push(p);
-		return Promise.resolve(`result:${p}`);
-	}, 20);
+	const store = new PayloadFetchStore<string, string>(
+		"A",
+		NONE,
+		p => {
+			received.push(p);
+			return Promise.resolve(`result:${p}`);
+		},
+		20,
+	);
 
 	store.payload.value = "B";
 	await runMicrotasks();
@@ -154,10 +159,15 @@ test("debounce: busy is true immediately but fetch is delayed", async () => {
 
 test("debounce: rapid payload changes only trigger one fetch with the last payload", async () => {
 	const received: string[] = [];
-	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
-		received.push(p);
-		return Promise.resolve(`result:${p}`);
-	}, 20);
+	const store = new PayloadFetchStore<string, string>(
+		"A",
+		NONE,
+		p => {
+			received.push(p);
+			return Promise.resolve(`result:${p}`);
+		},
+		20,
+	);
 
 	store.payload.value = "B";
 	await runMicrotasks();
@@ -192,10 +202,15 @@ test("debounce: busy stays true across rapid changes", async () => {
 
 test("debounce=0: behaves identically to no debounce", async () => {
 	const received: string[] = [];
-	const store = new PayloadFetchStore<string, string>("A", NONE, p => {
-		received.push(p);
-		return Promise.resolve(`result:${p}`);
-	}, 0);
+	const store = new PayloadFetchStore<string, string>(
+		"A",
+		NONE,
+		p => {
+			received.push(p);
+			return Promise.resolve(`result:${p}`);
+		},
+		0,
+	);
 
 	expect(store.loading).toBe(true);
 	await runMicrotasks();

--- a/modules/store/PayloadFetchStore.ts
+++ b/modules/store/PayloadFetchStore.ts
@@ -1,4 +1,5 @@
 import type { NONE } from "../util/constants.js";
+import { awaitAbort, getDelay } from "../util/async.js";
 import { awaitDispose } from "../util/dispose.js";
 import { FetchStore } from "./FetchStore.js";
 import { Store } from "./Store.js";
@@ -11,6 +12,7 @@ export type PayloadFetchCallback<P, R> = (payload: P, signal: AbortSignal) => R 
  * @param payload The initial payload for the store.
  * @param value The initial value for the store, or `NONE` if it does not have one yet.
  * @param callback An optional callback that, if set, will be called with the current payload when the `fetch()` method is invoked to fetch the next value.
+ * @param debounce Delay in milliseconds before the fetch is triggered after a payload change. `busy` becomes `true` immediately; the actual fetch waits for the debounce period to expire. If the payload changes again before the delay expires the previous fetch is cancelled and the timer resets.
  */
 export class PayloadFetchStore<P, R> extends FetchStore<R> {
 	/**
@@ -20,9 +22,16 @@ export class PayloadFetchStore<P, R> extends FetchStore<R> {
 	readonly payload: Store<P>;
 
 	// Override to save initial payload and callback.
-	constructor(payload: P, value: R | typeof NONE, callback?: PayloadFetchCallback<P, R>) {
+	constructor(payload: P, value: R | typeof NONE, callback?: PayloadFetchCallback<P, R>, debounce = 0) {
 		const payloadStore = new Store(payload);
-		super(value, callback && (signal => callback(payloadStore.value, signal)));
+		const fetch = callback && (debounce > 0
+			? async (signal: AbortSignal) => {
+				const snap = payloadStore.value;
+				await Promise.race([getDelay(debounce), awaitAbort(signal)]);
+				return callback(snap, signal);
+			}
+			: (signal: AbortSignal) => callback(payloadStore.value, signal));
+		super(value, fetch);
 		this.payload = payloadStore;
 		void _iterate(this);
 	}

--- a/modules/store/PayloadFetchStore.ts
+++ b/modules/store/PayloadFetchStore.ts
@@ -1,5 +1,5 @@
-import type { NONE } from "../util/constants.js";
 import { awaitAbort, getDelay } from "../util/async.js";
+import type { NONE } from "../util/constants.js";
 import { awaitDispose } from "../util/dispose.js";
 import { FetchStore } from "./FetchStore.js";
 import { Store } from "./Store.js";
@@ -24,13 +24,15 @@ export class PayloadFetchStore<P, R> extends FetchStore<R> {
 	// Override to save initial payload and callback.
 	constructor(payload: P, value: R | typeof NONE, callback?: PayloadFetchCallback<P, R>, debounce = 0) {
 		const payloadStore = new Store(payload);
-		const fetch = callback && (debounce > 0
-			? async (signal: AbortSignal) => {
-				const snap = payloadStore.value;
-				await Promise.race([getDelay(debounce), awaitAbort(signal)]);
-				return callback(snap, signal);
-			}
-			: (signal: AbortSignal) => callback(payloadStore.value, signal));
+		const fetch =
+			callback &&
+			(debounce > 0
+				? async (signal: AbortSignal) => {
+						const snap = payloadStore.value;
+						await Promise.race([getDelay(debounce), awaitAbort(signal)]);
+						return callback(snap, signal);
+					}
+				: (signal: AbortSignal) => callback(payloadStore.value, signal));
 		super(value, fetch);
 		this.payload = payloadStore;
 		void _iterate(this);

--- a/modules/util/async.test.ts
+++ b/modules/util/async.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { awaitValues, getDeferred, Errors as ShelvingAggregateError } from "../index.js";
+import { awaitAbort, awaitValues, getDeferred, Errors as ShelvingAggregateError } from "../index.js";
 
+describe("awaitAbort()", () => {
+	test("rejects when signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort("reason");
+		await expect(awaitAbort(controller.signal)).rejects.toBe("reason");
+	});
+	test("rejects when signal fires after creation", async () => {
+		const controller = new AbortController();
+		const promise = awaitAbort(controller.signal);
+		controller.abort("later");
+		await expect(promise).rejects.toBe("later");
+	});
+	test("races against getDelay — delay wins when signal never fires", async () => {
+		const controller = new AbortController();
+		const { getDelay } = await import("./async.js");
+		const result = await Promise.race([getDelay(10).then(() => "done"), awaitAbort(controller.signal).catch(() => "aborted")]);
+		expect(result).toBe("done");
+	});
+	test("races against getDelay — abort wins when signal fires first", async () => {
+		const controller = new AbortController();
+		const { getDelay } = await import("./async.js");
+		const race = Promise.race([getDelay(100).then(() => "done"), awaitAbort(controller.signal).catch(() => "aborted")]);
+		controller.abort();
+		expect(await race).toBe("aborted");
+	});
+});
 describe("Deferred", () => {
 	test("Works correctly", async () => {
 		const { promise, resolve, reject } = getDeferred<string>();

--- a/modules/util/async.ts
+++ b/modules/util/async.ts
@@ -135,3 +135,17 @@ export function getDeferred<T = void>(): Deferred<T> {
 export function getDelay(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Get a promise that rejects with the signal's reason when an `AbortSignal` fires.
+ * - Rejects immediately if the signal is already aborted.
+ * - Use with `Promise.race()` to cancel a concurrent operation when a signal fires.
+ *
+ * @example await Promise.race([getDelay(300), awaitAbort(signal)]);
+ */
+export function awaitAbort(signal: AbortSignal): Promise<never> {
+	return new Promise<never>((_, reject) => {
+		if (signal.aborted) reject(signal.reason);
+		else signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+	});
+}


### PR DESCRIPTION
## Summary
This PR adds debounce functionality to `PayloadFetchStore`, allowing fetch operations to be delayed and coalesced when the payload changes rapidly. It also introduces a new utility function `awaitAbort()` for handling abort signals in async operations.

## Key Changes

- **Added `awaitAbort()` utility function** in `modules/util/async.ts`
  - Returns a promise that rejects with the signal's reason when an `AbortSignal` fires
  - Handles both pre-aborted signals and signals that fire after creation
  - Designed to be used with `Promise.race()` for cancellation patterns

- **Extended `PayloadFetchStore` constructor** with optional `debounce` parameter
  - Accepts a debounce delay in milliseconds (defaults to 0 for backward compatibility)
  - When debounce > 0, the `busy` flag becomes `true` immediately upon payload change, but the actual fetch is delayed
  - Rapid payload changes reset the debounce timer and only the final payload is fetched
  - Uses `Promise.race()` with `getDelay()` and `awaitAbort()` to implement the debounce logic

- **Added comprehensive test coverage** for debounce behavior
  - Tests verify that `busy` becomes true immediately while fetch is delayed
  - Tests confirm that rapid changes coalesce into a single fetch with the final payload
  - Tests ensure `busy` stays true across rapid changes
  - Tests verify that `debounce=0` behaves identically to no debounce

## Implementation Details

The debounce implementation captures the current payload value at the moment the debounce timer starts, then races the delay against an abort signal. This ensures that if the payload changes again before the delay expires, the previous fetch is cancelled and the timer resets. The actual fetch callback receives the payload value that was current when the debounce period expired.

https://claude.ai/code/session_01HHE5d6HxA3zeQ6JEa7SahC