### PR TITLE
fix(extract): Use basename without extension for FileElement.name

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -39,7 +39,6 @@
 - [ ] **718** — Polish styling of documentation cards (`DocumentationCard`) and file cards (`FileCard`) in `modules/ui/docs/`. Currently plain `<div><h3><code>name</code></h3>…</div>` — needs typography, spacing, dividers, proper code-block treatment, and better visual hierarchy.
 - [ ] **405** — General styling polish of the entire documentation site. Typography scale, spacing rhythm, page max-width, code blocks, table treatment, link styles, sidebar treatment, mobile responsiveness. Bring it in line with the rest of the shelving design language.
 - [ ] **829** — Add colourful tags for code elements based on `kind` (e.g. `function`, `class`, `interface`, `type`, `constant`, `method`, `property`). Implement a `DocumentationKind` component that renders the `kind` prop as a small colour-coded badge — distinct hue per kind. Surface the badge in cards, on the page header, optionally in the sidebar, and anywhere else a documented symbol appears. Define the colour palette as CSS custom properties so it can be reused elsewhere in the design system.
-- [ ] **692** — Change `FileExtractor` (and subclasses) so the `name` prop is the basename **without** extension (e.g. `"OptionalSchema"`, not `"OptionalSchema.ts"`). The `.ts` clutters menus and cards. The extension can still be derived from the source filename if anything ever needs it, but `name` should be display-ready.
 
 ---
 

--- a/modules/extract/FileExtractor.ts
+++ b/modules/extract/FileExtractor.ts
@@ -8,7 +8,8 @@ import { Extractor } from "./Extractor.js";
 /**
  * Base extractor for a file in a tree.
  * - Reads the file's content as text and stores it in `content`.
- * - Sets `key` to the slugified basename (without extension).
+ * - Sets `key` to the slugified basename without extension.
+ * - Sets `name` to the display-ready basename without extension (e.g. `"OptionalSchema"`, not `"OptionalSchema.ts"`).
  * - Does NOT set `title` — `title` is only set by subclasses that have a confident source for one
  *   (e.g. `MarkdownExtractor` uses the first `<h1>`). Renderers fall back to `name` when missing.
  * - Subclasses (e.g. `MarkdownExtractor`, `TypescriptExtractor`) override `extractProps()` to parse the content into richer elements.
@@ -16,20 +17,19 @@ import { Extractor } from "./Extractor.js";
 export class FileExtractor extends Extractor<BunFile, FileElement> {
 	async extract(file: BunFile): Promise<FileElement> {
 		const path = file.name ?? "unnamed";
-		const name = isAbsolutePath(path) ? (splitAbsolutePath(path).at(-1) ?? "unnamed") : path;
-		const [base = name] = splitFileExtension(name);
+		const filename = isAbsolutePath(path) ? (splitAbsolutePath(path).at(-1) ?? "unnamed") : path;
+		const [base = filename] = splitFileExtension(filename);
 
 		return {
 			type: "tree-file",
 			key: requireSlug(base),
-			props: this.extractProps(name, await file.text()),
+			props: this.extractProps(base, await file.text()),
 		};
 	}
 
 	/**
 	 * Build the file element props from the extracted content.
-	 * - `name` is the basename including extension (e.g. `"array.ts"`).
-	 * - `base` is the basename without extension (e.g. `"array"`) — useful as a title fallback.
+	 * - `name` is the basename without extension (e.g. `"array"`) — display-ready, used by menus and cards.
 	 * - Override to parse `text` into richer elements (content/children/description) and to set
 	 *   `title` if a confident title is available.
 	 */

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -146,7 +146,7 @@ export function first<T>(arr: T[]): T | undefined {
 	test("leaves title undefined (no confident source for a TS source file)", async () => {
 		const element = await extractor.extract(file("export const X = 1;", "array.ts"));
 		expect(element.props.title).toBeUndefined();
-		expect(element.props.name).toBe("array.ts");
+		expect(element.props.name).toBe("array");
 		expect(element.key).toBe("array");
 	});
 
@@ -154,7 +154,7 @@ export function first<T>(arr: T[]): T | undefined {
 		// In production, `BunFile.name` is the full absolute path (e.g. `/Users/.../modules/util/array.ts`).
 		// The extractor should use only the basename.
 		const element = await extractor.extract(file("export const X = 1;", "/Users/foo/modules/util/array.ts"));
-		expect(element.props.name).toBe("array.ts");
+		expect(element.props.name).toBe("array");
 		expect(element.key).toBe("array");
 	});
 });


### PR DESCRIPTION
## Summary
- `FileExtractor` (and subclasses via `extractProps(name, ...)`) now receive the basename without extension (e.g. `OptionalSchema`, not `OptionalSchema.ts`).
- The extension cluttered menus and cards in the docs site; `name` should be display-ready.
- The original filename is still available via the file's own `.name` if anything ever needs it.

Closes PROJECT.md #692.

## Test plan
- [x] Type check passes (`bun run test:type`)
- [x] Extract tests pass (`bun test modules/extract`) — updated `TypescriptExtractor.test.ts` assertions from `"array.ts"` to `"array"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)