### PR TITLE
Rename getter functions to use `create*` prefix for factory functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,9 @@ The codebase uses a tight, consistent prefix system. Pick the one that matches t
 | `has*` | Boolean predicate (possession / state, not type) | `hasItems` |
 | `assert*` | Throws if invalid; uses `asserts value is T` | `assertArray`, `assertString` |
 | `validate*` | Throws on invalid; returns the validated value (also strips/coerces) | `validateData` |
-| `get*` | Returns value or `undefined` — never throws for "missing" | `getString`, `getData` |
+| `get*` | Returns value or `undefined` — never throws for "missing"; may return input unchanged when already valid | `getString`, `getData` |
 | `require*` | Returns value or throws `RequiredError` | `requireFirst`, `requireString` |
+| `create*` | Always returns a freshly constructed instance — never returns the input unchanged and never returns `undefined` | `createDeferred`, `createMarkupRule`, `createJSONRequest` |
 | `with*` | Returns immutable updated copy with a value set | `withProp`, `withArrayItem` |
 | `omit*` | Returns immutable updated copy with keys removed | `omitProp`, `omitArrayItem` |
 | `add*` | Returns immutable updated copy with an item added | `addArrayItem`, `addSetItem` |
@@ -114,6 +115,8 @@ The codebase uses a tight, consistent prefix system. Pick the one that matches t
 | `run*` | Executes a callback or sequence | `runSequence` |
 
 **Pairing rule:** `get*` / `require*` and `is*` / `assert*` come as pairs over the same target. Choosing between them is a contract decision the caller depends on. If you add a new `require*`, consider whether a sibling `get*` belongs alongside it; same for `assert*` / `is*`.
+
+**`get*` vs `create*`:** if a helper unconditionally constructs and returns a brand-new instance (e.g. always calls `new X(...)` or always returns a fresh object literal), name it `create*`. Reserve `get*` for "look up, coerce, or normalise" — helpers that may return the input unchanged when it's already valid, or return `undefined` when there's nothing to return. Most factories the codebase needs are written inline as `new X(...)`; the `create*` prefix is for the few cases where a helper wraps construction (typing, defaulting, composing).
 
 ### Reserved prefixes (UI / event layer)
 

--- a/modules/api/provider/APIProvider.ts
+++ b/modules/api/provider/APIProvider.ts
@@ -35,7 +35,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @throws {RequiredError} if this is a `HEAD` or `GET` request but `payload` is not a data object.
 	 */
-	abstract getRequest<PP extends P, RR extends R>(
+	abstract createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
@@ -59,7 +59,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 		options?: RequestOptions,
 		caller?: AnyCaller,
 	): Promise<RR> {
-		const request = this.getRequest(endpoint, payload, options, caller);
+		const request = this.createRequest(endpoint, payload, options, caller);
 		const response = await this.fetch(request);
 		return this.parseResponse(endpoint, response, caller);
 	}

--- a/modules/api/provider/ClientAPIProvider.test.ts
+++ b/modules/api/provider/ClientAPIProvider.test.ts
@@ -2,28 +2,28 @@ import { describe, expect, test } from "bun:test";
 import { ClientAPIProvider, DATA, GET, POST, RequiredError, ResponseError, STRING, ValidationAPIProvider } from "../../index.js";
 
 describe("ClientAPIProvider", () => {
-	test("getRequest() renders placeholders into the URL and omits them from the remaining payload", () => {
+	test("createRequest() renders placeholders into the URL and omits them from the remaining payload", () => {
 		const provider = new ClientAPIProvider({ url: "https://api.example.com/v1/" });
 		const endpoint = GET("/users/{id}", DATA({ id: STRING, extra: STRING }), STRING);
-		const request = provider.getRequest(endpoint, { id: "123", extra: "x" });
+		const request = provider.createRequest(endpoint, { id: "123", extra: "x" });
 
 		expect(request.method).toBe("GET");
 		expect(request.url).toBe("https://api.example.com/v1/users/123?extra=x");
 	});
 
-	test("getRequest() serializes POST payloads as JSON bodies", async () => {
+	test("createRequest() serializes POST payloads as JSON bodies", async () => {
 		const provider = new ClientAPIProvider({ url: "https://api.example.com/" });
 		const endpoint = POST("/items", DATA({ name: STRING }), STRING);
-		const request = provider.getRequest(endpoint, { name: "abc" });
+		const request = provider.createRequest(endpoint, { name: "abc" });
 
 		expect(request.headers.get("Content-Type")).toBe("application/json");
 		expect(await request.text()).toBe(JSON.stringify({ name: "abc" }));
 	});
 
-	test("getRequest() rejects non-data payloads for GET endpoints", () => {
+	test("createRequest() rejects non-data payloads for GET endpoints", () => {
 		const provider = new ClientAPIProvider({ url: "https://api.example.com/" });
 		const endpoint = GET("/users/{id}", DATA({ id: STRING }), STRING);
-		expect(() => provider.getRequest(endpoint, "123" as never)).toThrow(RequiredError);
+		expect(() => provider.createRequest(endpoint, "123" as never)).toThrow(RequiredError);
 	});
 
 	test("fetch() returns validated JSON responses", async () => {

--- a/modules/api/provider/ClientAPIProvider.ts
+++ b/modules/api/provider/ClientAPIProvider.ts
@@ -4,8 +4,8 @@ import { getMessage } from "../../util/error.js";
 import type { AnyCaller } from "../../util/function.js";
 import {
 	assertRequestHeadPayload,
-	getHeadRequest,
-	getRequest,
+	createHeadRequest,
+	createRequest,
 	isRequestHeadMethod,
 	mergeRequestOptions,
 	parseResponseBody,
@@ -120,7 +120,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		options: RequestOptions,
 		caller: AnyCaller,
 	): Request {
-		return getHeadRequest(method, url, params, options, caller);
+		return createHeadRequest(method, url, params, options, caller);
 	}
 
 	/** Internal implementation function for `getRequest()` used for requests that have a body.  */
@@ -131,7 +131,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		options: RequestOptions,
 		caller: AnyCaller,
 	): Request {
-		return getRequest(method, url, payload, options, caller);
+		return createRequest(method, url, payload, options, caller);
 	}
 
 	// Override to set default functionality of a client provider to send requests over the network with `fetch()` and parse responses with `parseResponse()`.

--- a/modules/api/provider/ClientAPIProvider.ts
+++ b/modules/api/provider/ClientAPIProvider.ts
@@ -33,7 +33,7 @@ export interface ClientAPIProviderOptions {
 	readonly url: PossibleURL;
 
 	/**
-	 * Options used for HTTP requests created with `this.getRequest()` and `this.fetch()`
+	 * Options used for HTTP requests created with `this.createRequest()` and `this.fetch()`
 	 * - Omits `signal` because it's not relevant at the provider level.
 	 */
 	readonly options?: Omit<RequestOptions, "signal">;
@@ -51,14 +51,14 @@ export interface ClientAPIProviderOptions {
  * - Can be used on a server environment to make outgoing API calls, or in a browser environment to call a server API.
  * - Renders endpoint paths and query params into the URL and sends body payloads as JSON.
  * - Parses JSON responses and throws `ResponseError` for non-2xx responses.
- * - Extendable with custom request-building and response-parsing logic by overriding `getRequest()` and `parseResponse()`.
+ * - Extendable with custom request-building and response-parsing logic by overriding `createRequest()` and `parseResponse()`.
  * - Wrap in `ValidationAPIProvider` to add automatic validation of request payloads and response results against endpoint schemas.
  */
 export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, R> {
 	/** The common base URL for all rendered endpoint requests. */
 	readonly url: URL;
 
-	/** Default options used for HTTP requests created with `this.getRequest()` and `this.fetch()` */
+	/** Default options used for HTTP requests created with `this.createRequest()` and `this.fetch()` */
 	readonly options: RequestOptions;
 
 	/** Timeout in milliseconds before the request is aborted, or `0` for no timeout. */
@@ -90,11 +90,11 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		return url;
 	}
 
-	getRequest<PP extends P, RR extends R>(
+	createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
-		caller: AnyCaller = this.getRequest,
+		caller: AnyCaller = this.createRequest,
 	): Request {
 		// Render the path into the base URL.
 		const url = this.renderURL(endpoint, payload, caller);
@@ -105,15 +105,15 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		const mergedOptions = mergeRequestOptions({ signal, ...this.options }, options);
 
 		// HEAD or GET requests need no payload because it was already rendered into the URL as `?query` params by `this.renderURL()`
-		if (isRequestHeadMethod(endpoint.method)) return this._getHeadRequest(endpoint.method, url, undefined, mergedOptions, caller);
+		if (isRequestHeadMethod(endpoint.method)) return this._createHeadRequest(endpoint.method, url, undefined, mergedOptions, caller);
 
 		// Body request.
 		const body: P = isData(payload) ? (omitProps(payload, ...endpoint.placeholders) as P) : payload; // Omit any params that have already been embedded as `{placeholders}`.
-		return this._getBodyRequest(endpoint.method, url, body, mergedOptions, caller);
+		return this._createBodyRequest(endpoint.method, url, body, mergedOptions, caller);
 	}
 
-	/** Internal implementation function for `getRequest()` used for requests that have no body. */
-	protected _getHeadRequest(
+	/** Internal implementation function for `createRequest()` used for requests that have no body. */
+	protected _createHeadRequest(
 		method: RequestHeadMethod, //
 		url: PossibleURL,
 		params: Nullish<PossibleURIParams>,
@@ -123,8 +123,8 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		return createHeadRequest(method, url, params, options, caller);
 	}
 
-	/** Internal implementation function for `getRequest()` used for requests that have a body.  */
-	protected _getBodyRequest(
+	/** Internal implementation function for `createRequest()` used for requests that have a body.  */
+	protected _createBodyRequest(
 		method: RequestBodyMethod, //
 		url: PossibleURL,
 		payload: P,

--- a/modules/api/provider/DebugAPIProvider.ts
+++ b/modules/api/provider/DebugAPIProvider.ts
@@ -7,14 +7,14 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
 
 /** Provider that logs everything to the console in some detail to help diagnose issues in development. */
 export class DebugAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
-	override getRequest<PP extends P, RR extends R>(
+	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
-		caller: AnyCaller = this.getRequest,
+		caller: AnyCaller = this.createRequest,
 	): Request {
 		try {
-			const request = super.getRequest(endpoint, payload, options, caller);
+			const request = super.createRequest(endpoint, payload, options, caller);
 			console.debug(`${ANSI_WAITING} ${endpoint.toString()}`, payload);
 			return request;
 		} catch (reason) {

--- a/modules/api/provider/JSONAPIProvider.test.ts
+++ b/modules/api/provider/JSONAPIProvider.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { DATA, GET, JSONAPIProvider, POST, ResponseError, STRING } from "../../index.js";
 
 describe("JSONAPIProvider", () => {
-	test("getRequest() serializes POST payloads as JSON bodies", async () => {
+	test("createRequest() serializes POST payloads as JSON bodies", async () => {
 		const provider = new JSONAPIProvider({ url: "https://api.example.com/" });
 		const endpoint = POST("/items", DATA({ name: STRING }), STRING);
-		const request = provider.getRequest(endpoint, { name: "abc" });
+		const request = provider.createRequest(endpoint, { name: "abc" });
 
 		expect(request.headers.get("Content-Type")).toBe("application/json");
 		expect(await request.text()).toBe('{"name":"abc"}');

--- a/modules/api/provider/JSONAPIProvider.ts
+++ b/modules/api/provider/JSONAPIProvider.ts
@@ -1,7 +1,7 @@
 import { ResponseError } from "../../error/ResponseError.js";
 import { getMessage } from "../../util/error.js";
 import type { AnyCaller } from "../../util/function.js";
-import { getJSONRequest, parseResponseJSON, type RequestBodyMethod, type RequestOptions } from "../../util/http.js";
+import { createJSONRequest, parseResponseJSON, type RequestBodyMethod, type RequestOptions } from "../../util/http.js";
 import type { PossibleURL } from "../../util/url.js";
 import type { Endpoint } from "../endpoint/Endpoint.js";
 import { ClientAPIProvider } from "./ClientAPIProvider.js";
@@ -15,7 +15,7 @@ export class JSONAPIProvider<P = unknown, R = unknown> extends ClientAPIProvider
 		options: RequestOptions,
 		caller: AnyCaller,
 	): Request {
-		return getJSONRequest(method, url, payload, options, caller);
+		return createJSONRequest(method, url, payload, options, caller);
 	}
 
 	/**

--- a/modules/api/provider/JSONAPIProvider.ts
+++ b/modules/api/provider/JSONAPIProvider.ts
@@ -8,7 +8,7 @@ import { ClientAPIProvider } from "./ClientAPIProvider.js";
 
 /** API provider that always sends request bodies as JSON and parses responses as JSON. */
 export class JSONAPIProvider<P = unknown, R = unknown> extends ClientAPIProvider<P, R> {
-	protected override _getBodyRequest(
+	protected override _createBodyRequest(
 		method: RequestBodyMethod,
 		url: PossibleURL,
 		payload: P,

--- a/modules/api/provider/MockAPIProvider.ts
+++ b/modules/api/provider/MockAPIProvider.ts
@@ -46,14 +46,14 @@ export class MockAPIProvider<P = unknown, R = unknown> extends ThroughAPIProvide
 		this.handler = handler;
 	}
 
-	// Override `getRequest()` to log the endpoint and payload before delegating to the source provider for request building.
-	override getRequest<PP extends P, RR extends R>(
+	// Override `createRequest()` to log the endpoint and payload before delegating to the source provider for request building.
+	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
-		caller: AnyCaller = this.getRequest,
+		caller: AnyCaller = this.createRequest,
 	): Request {
-		const request = super.getRequest(endpoint, payload, options, caller);
+		const request = super.createRequest(endpoint, payload, options, caller);
 		this.requestCalls.push({ endpoint, payload, options, request });
 		return request;
 	}

--- a/modules/api/provider/ThroughAPIProvider.ts
+++ b/modules/api/provider/ThroughAPIProvider.ts
@@ -25,13 +25,13 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 		return this.source.renderURL(endpoint, payload, caller);
 	}
 
-	getRequest<PP extends P, RR extends R>(
+	createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
-		caller: AnyCaller = this.getRequest,
+		caller: AnyCaller = this.createRequest,
 	): Request {
-		return this.source.getRequest(endpoint, payload, options, caller);
+		return this.source.createRequest(endpoint, payload, options, caller);
 	}
 
 	parseResponse<PP extends P, RR extends R>(

--- a/modules/api/provider/ValidationAPIProvider.ts
+++ b/modules/api/provider/ValidationAPIProvider.ts
@@ -6,14 +6,14 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
 
 /** Validate an asynchronous source provider (source can have any type because validation guarantees the type). */
 export class ValidationAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
-	override getRequest<PP extends P, RR extends R>(
+	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
-		caller: AnyCaller = this.getRequest,
+		caller: AnyCaller = this.createRequest,
 	): Request {
 		// Validate payload — let thrown strings bubble up as user-readable messages for e.g. form handlers.
-		return super.getRequest(endpoint, endpoint.payload.validate(payload), options, caller);
+		return super.createRequest(endpoint, endpoint.payload.validate(payload), options, caller);
 	}
 
 	override async parseResponse<PP extends P, RR extends R>(

--- a/modules/api/provider/XMLAPIProvider.test.ts
+++ b/modules/api/provider/XMLAPIProvider.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, test } from "bun:test";
 import { DATA, type Endpoint, GET, POST, RequiredError, STRING, XMLAPIProvider } from "../../index.js";
 
 describe("XMLAPIProvider", () => {
-	test("getRequest() serializes POST payloads as XML bodies", async () => {
+	test("createRequest() serializes POST payloads as XML bodies", async () => {
 		const provider = new XMLAPIProvider({ url: "https://api.example.com/" });
 		const endpoint = POST("/items", DATA({ item: DATA({ name: STRING }) }), STRING);
-		const request = provider.getRequest(endpoint, { item: { name: "abc" } });
+		const request = provider.createRequest(endpoint, { item: { name: "abc" } });
 
 		expect(request.headers.get("Content-Type")).toBe("application/xml; charset=UTF-8");
 		expect(await request.text()).toBe('<?xml version="1.0" encoding="UTF-8"?><item><name>abc</name></item>');
 	});
 
-	test("getRequest() rejects non-data XML payloads", () => {
+	test("createRequest() rejects non-data XML payloads", () => {
 		const provider = new XMLAPIProvider({ url: "https://api.example.com/" });
 		const endpoint = POST("/items", STRING, STRING);
-		expect(() => provider.getRequest(endpoint as Endpoint<any, string>, "abc")).toThrow(RequiredError);
+		expect(() => provider.createRequest(endpoint as Endpoint<any, string>, "abc")).toThrow(RequiredError);
 	});
 
 	test("fetch() parses responses as plain text", async () => {

--- a/modules/api/provider/XMLAPIProvider.ts
+++ b/modules/api/provider/XMLAPIProvider.ts
@@ -1,7 +1,7 @@
 import { ResponseError } from "../../error/ResponseError.js";
 import type { Data } from "../../util/data.js";
 import type { AnyCaller } from "../../util/function.js";
-import { getXMLRequest, type RequestBodyMethod, type RequestOptions } from "../../util/http.js";
+import { createXMLRequest, type RequestBodyMethod, type RequestOptions } from "../../util/http.js";
 import type { PossibleURL } from "../../util/url.js";
 import type { Endpoint } from "../endpoint/Endpoint.js";
 import { ClientAPIProvider } from "./ClientAPIProvider.js";
@@ -15,7 +15,7 @@ export class XMLAPIProvider<P extends Data = Data, R extends string = string> ex
 		options: RequestOptions,
 		caller: AnyCaller,
 	): Request {
-		return getXMLRequest(method, url, payload, options, caller);
+		return createXMLRequest(method, url, payload, options, caller);
 	}
 
 	/**

--- a/modules/api/provider/XMLAPIProvider.ts
+++ b/modules/api/provider/XMLAPIProvider.ts
@@ -8,7 +8,7 @@ import { ClientAPIProvider } from "./ClientAPIProvider.js";
 
 /** API provider that always sends request bodies as XML and parses responses as plain text. */
 export class XMLAPIProvider<P extends Data = Data, R extends string = string> extends ClientAPIProvider<P, R> {
-	protected override _getBodyRequest(
+	protected override _createBodyRequest(
 		method: RequestBodyMethod,
 		url: PossibleURL,
 		payload: P,

--- a/modules/api/store/EndpointStore.test.ts
+++ b/modules/api/store/EndpointStore.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, EndpointStore, GET, getDeferred, MockAPIProvider, runMicrotasks, STRING } from "../../index.js";
+import { createDeferred, DATA, EndpointStore, GET, MockAPIProvider, runMicrotasks, STRING } from "../../index.js";
 import { EXPECT_PROMISELIKE } from "../../test/index.js";
 
 describe("EndpointStore", () => {
 	test("starts loading and resolves after reading loading", async () => {
-		const deferred = getDeferred<Response>();
+		const deferred = createDeferred<Response>();
 		const provider = new MockAPIProvider(() => deferred.promise);
 		const endpoint = GET("/users/{id}", DATA({ id: STRING }), STRING);
 		const store = new EndpointStore(endpoint, { id: "123" }, provider);
@@ -27,7 +27,7 @@ describe("EndpointStore", () => {
 	});
 
 	test("refresh() reuses the current in-flight request", async () => {
-		const deferred = getDeferred<Response>();
+		const deferred = createDeferred<Response>();
 		const provider = new MockAPIProvider(() => deferred.promise);
 		const endpoint = GET("/users/{id}", DATA({ id: STRING }), STRING);
 		const store = new EndpointStore(endpoint, { id: "123" }, provider);

--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -64,13 +64,13 @@ The third argument to `renderMarkup` is the starting context (`"block"` by defau
 
 ### Custom rules
 
-Build custom rules with `getMarkupRule` and combine them with the defaults:
+Build custom rules with `createMarkupRule` and combine them with the defaults:
 
 ```ts
-import { getMarkupRule, MARKUP_RULES, renderMarkup } from "shelving/markup";
+import { createMarkupRule, MARKUP_RULES, renderMarkup } from "shelving/markup";
 import { REACT_ELEMENT_TYPE } from "shelving/markup/util/internal";
 
-const HIGHLIGHT_RULE = getMarkupRule(
+const HIGHLIGHT_RULE = createMarkupRule(
   /==(?<text>[^=]+)==/,
   ({ groups: { text } }, options, key) => ({
     key,

--- a/modules/markup/rule/blockquote.ts
+++ b/modules/markup/rule/blockquote.ts
@@ -1,12 +1,12 @@
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { BLOCK_CONTENT_REGEXP, getBlockRegExp } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { BLOCK_CONTENT_REGEXP, createBlockRegExp } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
 const PREFIX = ">";
 const INDENT = new RegExp(`^${PREFIX}`, "gm");
 
-export const BLOCKQUOTE_REGEXP = getBlockRegExp(`${PREFIX}${BLOCK_CONTENT_REGEXP}`);
+export const BLOCKQUOTE_REGEXP = createBlockRegExp(`${PREFIX}${BLOCK_CONTENT_REGEXP}`);
 
 /**
  * Blockquote block.
@@ -14,7 +14,7 @@ export const BLOCKQUOTE_REGEXP = getBlockRegExp(`${PREFIX}${BLOCK_CONTENT_REGEXP
  * - No spaces can appear before the `>` quote character.
  * - Quote block is only broken by `\n\n` two newline characters.
  */
-export const BLOCKQUOTE_RULE = getMarkupRule(
+export const BLOCKQUOTE_RULE = createMarkupRule(
 	BLOCKQUOTE_REGEXP,
 	([quote], options, key) => ({
 		key,

--- a/modules/markup/rule/code.ts
+++ b/modules/markup/rule/code.ts
@@ -1,7 +1,7 @@
 import { getRegExp } from "../../util/regexp.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
 import { BLOCK_CONTENT_REGEXP } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createMarkupRule } from "../util/rule.js";
 
 const CODE_REGEXP = getRegExp<{ code: string }>(`(?<fence>\`+)(?<code>${BLOCK_CONTENT_REGEXP})\\k<fence>`);
 
@@ -12,7 +12,7 @@ const CODE_REGEXP = getRegExp<{ code: string }>(`(?<fence>\`+)(?<code>${BLOCK_CO
  * - Closing characters must exactly match opening characters.
  * - Same as Markdown syntax.
  */
-export const CODE_RULE = getMarkupRule(
+export const CODE_RULE = createMarkupRule(
 	CODE_REGEXP,
 	({ groups: { code } }, _options, key) => ({
 		key,

--- a/modules/markup/rule/fenced.ts
+++ b/modules/markup/rule/fenced.ts
@@ -1,10 +1,10 @@
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { BLOCK_CONTENT_REGEXP, BLOCK_START_REGEXP, getBlockRegExp, LINE_CONTENT_REGEXP, LINE_SPACE_REGEXP } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { BLOCK_CONTENT_REGEXP, BLOCK_START_REGEXP, createBlockRegExp, LINE_CONTENT_REGEXP, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
 const FENCE = "`{3,}|~{3,}";
 
-const FENCED_REGEXP = getBlockRegExp<{
+const FENCED_REGEXP = createBlockRegExp<{
 	fence: string;
 	title?: string;
 	code: string;
@@ -25,7 +25,7 @@ const FENCED_REGEXP = getBlockRegExp<{
  * - If there's no closing fence the code block will run to the end of the current string.
  * - Markdown-style four-space indent syntax is not supported (only fenced code since it's less confusing and more common).
  */
-export const FENCED_RULE = getMarkupRule(
+export const FENCED_RULE = createMarkupRule(
 	FENCED_REGEXP,
 	({ groups: { title, code } }, _options, key) => ({
 		key,

--- a/modules/markup/rule/heading.ts
+++ b/modules/markup/rule/heading.ts
@@ -1,9 +1,9 @@
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { getLineRegExp, LINE_CONTENT_REGEXP, LINE_SPACE_REGEXP } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createLineRegExp, LINE_CONTENT_REGEXP, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
-const HEADING_REGEXP = getLineRegExp<{
+const HEADING_REGEXP = createLineRegExp<{
 	prefix: string;
 	heading?: string;
 }>(`(?<prefix>#{1,6})(?:${LINE_SPACE_REGEXP}+(?<heading>${LINE_CONTENT_REGEXP}))?`);
@@ -14,7 +14,7 @@ const HEADING_REGEXP = getLineRegExp<{
  * - `#` must be the first character on the line.
  * - Markdown's underline syntax is not supported (for simplification).
  */
-export const HEADING_RULE = getMarkupRule(
+export const HEADING_RULE = createMarkupRule(
 	HEADING_REGEXP,
 	({ groups: { prefix, heading = "" } }, options, key) => ({
 		key,

--- a/modules/markup/rule/inline.ts
+++ b/modules/markup/rule/inline.ts
@@ -1,12 +1,12 @@
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { getWordRegExp } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createWordRegExp } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
 /** Map characters, e.g. `*`, to their coresponding HTML tag, e.g. `strong` */
 const INLINE_CHARS = { "-": "del", "~": "del", "+": "ins", "*": "strong", _: "em", "=": "mark" }; // Hyphen must be first so it works when we use the keys as a character class.
 
-const INLINE_REGEXP = getWordRegExp<{
+const INLINE_REGEXP = createWordRegExp<{
 	char: keyof typeof INLINE_CHARS;
 	text: string;
 }>(`(?<wrap>(?<char>[${Object.keys(INLINE_CHARS).join("")}])+)(?<text>(?!\\k<char>)\\S(?:[\\s\\S]*?(?!\\k<char>)\\S)?)\\k<wrap>`);
@@ -24,7 +24,7 @@ const INLINE_REGEXP = getWordRegExp<{
  * - Closing characters must exactly match opening characters.
  * - Different to Markdown: strong is always surrounded by `*asterisks*` and emphasis is always surrounded by `_underscores_` (strong isn't 'double emphasis').
  */
-export const INLINE_RULE = getMarkupRule(
+export const INLINE_RULE = createMarkupRule(
 	INLINE_REGEXP,
 	({ groups: { char, text } }, options, key) => ({
 		key,

--- a/modules/markup/rule/linebreak.ts
+++ b/modules/markup/rule/linebreak.ts
@@ -1,5 +1,5 @@
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createMarkupRule } from "../util/rule.js";
 
 /**
  * Hard linebreak (`<br />` tag).
@@ -11,7 +11,7 @@ import { getMarkupRule } from "../util/rule.js";
  *   - This is more intuitive (a linebreak becomes a linebreak is isn't silently ignored).
  *   - This works better with textareas that wrap text (since manually breaking up long lines is no longer necessary).
  */
-export const LINEBREAK_RULE = getMarkupRule(
+export const LINEBREAK_RULE = createMarkupRule(
 	/[^\n\S]*\n[^\n\S]*/,
 	(_match, _options, key) => ({
 		key,

--- a/modules/markup/rule/link.ts
+++ b/modules/markup/rule/link.ts
@@ -6,7 +6,7 @@ import { getURL } from "../../util/url.js";
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
 import type { MarkupOptions } from "../util/options.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createMarkupRule } from "../util/rule.js";
 
 type LinkMarkupRuleData = { title?: string; href: string };
 
@@ -38,7 +38,7 @@ export const LINK_REGEXP = getRegExp<LinkMarkupRuleData>(/\[(?<title>[^\]\n]*?)\
  * - If link is not valid (using `new URL(url)` then unparsed text will be returned.
  * - For security only `http://` or `https://` links will work (if invalid the unparsed text will be returned).
  */
-export const LINK_RULE = getMarkupRule(
+export const LINK_RULE = createMarkupRule(
 	LINK_REGEXP, //
 	renderLinkMarkupRule,
 	["inline", "list"],
@@ -53,7 +53,7 @@ export const AUTOLINK_REGEXP = getRegExp<LinkMarkupRuleData>(/(?<href>[a-z]{2,}:
  * - If link is not valid (using `new URL(url)` then unparsed text will be returned.
  * - For security only schemes that appear in `options.schemes` will match (defaults to `http:` and `https:`).
  */
-export const AUTOLINK_RULE = getMarkupRule(
+export const AUTOLINK_RULE = createMarkupRule(
 	AUTOLINK_REGEXP, //
 	renderLinkMarkupRule,
 	["inline", "list"],

--- a/modules/markup/rule/ordered.ts
+++ b/modules/markup/rule/ordered.ts
@@ -2,8 +2,8 @@ import type { Element } from "../../util/element.js";
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
 import type { MarkupOptions } from "../util/options.js";
-import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, getBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
 const INDENT = /^\t/gm; // Nesting is recognised with tabs only.
 const NUMBER = "\\d{1,9}[.):]"; // Number for a numbered list, e.g. `1.` or `2)` or `3:` followed by one or more spaces.
@@ -12,7 +12,7 @@ const ITEM = new RegExp(
 	"g",
 );
 
-export const ORDERED_REGEXP = getBlockRegExp<{
+export const ORDERED_REGEXP = createBlockRegExp<{
 	list: string;
 }>(`(?<list>${NUMBER}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`);
 
@@ -23,7 +23,7 @@ export const ORDERED_REGEXP = getBlockRegExp<{
  * - Second-level list can be created by indenting with `\t` one tab.
  * - Sparse lists are not supported.
  */
-export const ORDERED_RULE = getMarkupRule(
+export const ORDERED_RULE = createMarkupRule(
 	ORDERED_REGEXP,
 	({ groups: { list } }, options, key) => ({
 		key,

--- a/modules/markup/rule/paragraph.ts
+++ b/modules/markup/rule/paragraph.ts
@@ -1,9 +1,9 @@
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { BLOCK_SPACE_REGEXP, BLOCK_START_REGEXP, getBlockRegExp } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { BLOCK_SPACE_REGEXP, BLOCK_START_REGEXP, createBlockRegExp } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
-export const PARAGRAPH_REGEXP = getBlockRegExp<{
+export const PARAGRAPH_REGEXP = createBlockRegExp<{
 	paragraph: string;
 }>(
 	"(?<paragraph>(?:(?=\\S)[\\s\\S]*?\\S))",
@@ -17,7 +17,7 @@ export const PARAGRAPH_REGEXP = getBlockRegExp<{
  * - Any run of non-whitespace.
  * - Leading and trailing whitespace is trimmed.
  */
-export const PARAGRAPH_RULE = getMarkupRule(
+export const PARAGRAPH_RULE = createMarkupRule(
 	PARAGRAPH_REGEXP,
 	({ groups: { paragraph } }, options, key) => ({
 		key,

--- a/modules/markup/rule/separator.ts
+++ b/modules/markup/rule/separator.ts
@@ -1,8 +1,8 @@
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
-import { getLineRegExp } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { createLineRegExp } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
-const SEPARATOR_REGEXP = getLineRegExp("([-*•+_=])(?: *\\1){2,}");
+const SEPARATOR_REGEXP = createLineRegExp("([-*•+_=])(?: *\\1){2,}");
 
 /**
  * Separator (horizontal rule / thematic break).
@@ -12,7 +12,7 @@ const SEPARATOR_REGEXP = getLineRegExp("([-*•+_=])(?: *\\1){2,}");
  * - Might have infinite number of spaces between the characters.
  */
 
-export const SEPARATOR_RULE = getMarkupRule(
+export const SEPARATOR_RULE = createMarkupRule(
 	SEPARATOR_REGEXP,
 	(_match, _options, key) => ({
 		key,

--- a/modules/markup/rule/unordered.ts
+++ b/modules/markup/rule/unordered.ts
@@ -2,8 +2,8 @@ import type { Element } from "../../util/element.js";
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
 import type { MarkupOptions } from "../util/options.js";
-import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, getBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
-import { getMarkupRule } from "../util/rule.js";
+import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { createMarkupRule } from "../util/rule.js";
 
 const INDENT = /^\t/gm; // Nesting is recognised with tabs only.
 const BULLET = "[-*•+]"; // Allowed bullet symbol.
@@ -12,7 +12,7 @@ const ITEM = new RegExp(
 	"g",
 );
 
-export const UNORDERED_REGEXP = getBlockRegExp<{
+export const UNORDERED_REGEXP = createBlockRegExp<{
 	list?: string;
 }>(`(?<list>${BULLET}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`);
 
@@ -24,7 +24,7 @@ export const UNORDERED_REGEXP = getBlockRegExp<{
  * - List block is ended by `\n\n` two newline characters.
  * - Sparse lists are not supported.
  */
-export const UNORDERED_RULE = getMarkupRule(
+export const UNORDERED_RULE = createMarkupRule(
 	UNORDERED_REGEXP,
 	({ groups: { list = "" } }, options, key) => ({
 		key,

--- a/modules/markup/util/regexp.ts
+++ b/modules/markup/util/regexp.ts
@@ -16,17 +16,17 @@ export const WORD_START_REGEXP = "(?<![\\p{L}\\p{N}])"; // Start of word (previo
 export const WORD_END_REGEXP = "(?![\\p{L}\\p{N}])"; // End of word (next character is not a letter or number).
 
 /** Create regular expression that matches a block of content. */
-export function getBlockRegExp<T extends NamedRegExpData>(
+export function createBlockRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getBlockRegExp<T extends NamedRegExpData | undefined = undefined>(
+export function createBlockRegExp<T extends NamedRegExpData | undefined = undefined>(
 	pattern: PossibleRegExp,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getBlockRegExp(
+export function createBlockRegExp(
 	content: PossibleRegExp,
 	start: PossibleRegExp = BLOCK_START_REGEXP,
 	end: PossibleRegExp = BLOCK_END_REGEXP,
@@ -35,17 +35,17 @@ export function getBlockRegExp(
 }
 
 /** Create regular expression that matches a line of content. */
-export function getLineRegExp<T extends NamedRegExpData>(
+export function createLineRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getLineRegExp<T extends NamedRegExpData | undefined = undefined>(
+export function createLineRegExp<T extends NamedRegExpData | undefined = undefined>(
 	pattern: PossibleRegExp,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getLineRegExp(
+export function createLineRegExp(
 	content: PossibleRegExp = LINE_CONTENT_REGEXP,
 	end: PossibleRegExp = LINE_END_REGEXP,
 	start: PossibleRegExp = LINE_START_REGEXP,
@@ -54,17 +54,17 @@ export function getLineRegExp(
 }
 
 /** Create regular expression that matches a word of content. */
-export function getWordRegExp<T extends NamedRegExpData>(
+export function createWordRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getWordRegExp<T extends NamedRegExpData | undefined = undefined>(
+export function createWordRegExp<T extends NamedRegExpData | undefined = undefined>(
 	pattern: PossibleRegExp,
 	start?: PossibleRegExp,
 	end?: PossibleRegExp,
 ): T extends NamedRegExpData ? NamedRegExp<T> : RegExp;
-export function getWordRegExp(
+export function createWordRegExp(
 	content: PossibleRegExp = WORD_CONTENT_REGEXP,
 	start: PossibleRegExp = WORD_START_REGEXP,
 	end: PossibleRegExp = WORD_END_REGEXP,

--- a/modules/markup/util/rule.ts
+++ b/modules/markup/util/rule.ts
@@ -18,7 +18,7 @@ export interface MarkupRule {
 export type MarkupRules = readonly MarkupRule[];
 
 /** Helper to make it easier to create typed `MarkupRule` instances using `NamedRegExp` regular expressions. */
-export function getMarkupRule<T extends NamedRegExp | RegExp>(
+export function createMarkupRule<T extends NamedRegExp | RegExp>(
 	regexp: T,
 	render: T extends NamedRegExp<infer X>
 		? (match: NamedRegExpExecArray<X>, options: MarkupOptions, key: string) => Element

--- a/modules/sequence/DeferredSequence.ts
+++ b/modules/sequence/DeferredSequence.ts
@@ -1,5 +1,5 @@
 import type { Deferred } from "../util/async.js";
-import { getDeferred } from "../util/async.js";
+import { createDeferred } from "../util/async.js";
 import { awaitDispose } from "../util/dispose.js";
 import type { Nullable } from "../util/null.js";
 import { Sequence } from "./Sequence.js";
@@ -25,7 +25,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 
 	/** Get the next promise to be resolved/rejected. */
 	get promise(): Promise<T> {
-		this._promiseDeferred ||= getDeferred();
+		this._promiseDeferred ||= createDeferred();
 		return this._promiseDeferred.promise;
 	}
 
@@ -92,7 +92,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 
 	// Implement `AsyncIterator` — returns the promise directly since it already resolves to IteratorResult.
 	next(_next?: N | undefined): Promise<IteratorResult<T, R | undefined>> {
-		this._iteratorDeferred ||= getDeferred();
+		this._iteratorDeferred ||= createDeferred();
 		return this._iteratorDeferred.promise;
 	}
 

--- a/modules/store/BusyStore.test.ts
+++ b/modules/store/BusyStore.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { BusyStore, getDeferred, NONE, runMicrotasks } from "../index.js";
+import { BusyStore, createDeferred, NONE, runMicrotasks } from "../index.js";
 
 test("busy is false initially", () => {
 	const store = new BusyStore<number>(42);
@@ -7,14 +7,14 @@ test("busy is false initially", () => {
 });
 
 test("await() sets busy to true", () => {
-	const d = getDeferred<number>();
+	const d = createDeferred<number>();
 	const store = new BusyStore<number>(NONE);
 	void store.await(d.promise);
 	expect(store.busy.value).toBe(true);
 });
 
 test("busy is false after await() resolves", async () => {
-	const d = getDeferred<number>();
+	const d = createDeferred<number>();
 	const store = new BusyStore<number>(NONE);
 	void store.await(d.promise);
 	d.resolve(42);
@@ -25,7 +25,7 @@ test("busy is false after await() resolves", async () => {
 
 test("busy is false after await() rejects", async () => {
 	const err = new Error("oops");
-	const d = getDeferred<number>();
+	const d = createDeferred<number>();
 	const store = new BusyStore<number>(NONE);
 	void store.await(d.promise);
 	d.reject(err);
@@ -35,7 +35,7 @@ test("busy is false after await() rejects", async () => {
 });
 
 test("abort() sets busy to false and discards the pending value", async () => {
-	const d = getDeferred<number>();
+	const d = createDeferred<number>();
 	const store = new BusyStore<number>(NONE);
 	void store.await(d.promise);
 	expect(store.busy.value).toBe(true);
@@ -47,7 +47,7 @@ test("abort() sets busy to false and discards the pending value", async () => {
 });
 
 test("writing a value while busy clears busy and discards the pending value", async () => {
-	const d = getDeferred<number>();
+	const d = createDeferred<number>();
 	const store = new BusyStore<number>(NONE);
 	void store.await(d.promise);
 	expect(store.busy.value).toBe(true);

--- a/modules/store/FetchStore.test.ts
+++ b/modules/store/FetchStore.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { type Deferred, FetchStore, getDeferred, NONE, runMicrotasks } from "../index.js";
+import { createDeferred, type Deferred, FetchStore, NONE, runMicrotasks } from "../index.js";
 import { EXPECT_PROMISELIKE } from "../test/util.js";
 
 // --- Basic fetch ---
@@ -156,7 +156,7 @@ test("stale-data protection: fetch that resolves after invalidate() is discarded
 	const fetches: Array<Deferred<number>> = [];
 	const store = new FetchStore<number>(NONE, () => {
 		calls++;
-		const d = getDeferred<number>();
+		const d = createDeferred<number>();
 		fetches.push(d);
 		return d.promise;
 	});

--- a/modules/store/Store.test.ts
+++ b/modules/store/Store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getDeferred, NONE, runMicrotasks, runSequence, Store } from "../index.js";
+import { createDeferred, NONE, runMicrotasks, runSequence, Store } from "../index.js";
 import { EXPECT_PROMISELIKE } from "../test/util.js";
 
 test("No initial value", async () => {
@@ -157,7 +157,7 @@ describe("await() resolves and rejects correctly", () => {
 	});
 
 	test("loading reflects pending state throughout", async () => {
-		const d = getDeferred<number>();
+		const d = createDeferred<number>();
 		const store = new Store<number>(NONE);
 		expect(store.loading).toBe(true);
 		const p = store.await(d.promise);
@@ -171,7 +171,7 @@ describe("await() resolves and rejects correctly", () => {
 
 describe("await() abort", () => {
 	test("abort() discards a result that arrives after the abort", async () => {
-		const d = getDeferred<number>();
+		const d = createDeferred<number>();
 		const store = new Store<number>(NONE);
 		const awaitResult = store.await(d.promise);
 		store.abort();
@@ -182,7 +182,7 @@ describe("await() abort", () => {
 	});
 
 	test("setting a new value discards a pending await result", async () => {
-		const d = getDeferred<number>();
+		const d = createDeferred<number>();
 		const store = new Store<number>(NONE);
 		const awaitResult = store.await(d.promise);
 		store.value = 99; // explicit set cancels the pending await
@@ -271,7 +271,7 @@ describe("call() asynchronous", () => {
 	});
 
 	test("returns Promise<false> when aborted before result arrives", async () => {
-		const d = getDeferred<number>();
+		const d = createDeferred<number>();
 		const store = new Store<number>(NONE);
 		const callResult = store.call(() => d.promise);
 		store.abort();

--- a/modules/util/async.test.ts
+++ b/modules/util/async.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { awaitAbort, awaitValues, getDeferred, Errors as ShelvingAggregateError } from "../index.js";
+import { awaitAbort, awaitValues, createDeferred, Errors as ShelvingAggregateError } from "../index.js";
 
 describe("awaitAbort()", () => {
 	test("rejects when signal is already aborted", async () => {
@@ -29,7 +29,7 @@ describe("awaitAbort()", () => {
 });
 describe("Deferred", () => {
 	test("Works correctly", async () => {
-		const { promise, resolve, reject } = getDeferred<string>();
+		const { promise, resolve, reject } = createDeferred<string>();
 		expect(promise).toBeInstanceOf(Promise);
 		expect(resolve).toBeInstanceOf(Function);
 		expect(reject).toBeInstanceOf(Function);

--- a/modules/util/async.ts
+++ b/modules/util/async.ts
@@ -113,10 +113,10 @@ export type Deferred<T = unknown> = {
 };
 
 /**
- * Get a deferred to access the `resolve()` and `reject()` functions of a promise.
+ * Create a deferred to access the `resolve()` and `reject()` functions of a promise.
  * - See https://github.com/tc39/proposal-promise-with-resolvers/
  */
-export function getDeferred<T = void>(): Deferred<T> {
+export function createDeferred<T = void>(): Deferred<T> {
 	let resolve: ValueCallback<T>;
 	let reject: ErrorCallback;
 	return {

--- a/modules/util/http.test.ts
+++ b/modules/util/http.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-	getFormDataRequest,
-	getJSONRequest,
-	getTextRequest,
-	getXMLRequest,
+	createFormDataRequest,
+	createJSONRequest,
+	createTextRequest,
+	createXMLRequest,
 	isRequestHeadMethod,
 	parseRequestBody,
 	parseRequestFormData,
@@ -133,28 +133,28 @@ describe("parseResponseFormData()", () => {
 });
 
 describe("request builders", () => {
-	test("getTextRequest() creates a text request", async () => {
-		const request = getTextRequest("POST", "https://example.com/items", "hello");
+	test("createTextRequest() creates a text request", async () => {
+		const request = createTextRequest("POST", "https://example.com/items", "hello");
 		expect(request.headers.get("Content-Type")).toBe("text/plain");
 		expect(await request.text()).toBe("hello");
 	});
 
-	test("getJSONRequest() creates a JSON request", async () => {
-		const request = getJSONRequest("POST", "https://example.com/items", { name: "abc" });
+	test("createJSONRequest() creates a JSON request", async () => {
+		const request = createJSONRequest("POST", "https://example.com/items", { name: "abc" });
 		expect(request.headers.get("Content-Type")).toBe("application/json");
 		expect(await request.text()).toBe('{"name":"abc"}');
 	});
 
-	test("getFormDataRequest() creates a form-data request", async () => {
+	test("createFormDataRequest() creates a form-data request", async () => {
 		const body = new FormData();
 		body.set("name", "abc");
 
-		const request = getFormDataRequest("POST", "https://example.com/items", body);
+		const request = createFormDataRequest("POST", "https://example.com/items", body);
 		expect((await request.formData()).get("name")).toBe("abc");
 	});
 
-	test("getXMLRequest() creates an XML request", async () => {
-		const request = getXMLRequest("POST", "https://example.com/items", { item: { name: "abc" } });
+	test("createXMLRequest() creates an XML request", async () => {
+		const request = createXMLRequest("POST", "https://example.com/items", { item: { name: "abc" } });
 		expect(request.headers.get("Content-Type")).toBe("application/xml; charset=UTF-8");
 		expect(await request.text()).toBe('<?xml version="1.0" encoding="UTF-8"?><item><name>abc</name></item>');
 	});

--- a/modules/util/http.ts
+++ b/modules/util/http.ts
@@ -232,14 +232,14 @@ export function mergeRequestOptions(
  * @param options Additional request options.
  * @returns A `Request` with no body content.
  *
- * @example getHeadRequest("POST", "https://api.example.com/items", { name: "abc" })
+ * @example createHeadRequest("POST", "https://api.example.com/items", { name: "abc" })
  */
-export function getHeadRequest(
+export function createHeadRequest(
 	method: RequestHeadMethod,
 	url: PossibleURL,
 	params: Nullish<PossibleURIParams>,
 	options: RequestOptions = {},
-	caller: AnyCaller = getHeadRequest,
+	caller: AnyCaller = createHeadRequest,
 ): Request {
 	return new Request(withURIParams(requireURL(url, undefined, caller), params), { ...options, method, body: null });
 }
@@ -255,14 +255,14 @@ export function getHeadRequest(
  * @param options Additional request options.
  * @returns A `Request` with `text/plain` content type.
  *
- * @example getTextRequest("POST", "https://api.example.com/items", "hello")
+ * @example createTextRequest("POST", "https://api.example.com/items", "hello")
  */
-export function getTextRequest(
+export function createTextRequest(
 	method: RequestMethod,
 	url: PossibleURL,
 	body: string,
 	options: RequestOptions = {},
-	caller: AnyCaller = getTextRequest,
+	caller: AnyCaller = createTextRequest,
 ): Request {
 	return new Request(requireURL(url, undefined, caller), { ...mergeRequestOptions(_REQUEST_TEXT_OPTIONS, options), method, body });
 }
@@ -279,14 +279,14 @@ const _REQUEST_TEXT_OPTIONS = { headers: { "Content-Type": "text/plain" } };
  * @param options Additional request options.
  * @returns A `Request` with `application/json` content type.
  *
- * @example getJSONRequest("POST", "https://api.example.com/items", { name: "abc" })
+ * @example createJSONRequest("POST", "https://api.example.com/items", { name: "abc" })
  */
-export function getJSONRequest(
+export function createJSONRequest(
 	method: RequestBodyMethod,
 	url: PossibleURL,
 	body: unknown,
 	options: RequestOptions = {},
-	caller: AnyCaller = getJSONRequest,
+	caller: AnyCaller = createJSONRequest,
 ): Request {
 	return new Request(requireURL(url, undefined, caller), {
 		...mergeRequestOptions(_REQUEST_JSON_OPTIONS, options),
@@ -306,14 +306,14 @@ const _REQUEST_JSON_OPTIONS = { headers: { "Content-Type": "application/json" } 
  * @param options Additional request options.
  * @returns A `Request` with a multipart body.
  *
- * @example getFormDataRequest("POST", "https://api.example.com/upload", new FormData())
+ * @example createFormDataRequest("POST", "https://api.example.com/upload", new FormData())
  */
-export function getFormDataRequest(
+export function createFormDataRequest(
 	method: RequestBodyMethod,
 	url: PossibleURL,
 	body: FormData,
 	options: RequestOptions = {},
-	caller: AnyCaller = getFormDataRequest,
+	caller: AnyCaller = createFormDataRequest,
 ): Request {
 	return new Request(requireURL(url, undefined, caller), { ...options, method, body });
 }
@@ -331,14 +331,14 @@ export function getFormDataRequest(
  *
  * @throws {RequiredError} If the XML data contains invalid element names or values.
  *
- * @example getXMLRequest("POST", "https://api.example.com/items", { item: { name: "abc" } })
+ * @example createXMLRequest("POST", "https://api.example.com/items", { item: { name: "abc" } })
  */
-export function getXMLRequest(
+export function createXMLRequest(
 	method: RequestBodyMethod,
 	url: PossibleURL,
 	data: Data,
 	options: RequestOptions = {},
-	caller: AnyCaller = getXMLRequest,
+	caller: AnyCaller = createXMLRequest,
 ): Request {
 	return new Request(requireURL(url, undefined, caller), {
 		...mergeRequestOptions(_REQUEST_XML_OPTIONS, options),
@@ -361,12 +361,12 @@ const _REQUEST_XML_OPTIONS = { headers: { "Content-Type": "application/xml; char
  *
  * @throws {RequiredError} if this is a `HEAD` or `GET` request but `body` is not a data object.
  */
-export function getRequest(
+export function createRequest(
 	method: RequestMethod,
 	url: PossibleURL,
 	payload: unknown,
 	options: RequestOptions = {},
-	caller: AnyCaller = getRequest,
+	caller: AnyCaller = createRequest,
 ): Request {
 	url = requireURL(url, undefined, caller);
 
@@ -380,13 +380,13 @@ export function getRequest(
 	}
 
 	// `FormData` instances in body pass through unaltered and will set their own `Content-Type` with complex boundary information
-	if (payload instanceof FormData) return getFormDataRequest(method, url, payload, options, caller);
+	if (payload instanceof FormData) return createFormDataRequest(method, url, payload, options, caller);
 
 	// Strings are sent as plain text.
-	if (typeof payload === "string") return getTextRequest(method, url, payload, options, caller);
+	if (typeof payload === "string") return createTextRequest(method, url, payload, options, caller);
 
 	// JSON is the default.
-	return getJSONRequest(method, url, payload, options, caller);
+	return createJSONRequest(method, url, payload, options, caller);
 }
 
 /** Assert that the payload for a HEAD or GET method is a data object, null, or undefined. */

--- a/modules/util/sequence.test.ts
+++ b/modules/util/sequence.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { MutableArray } from "../index.js";
-import { getDeferred, mergeSequences, repeatDelay, repeatUntil, runSequence } from "../index.js";
+import { createDeferred, mergeSequences, repeatDelay, repeatUntil, runSequence } from "../index.js";
 
 const DELAY = 50;
 
 test("repeatUntil() and repeatDelay()", async () => {
 	const yielded: number[] = [];
-	const { promise, resolve } = getDeferred();
+	const { promise, resolve } = createDeferred();
 	for await (const count of repeatUntil(repeatDelay(DELAY), promise)) {
 		yielded.push(count);
 		if (count >= 3) resolve();

--- a/modules/util/sequence.ts
+++ b/modules/util/sequence.ts
@@ -1,5 +1,5 @@
 import { UnexpectedError } from "../error/UnexpectedError.js";
-import { getDeferred, getDelay } from "./async.js";
+import { createDeferred, getDelay } from "./async.js";
 import { ABORT } from "./constants.js";
 import type { AnyCaller, ErrorCallback, ValueCallback } from "./function.js";
 
@@ -109,7 +109,7 @@ export function runSequence<T, R, N>(
 	onError?: ErrorCallback,
 	onReturn?: (value: R | undefined) => void,
 ): (value?: R | undefined) => void {
-	const { promise, resolve } = getDeferred<IteratorAbortResult<R | undefined>>();
+	const { promise, resolve } = createDeferred<IteratorAbortResult<R | undefined>>();
 	void _runSequenceIterator(sequence[Symbol.asyncIterator](), promise, onNext, onError, onReturn);
 	return (value?: R | undefined) => resolve(_getAbortResult(value));
 }


### PR DESCRIPTION
This PR renames functions that create new instances from `get*` to `create*` to better reflect their purpose and align with naming conventions.

## Summary
Functions that instantiate new objects (factories) have been renamed from the `get*` prefix to `create*` to distinguish them from accessor functions that retrieve existing values. This improves code clarity and follows the established naming convention where `create*` indicates a fresh instance is always returned.

## Key Changes

### HTTP Request Builders
- `getHeadRequest()` → `createHeadRequest()`
- `getTextRequest()` → `createTextRequest()`
- `getJSONRequest()` → `createJSONRequest()`
- `getFormDataRequest()` → `createFormDataRequest()`
- `getXMLRequest()` → `createXMLRequest()`
- `getRequest()` → `createRequest()`

### API Provider Methods
- `ClientAPIProvider.getRequest()` → `createRequest()`
- `ClientAPIProvider._getHeadRequest()` → `_createHeadRequest()`
- `ClientAPIProvider._getBodyRequest()` → `_createBodyRequest()`
- Updated all subclasses: `MockAPIProvider`, `DebugAPIProvider`, `ThroughAPIProvider`, `ValidationAPIProvider`, `JSONAPIProvider`, `XMLAPIProvider`

### Markup Rule Builders
- `getBlockRegExp()` → `createBlockRegExp()`
- `getLineRegExp()` → `createLineRegExp()`
- `getWordRegExp()` → `createWordRegExp()`
- `getMarkupRule()` → `createMarkupRule()`

### Async Utilities
- `getDeferred()` → `createDeferred()`

## Implementation Details
- All function signatures, JSDoc examples, and internal references have been updated consistently
- Test files updated to use new function names
- Documentation (AGENTS.md) updated to clarify the `create*` prefix means "always returns a fresh instance"
- All internal function calls updated to use new names

https://claude.ai/code/session_01PC8xZJy5dp1oA83M8zPAi5