### PR TITLE
Add isURLActive/isURLProud helpers and URLStore methods

### DIFF
--- a/modules/store/URLStore.ts
+++ b/modules/store/URLStore.ts
@@ -13,7 +13,7 @@ import {
 	withURIParam,
 	withURIParams,
 } from "../util/uri.js";
-import { getURL, type ImmutableURL, type PossibleURL, requireURL, type URLString } from "../util/url.js";
+import { getURL, type ImmutableURL, isURLActive, isURLProud, type PossibleURL, requireURL, type URLString } from "../util/url.js";
 import { BusyStore } from "./BusyStore.js";
 
 /** Store a URL, e.g. `https://top.com/a/b/c` */
@@ -144,6 +144,27 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/** Return the current URL with an additional param. */
 	omitParam(key: string): ImmutableURL {
 		return omitURIParams(this.value, key);
+	}
+
+	/**
+	 * Is `target` active relative to this store's URL?
+	 * - Active means `target` resolves to the exact same URL as this store's current value.
+	 *
+	 * @param target URL (or relative path resolved against this store's `base`) to test.
+	 */
+	isActive(target: PossibleURL): boolean {
+		return isURLActive(this.value, requireURL(target, this.base, this.isActive));
+	}
+
+	/**
+	 * Is `target` proud relative to this store's URL?
+	 * - Proud means this store's URL is `target` or a descendant of `target` — i.e. `target` sits at or above the current URL in the hierarchy.
+	 * - Useful for marking a menu item as "current branch" when the user is somewhere deeper in its sub-tree.
+	 *
+	 * @param target URL (or relative path resolved against this store's `base`) to test.
+	 */
+	isProud(target: PossibleURL): boolean {
+		return isURLProud(this.value, requireURL(target, this.base, this.isProud));
 	}
 
 	override toString(): string {

--- a/modules/util/url.test.ts
+++ b/modules/util/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getURL, isURL, matchURLPrefix, requireURL } from "../index.js";
+import { getURL, isURL, isURLActive, isURLProud, matchURLPrefix, requireURL } from "../index.js";
 
 describe("isURL()", () => {
 	test("returns true for URL instance", () => {
@@ -65,5 +65,44 @@ describe("matchURLPrefix()", () => {
 	test("normalizes base path to directory semantics", () => {
 		expect(matchURLPrefix("def", "https://x.com/abc")).toBe("/def");
 		expect(matchURLPrefix("https://x.com/abc", "https://x.com/abc")).toBe("/");
+	});
+});
+describe("isURLActive()", () => {
+	test("true when target equals base (after resolution)", () => {
+		expect(isURLActive("https://x.com/users", "https://x.com/users")).toBe(true);
+		expect(isURLActive("https://x.com/users/", "https://x.com/users")).toBe(true);
+		expect(isURLActive("/users", "https://x.com/users")).toBe(true);
+	});
+	test("false when target is a descendant of base", () => {
+		expect(isURLActive("https://x.com/users/123", "https://x.com/users")).toBe(false);
+	});
+	test("false when target is unrelated to base", () => {
+		expect(isURLActive("https://x.com/posts", "https://x.com/users")).toBe(false);
+	});
+	test("false on origin mismatch", () => {
+		expect(isURLActive("https://y.com/users", "https://x.com/users")).toBe(false);
+	});
+});
+
+describe("isURLProud()", () => {
+	test("true when target equals base", () => {
+		expect(isURLProud("https://x.com/users", "https://x.com/users")).toBe(true);
+	});
+	test("true when target is a descendant of base", () => {
+		expect(isURLProud("https://x.com/users/123", "https://x.com/users")).toBe(true);
+		expect(isURLProud("https://x.com/users/123/edit", "https://x.com/users")).toBe(true);
+		expect(isURLProud("/users/123", "https://x.com/users")).toBe(true);
+	});
+	test("true for any descendant of root", () => {
+		expect(isURLProud("https://x.com/anything", "https://x.com/")).toBe(true);
+	});
+	test("false when target is an ancestor of base", () => {
+		expect(isURLProud("https://x.com/", "https://x.com/users")).toBe(false);
+	});
+	test("false when target is unrelated to base", () => {
+		expect(isURLProud("https://x.com/posts", "https://x.com/users")).toBe(false);
+	});
+	test("false on origin mismatch", () => {
+		expect(isURLProud("https://y.com/users/123", "https://x.com/users")).toBe(false);
 	});
 });

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -121,6 +121,31 @@ export function matchURLPrefix(target: PossibleURL, base: PossibleURL, caller: A
 	if (targetPath.startsWith(basePath)) return targetPath.slice(basePath.length - 1) as AbsolutePath;
 }
 
+/**
+ * Is a target URL active relative to a base URL?
+ * - Active means `target` and `base` resolve to the exact same URL (same origin, same path).
+ * - Origin mismatches return `false`.
+ *
+ * @param target URL whose status to test — relative paths resolve against `base`.
+ * @param base Base URL to test against.
+ */
+export function isURLActive(target: PossibleURL, base: PossibleURL, caller: AnyCaller = isURLActive): boolean {
+	return matchURLPrefix(target, base, caller) === "/";
+}
+
+/**
+ * Is a target URL proud relative to a base URL?
+ * - Proud means `target` is `base` or a descendant of `base` — i.e. `base` is at or above `target` in the URL hierarchy.
+ * - Useful for marking a menu item as "current branch" when the user is somewhere deeper in its sub-tree.
+ * - Origin mismatches return `false`.
+ *
+ * @param target URL whose status to test — relative paths resolve against `base`.
+ * @param base Base URL to test against.
+ */
+export function isURLProud(target: PossibleURL, base: PossibleURL, caller: AnyCaller = isURLProud): boolean {
+	return matchURLPrefix(target, base, caller) !== undefined;
+}
+
 /** BaseURL is a URL with a guaranteed trailing slash on pathname. */
 export interface BaseURL extends ImmutableURL {
 	readonly pathname: `/` | `/${string}/`;


### PR DESCRIPTION
## Summary
- New \`isURLActive(target, base)\` and \`isURLProud(target, base)\` helpers in \`util/url.ts\`. They lean on \`matchURLPrefix\` for origin/path matching: active means same URL, proud means same URL or descendant.
- New \`isActive(target)\` / \`isProud(target)\` methods on \`URLStore\` (inherited by \`NavigationStore\`). They resolve \`target\` against the store's \`base\` then compare with the current value.
- Tests covering equal/descendant/ancestor/unrelated/origin-mismatch cases.

Prep for #264 (proper sidebar menu items with active/proud styling) — splitting it out for individual review.

## Test plan
- [x] \`bun run test:type\`
- [x] \`bun test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)