### PR TITLE
docs: move home page content from root README to modules/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,15 @@
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org) [![Release](https://github.com/dhoulb/shelving/actions/workflows/release.yaml/badge.svg)](https://github.com/dhoulb/shelving/actions/workflows/release.yaml) [![npm](https://img.shields.io/npm/dm/shelving.svg)](https://www.npmjs.com/package/shelving)
 
-Shelving is a TypeScript toolkit for working with typed data. At its core it is a schema validation library — every schema has a `validate()` method that returns a typed value or throws a human-readable error. On top of that it provides a database provider abstraction, an API provider abstraction, observable state stores, React integration, and a large set of typed utility functions.
+TypeScript data toolkit — schema validation, database and API providers, observable state stores, React integration, and typed utility functions.
 
-> Note: Shelving is in active development and does not yet follow semver.
+## Documentation
 
-## Installation
+Full documentation is published at **<https://dhoulb.github.io/shelving/>**.
 
 ```sh
 npm install shelving
 ```
-
-Shelving is an ES module. Import from the main package or from individual module subpaths:
-
-```ts
-import { STRING, DataSchema } from "shelving"
-import { MemoryDBProvider } from "shelving/db"
-```
-
-## Modules
-
-| Module | Description |
-|---|---|
-| [schema](modules/schema/README.md) | Schema validation — the foundation of everything |
-| [db](modules/db/README.md) | Database provider abstraction (Collections, providers, queries) |
-| [api](modules/api/README.md) | API provider abstraction (Endpoints, providers, caching) |
-| [store](modules/store/README.md) | Observable state containers, Suspense-compatible |
-| [sequence](modules/sequence/README.md) | Async-iterable utilities (`DeferredSequence`) |
-| [react](modules/react/README.md) | React hooks for stores and sequences |
-| [error](modules/error/README.md) | Typed error classes |
-| [util](modules/util/README.md) | Typed helpers for arrays, objects, strings, data, queries, updates |
-| [markup](modules/markup/README.md) | Markdown renderer for user-facing content |
-| [cloudflare](modules/cloudflare/README.md) | Cloudflare Workers providers (KV, D1) |
-| [firestore](modules/firestore/README.md) | Firestore providers (client, lite, server) |
-| [bun](modules/bun/README.md) | Bun PostgreSQL provider |
 
 ## Changelog
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,39 @@
+# Shelving
+
+Shelving is a TypeScript toolkit for working with typed data. At its core it is a schema validation library — every schema has a `validate()` method that returns a typed value or throws a human-readable error. On top of that it provides a database provider abstraction, an API provider abstraction, observable state stores, React integration, and a large set of typed utility functions.
+
+> Note: Shelving is in active development and does not yet follow semver.
+
+## Installation
+
+```sh
+npm install shelving
+```
+
+Shelving is an ES module. Import from the main package or from individual module subpaths:
+
+```ts
+import { STRING, DataSchema } from "shelving"
+import { MemoryDBProvider } from "shelving/db"
+```
+
+## Modules
+
+| Module | Description |
+|---|---|
+| [schema](./schema/README.md) | Schema validation — the foundation of everything |
+| [db](./db/README.md) | Database provider abstraction (Collections, providers, queries) |
+| [api](./api/README.md) | API provider abstraction (Endpoints, providers, caching) |
+| [store](./store/README.md) | Observable state containers, Suspense-compatible |
+| [sequence](./sequence/README.md) | Async-iterable utilities (`DeferredSequence`) |
+| [react](./react/README.md) | React hooks for stores and sequences |
+| [error](./error/README.md) | Typed error classes |
+| [util](./util/README.md) | Typed helpers for arrays, objects, strings, data, queries, updates |
+| [markup](./markup/README.md) | Markdown renderer for user-facing content |
+| [cloudflare](./cloudflare/README.md) | Cloudflare Workers providers (KV, D1) |
+| [firestore](./firestore/README.md) | Firestore providers (client, lite, server) |
+| [bun](./bun/README.md) | Bun PostgreSQL provider |
+
+## Changelog
+
+See [Releases](https://github.com/dhoulb/shelving/releases) on GitHub.

--- a/modules/README.md
+++ b/modules/README.md
@@ -21,18 +21,18 @@ import { MemoryDBProvider } from "shelving/db"
 
 | Module | Description |
 |---|---|
-| [schema](./schema/README.md) | Schema validation — the foundation of everything |
-| [db](./db/README.md) | Database provider abstraction (Collections, providers, queries) |
-| [api](./api/README.md) | API provider abstraction (Endpoints, providers, caching) |
-| [store](./store/README.md) | Observable state containers, Suspense-compatible |
-| [sequence](./sequence/README.md) | Async-iterable utilities (`DeferredSequence`) |
-| [react](./react/README.md) | React hooks for stores and sequences |
-| [error](./error/README.md) | Typed error classes |
-| [util](./util/README.md) | Typed helpers for arrays, objects, strings, data, queries, updates |
-| [markup](./markup/README.md) | Markdown renderer for user-facing content |
-| [cloudflare](./cloudflare/README.md) | Cloudflare Workers providers (KV, D1) |
-| [firestore](./firestore/README.md) | Firestore providers (client, lite, server) |
-| [bun](./bun/README.md) | Bun PostgreSQL provider |
+| [schema](/schema) | Schema validation — the foundation of everything |
+| [db](/db) | Database provider abstraction (Collections, providers, queries) |
+| [api](/api) | API provider abstraction (Endpoints, providers, caching) |
+| [store](/store) | Observable state containers, Suspense-compatible |
+| [sequence](/sequence) | Async-iterable utilities (`DeferredSequence`) |
+| [react](/react) | React hooks for stores and sequences |
+| [error](/error) | Typed error classes |
+| [util](/util) | Typed helpers for arrays, objects, strings, data, queries, updates |
+| [markup](/markup) | Markdown renderer for user-facing content |
+| [cloudflare](/cloudflare) | Cloudflare Workers providers (KV, D1) |
+| [firestore](/firestore) | Firestore providers (client, lite, server) |
+| [bun](/bun) | Bun PostgreSQL provider |
 
 ## Changelog
 

--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -37,17 +37,21 @@ const node = renderMarkup("# Hello\n\nThis is **bold** and _italic_.", {
 |---|---|---|
 | `rules` | `MarkupRules` | The rules to apply (required). Use `MARKUP_RULES` for the default set. |
 | `rel` | `string` | `rel` attribute applied to all rendered links, e.g. `"nofollow ugc"`. |
-| `base` | `URLString` | Base URL for resolving relative links. Defaults to `window.location.href` in browser environments. |
+| `url` | `ImmutableURL` | Current page URL — base for resolving relative refs (`./foo`, `#x`, bare segments). |
+| `root` | `ImmutableURL` | Site root URL — base for resolving site-absolute paths (`/foo`), honoring its subfolder. |
 | `schemes` | `URISchemes` | Allowed URI schemes for links. Defaults to `["http:", "https:"]`. |
 
 ```ts
 const node = renderMarkup(content, {
   rules: MARKUP_RULES,
   rel: "nofollow ugc",
-  base: "https://example.com",
+  url: requireURL("https://example.com/page/"),
+  root: requireURL("https://example.com/"),
   schemes: ["http:", "https:", "mailto:"],
 });
 ```
+
+Link href resolution goes through [`getLink`](../util/README.md) — site-absolute paths resolve against `root`, relative refs resolve against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
 
 ### Block-only or inline-only rendering
 

--- a/modules/markup/rule/link.test.ts
+++ b/modules/markup/rule/link.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import type { Element } from "../../util/element.js";
+import { requireURL } from "../../util/url.js";
 import { MARKUP_RULES, renderMarkup } from "../index.js";
 
 const $$typeof = Symbol.for("react.transitional.element");
@@ -129,16 +130,23 @@ test("LINK_RULE", () => {
 		props: { href: "http://google.com/", children: "Google" },
 	});
 
-	// Relative links use `base` from the passed in context.
-	expect(renderMarkup("[XXX](a/b/c)", { ...OPTIONS, base: "https://x.com" }, "inline")).toMatchObject({
+	// Relative links use `url` from the passed in context.
+	expect(renderMarkup("[XXX](a/b/c)", { ...OPTIONS, url: requireURL("https://x.com") }, "inline")).toMatchObject({
 		$$typeof,
 		type: "a",
 		props: { href: "https://x.com/a/b/c", children: "XXX" },
 	});
-	expect(renderMarkup("[](a/b/c)", { ...OPTIONS, base: "https://x.com" }, "inline")).toMatchObject({
+	expect(renderMarkup("[](a/b/c)", { ...OPTIONS, url: requireURL("https://x.com") }, "inline")).toMatchObject({
 		$$typeof,
 		type: "a",
 		props: { href: "https://x.com/a/b/c", children: "x.com/a/b/c" },
+	});
+
+	// Site-absolute paths use `root` from the passed in context — honoring its subfolder.
+	expect(renderMarkup("[Schema](/schema)", { ...OPTIONS, root: requireURL("https://x.com/app/") }, "inline")).toMatchObject({
+		$$typeof,
+		type: "a",
+		props: { href: "https://x.com/app/schema", children: "Schema" },
 	});
 
 	// Links can contain other inlines.

--- a/modules/markup/rule/link.ts
+++ b/modules/markup/rule/link.ts
@@ -1,8 +1,8 @@
 import type { Element } from "../../util/element.js";
 import { formatURI } from "../../util/format.js";
+import { getLink } from "../../util/link.js";
 import { getRegExp, type NamedRegExpExecArray } from "../../util/regexp.js";
-import { getURI, HTTP_SCHEMES } from "../../util/uri.js";
-import { getURL } from "../../util/url.js";
+import { HTTP_SCHEMES } from "../../util/uri.js";
 import { renderMarkup } from "../render.js";
 import { REACT_ELEMENT_TYPE } from "../util/internal.js";
 import type { MarkupOptions } from "../util/options.js";
@@ -16,10 +16,10 @@ function renderLinkMarkupRule(
 	options: MarkupOptions,
 	key: string,
 ): Element {
-	const { base, schemes = HTTP_SCHEMES, rel } = options;
-	const uri = getURL(unsafeHref, base) ?? getURI(unsafeHref);
-	const href = uri && schemes.includes(uri.protocol) ? uri.href : undefined;
-	const children = title ? renderMarkup(title, options, "link") : uri ? formatURI(uri) : "";
+	const { url, root, schemes = HTTP_SCHEMES, rel } = options;
+	const resolved = getLink(unsafeHref, url, root);
+	const href = resolved && schemes.some(s => resolved.startsWith(s)) ? resolved : undefined;
+	const children = title ? renderMarkup(title, options, "link") : resolved ? formatURI(resolved) : "";
 	return {
 		key,
 		$$typeof: REACT_ELEMENT_TYPE,

--- a/modules/markup/util/options.ts
+++ b/modules/markup/util/options.ts
@@ -1,5 +1,5 @@
 import type { URISchemes } from "../../util/uri.js";
-import type { URLString } from "../../util/url.js";
+import type { ImmutableURL } from "../../util/url.js";
 import type { MarkupRules } from "./rule.js";
 
 /** The current parsing options (represents the current state of the parsing). */
@@ -14,10 +14,16 @@ export type MarkupOptions = {
 	readonly rel?: string | undefined;
 
 	/**
-	 * Set the base URL that any relative URLs will be relative to
-	 * @default `window.location.href` in browser environments, and `undefined` in server environments.
+	 * Current page URL — used as the base for resolving relative refs (`./foo`, `#x`, bare segments) in link hrefs.
+	 * @default Falls back to `root` if not set.
 	 */
-	readonly base?: URLString | undefined;
+	readonly url?: ImmutableURL | undefined;
+
+	/**
+	 * Site root URL — used as the base for resolving site-absolute path hrefs (`/foo`), honoring its subfolder.
+	 * @default Falls back to `url` if not set.
+	 */
+	readonly root?: ImmutableURL | undefined;
 
 	/**
 	 * Valid URI schemes/protocols for URLs and URIs.

--- a/modules/util/format.ts
+++ b/modules/util/format.ts
@@ -183,7 +183,7 @@ export function formatDateTime(date: PossibleDate, options?: DateFormatOptions, 
  * e.g. `http://shax.com/test?uid=129483` → `shax.com/test`
  */
 export function formatURI(url: PossibleURI, caller: AnyCaller = formatURI): string {
-	return _formatURI(requireURI(url, undefined, caller));
+	return _formatURI(requireURI(url, caller));
 }
 function _formatURI({ host, pathname }: URL): string {
 	return `${host}${pathname.endsWith("/") ? pathname.slice(0, -1) : pathname}`;

--- a/modules/util/format.ts
+++ b/modules/util/format.ts
@@ -183,7 +183,7 @@ export function formatDateTime(date: PossibleDate, options?: DateFormatOptions, 
  * e.g. `http://shax.com/test?uid=129483` → `shax.com/test`
  */
 export function formatURI(url: PossibleURI, caller: AnyCaller = formatURI): string {
-	return _formatURI(requireURI(url, caller));
+	return _formatURI(requireURI(url, undefined, caller));
 }
 function _formatURI({ host, pathname }: URL): string {
 	return `${host}${pathname.endsWith("/") ? pathname.slice(0, -1) : pathname}`;

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -36,6 +36,7 @@ export * from "./item.js";
 export * from "./iterate.js";
 export * from "./jwt.js";
 export * from "./lazy.js";
+export * from "./link.js";
 export * from "./map.js";
 export * from "./merge.js";
 export * from "./null.js";

--- a/modules/util/link.test.ts
+++ b/modules/util/link.test.ts
@@ -58,6 +58,9 @@ describe("getLink()", () => {
 		test("returns http URL ignoring url and root", () => {
 			expect(getLink("http://other.com/foo", PAGE, ROOT)).toBe("http://other.com/foo");
 		});
+		test("resolves protocol-relative URL against url's protocol", () => {
+			expect(getLink("//other.com/foo", PAGE, ROOT)).toBe("https://other.com/foo");
+		});
 		test("ignores document base for scheme classification", () => {
 			// Even though a relative path containing a colon could resolve via document.baseURI in browsers,
 			// scheme detection should be deterministic — only true scheme-prefixed strings pass through.

--- a/modules/util/link.test.ts
+++ b/modules/util/link.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { RequiredError } from "../error/RequiredError.js";
+import { getLink, requireLink, requireURL } from "../index.js";
+
+const ROOT = requireURL("https://x.com/app/");
+const ROOT_NO_SLASH = requireURL("https://x.com/app");
+const PAGE = requireURL("https://x.com/app/schema/");
+
+describe("getLink()", () => {
+	describe("URL instance", () => {
+		test("returns its href", () => {
+			expect(getLink(requireURL("https://other.com/foo"))).toBe("https://other.com/foo");
+		});
+		test("returns its href ignoring url and root", () => {
+			expect(getLink(requireURL("https://other.com/foo"), PAGE, ROOT)).toBe("https://other.com/foo");
+		});
+		test("returns mailto: href as-is", () => {
+			expect(getLink(new URL("mailto:a@b"))).toBe("mailto:a@b");
+		});
+	});
+
+	describe("absolute path", () => {
+		test("resolves against root honoring its subfolder", () => {
+			expect(getLink("/schema", PAGE, ROOT)).toBe("https://x.com/app/schema");
+		});
+		test("resolves nested absolute path against root", () => {
+			expect(getLink("/schema/db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+		});
+		test("resolves root against root", () => {
+			expect(getLink("/", PAGE, ROOT)).toBe("https://x.com/app/");
+		});
+		test("handles root without trailing slash", () => {
+			// getURL normalises base to a trailing-slash BaseURL internally.
+			expect(getLink("/schema", PAGE, ROOT_NO_SLASH)).toBe("https://x.com/app/schema");
+		});
+		test("ignores url when root is given", () => {
+			expect(getLink("/schema", requireURL("https://other.com/page/"), ROOT)).toBe("https://x.com/app/schema");
+		});
+		test("falls back to url with URL-spec default (host root) when no root", () => {
+			expect(getLink("/schema", PAGE)).toBe("https://x.com/schema");
+		});
+		test("returns undefined when neither url nor root given", () => {
+			expect(getLink("/schema")).toBeUndefined();
+		});
+	});
+
+	describe("scheme-prefixed URI", () => {
+		test("returns mailto: as-is", () => {
+			expect(getLink("mailto:a@b", PAGE, ROOT)).toBe("mailto:a@b");
+		});
+		test("returns tel: as-is", () => {
+			expect(getLink("tel:+44123", PAGE, ROOT)).toBe("tel:+44123");
+		});
+		test("returns external https URL as-is", () => {
+			expect(getLink("https://other.com/foo", PAGE, ROOT)).toBe("https://other.com/foo");
+		});
+		test("returns http URL ignoring url and root", () => {
+			expect(getLink("http://other.com/foo", PAGE, ROOT)).toBe("http://other.com/foo");
+		});
+		test("ignores document base for scheme classification", () => {
+			// Even though a relative path containing a colon could resolve via document.baseURI in browsers,
+			// scheme detection should be deterministic — only true scheme-prefixed strings pass through.
+			expect(getLink("mailto:a@b")).toBe("mailto:a@b");
+		});
+	});
+
+	describe("relative ref", () => {
+		test("resolves ./foo against url", () => {
+			expect(getLink("./db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+		});
+		test("resolves ../foo against url", () => {
+			expect(getLink("../other", PAGE, ROOT)).toBe("https://x.com/app/other");
+		});
+		test("resolves bare segment against url", () => {
+			expect(getLink("db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+		});
+		test("resolves fragment against url", () => {
+			expect(getLink("#anchor", PAGE, ROOT)).toBe("https://x.com/app/schema/#anchor");
+		});
+		test("resolves query against url", () => {
+			expect(getLink("?q=1", PAGE, ROOT)).toBe("https://x.com/app/schema/?q=1");
+		});
+		test("falls back to root when no url given", () => {
+			expect(getLink("./db", undefined, ROOT)).toBe("https://x.com/app/db");
+		});
+		test("returns undefined when neither url nor root given", () => {
+			expect(getLink("./db")).toBeUndefined();
+		});
+	});
+
+	describe("invalid input", () => {
+		test("returns undefined for empty string", () => {
+			expect(getLink("", PAGE, ROOT)).toBeUndefined();
+		});
+		test("returns undefined for null", () => {
+			expect(getLink(null, PAGE, ROOT)).toBeUndefined();
+		});
+		test("returns undefined for undefined", () => {
+			expect(getLink(undefined, PAGE, ROOT)).toBeUndefined();
+		});
+		test("returns undefined for number", () => {
+			expect(getLink(123, PAGE, ROOT)).toBeUndefined();
+		});
+		test("returns undefined for object", () => {
+			expect(getLink({ href: "/foo" }, PAGE, ROOT)).toBeUndefined();
+		});
+	});
+});
+
+describe("requireLink()", () => {
+	test("returns resolved href", () => {
+		expect(requireLink("/schema", PAGE, ROOT)).toBe("https://x.com/app/schema");
+	});
+	test("returns mailto: as-is", () => {
+		expect(requireLink("mailto:a@b", PAGE, ROOT)).toBe("mailto:a@b");
+	});
+	test("throws RequiredError for empty string", () => {
+		expect(() => requireLink("" as never, PAGE, ROOT)).toThrow(RequiredError);
+	});
+	test("throws RequiredError when absolute path has no base at all", () => {
+		expect(() => requireLink("/schema")).toThrow(RequiredError);
+	});
+});

--- a/modules/util/link.test.ts
+++ b/modules/util/link.test.ts
@@ -36,8 +36,9 @@ describe("getLink()", () => {
 		test("ignores url when root is given", () => {
 			expect(getLink("/schema", requireURL("https://other.com/page/"), ROOT)).toBe("https://x.com/app/schema");
 		});
-		test("falls back to url with URL-spec default (host root) when no root", () => {
-			expect(getLink("/schema", PAGE)).toBe("https://x.com/schema");
+		test("defaults root to url when root is omitted, resolving under url's directory", () => {
+			// PAGE is "https://x.com/app/schema/" — absolute paths resolve under it.
+			expect(getLink("/db", PAGE)).toBe("https://x.com/app/schema/db");
 		});
 		test("returns undefined when neither url nor root given", () => {
 			expect(getLink("/schema")).toBeUndefined();

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -1,8 +1,8 @@
 import { RequiredError } from "../error/RequiredError.js";
 import type { AnyCaller } from "./function.js";
 import { isAbsolutePath, type Path } from "./path.js";
-import { getURI, type ImmutableURI, type URIString } from "./uri.js";
-import { getURL, type ImmutableURL } from "./url.js";
+import type { ImmutableURI, URIString } from "./uri.js";
+import { getBasedURI, getURL, type ImmutableURL } from "./url.js";
 
 /** Anything that can be turned into an `<a href>` value — a site/relative path, a URI string, or a `URL` instance. */
 export type PossibleLink = Path | ImmutableURI | URIString;
@@ -13,13 +13,13 @@ export type PossibleLink = Path | ImmutableURI | URIString;
  * Classification:
  * - **`URL` instance** → returns its `.href` directly.
  * - **Absolute path** (single leading `/`, e.g. `/schema`) → resolved against `root` with a dot prefix so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
- * - **Anything else** — relative ref (`./foo`, `../foo`, `foo`, `#anchor`, `?q`), protocol-relative URL (`//host/path`), or scheme-prefixed URI (`mailto:a@b`, `tel:123`, `https://x.com/y`) → fed to `getURI` with `url` as the base. Self-contained URIs ignore the base (their own scheme makes them absolute); protocol-relative and relative refs resolve against the page URL.
+ * - **Anything else** — relative ref (`./foo`, `../foo`, `foo`, `#anchor`, `?q`), protocol-relative URL (`//host/path`), or scheme-prefixed URI (`mailto:a@b`, `tel:123`, `https://x.com/y`) → fed to `getBasedURI` with `url` as the base. Self-contained URIs ignore the base (their own scheme makes them absolute); protocol-relative and relative refs resolve against the page URL.
  *
  * Defaults:
  * - `root` defaults to `url`, so passing only `url` makes absolute paths resolve under the page URL's directory (same coordinate space the page lives in).
  * - When both are omitted, all branches return `undefined` (no base to resolve against).
  *
- * Bases are passed through to `getURL` / `getURI` lazily — neither `url` nor `root` is materialised into a normalised base until the chosen branch needs it.
+ * Bases are passed through to `getURL` / `getBasedURI` lazily — neither `url` nor `root` is materialised into a normalised base until the chosen branch needs it.
  *
  * @param link The link to resolve. Strings are classified by shape; `URL` instances pass through.
  * @param url The current page URL — base for relative refs and scheme-prefixed URIs.
@@ -34,9 +34,9 @@ export function getLink(link: unknown, url?: ImmutableURL, root: ImmutableURL | 
 	if (!link) return;
 	if (link instanceof URL) return link.href as URIString;
 	if (typeof link !== "string") return;
-	// Single leading slash is a site-absolute path; `//` is a protocol-relative URL and falls through to `getURI`.
+	// Single leading slash is a site-absolute path; `//` is a protocol-relative URL and falls through to `getBasedURI`.
 	if (isAbsolutePath(link) && !link.startsWith("//")) return getURL(`.${link}`, root)?.href;
-	return getURI(link, url ?? root)?.href;
+	return getBasedURI(link, url ?? root)?.href;
 }
 
 /**

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -4,13 +4,6 @@ import { isAbsolutePath, type Path } from "./path.js";
 import { getURI, type ImmutableURI, type URIString } from "./uri.js";
 import { getURL, type ImmutableURL } from "./url.js";
 
-/**
- * RFC 3986 scheme detector — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by a colon.
- * - Used to distinguish a scheme-prefixed URI string (e.g. `mailto:foo`, `tel:123`, `https://x.com`) from a relative path that happens to contain a colon later on.
- * - Avoids depending on `document.baseURI` (which `getURI` falls back to in browsers) for the classification.
- */
-const _R_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
-
 /** Anything that can be turned into an `<a href>` value — a site/relative path, a URI string, or a `URL` instance. */
 export type PossibleLink = Path | ImmutableURI | URIString;
 
@@ -19,48 +12,40 @@ export type PossibleLink = Path | ImmutableURI | URIString;
  *
  * Classification:
  * - **`URL` instance** → returns its `.href` directly.
- * - **Absolute path** (starts with `/`, e.g. `/schema`) → resolved against `root` (the site root). The leading `/` is dot-prefixed first so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
- * - **Scheme-prefixed URI string** (matches `^[a-z][a-z0-9+.-]*:`, e.g. `mailto:a@b`, `tel:123`, `https://x.com/y`) → returned as-is (via `getURI`).
- * - **Anything else** — relative path, fragment, query, or bare segment (e.g. `./foo`, `../foo`, `foo`, `#anchor`, `?q=1`) → resolved against `url` (the current page URL).
+ * - **Absolute path** (starts with `/`, e.g. `/schema`) → resolved against `root` with a dot prefix so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
+ * - **Anything else** — relative ref (`./foo`, `../foo`, `foo`, `#anchor`, `?q`) or scheme-prefixed URI (`mailto:a@b`, `tel:123`, `https://x.com/y`) → fed to `getURI` with `url` as the base. Self-contained URIs ignore the base (their own scheme makes them absolute); relative refs resolve against the page URL.
  *
- * Fallbacks:
- * - If `root` is omitted, absolute paths resolve against `url` using `new URL()`'s default semantics (host root of `url`'s origin) — the dot-prefix trick only applies when an explicit `root` is given.
- * - If `url` is omitted, relative refs fall back to `root` so they still have somewhere to anchor.
+ * Defaults:
+ * - `root` defaults to `url`, so passing only `url` makes absolute paths resolve under the page URL's directory (same coordinate space the page lives in).
+ * - When both are omitted, all branches return `undefined` (no base to resolve against).
  *
- * Bases are passed through to `getURL` / `getURI` lazily — neither `url` nor `root` is touched unless the chosen branch needs it, matching `getURL`'s pattern.
+ * Bases are passed through to `getURL` / `getURI` lazily — neither `url` nor `root` is materialised into a normalised base until the chosen branch needs it.
  *
  * @param link The link to resolve. Strings are classified by shape; `URL` instances pass through.
- * @param url The current page URL — used as the base for relative refs.
- * @param root The site root URL — used as the base for absolute paths.
+ * @param url The current page URL — base for relative refs and scheme-prefixed URIs.
+ * @param root The site root URL — base for absolute paths. Defaults to `url`.
  * @returns An absolute URI string, or `undefined` if `link` is missing, not a string/URL, or cannot be resolved.
  *
  * @example getLink("/schema", pageURL, siteRoot) // → "https://x.com/app/schema" when siteRoot is "https://x.com/app/"
  * @example getLink("./db", new URL("https://x.com/app/schema/")) // → "https://x.com/app/schema/db"
  * @example getLink("mailto:a@b") // → "mailto:a@b"
  */
-export function getLink(link: unknown, url?: ImmutableURL, root?: ImmutableURL): URIString | undefined {
+export function getLink(link: unknown, url?: ImmutableURL, root: ImmutableURL | undefined = url): URIString | undefined {
 	if (!link) return;
 	if (link instanceof URL) return link.href as URIString;
 	if (typeof link !== "string") return;
-
-	// Absolute path — resolve against `root` (with dot-prefix to honor its subfolder), or against `url` with URL-spec default if no root.
-	if (isAbsolutePath(link)) return root ? getURL(`.${link}`, root)?.href : getURL(link, url)?.href;
-
-	// Scheme-prefixed URI (mailto:, tel:, https://, …) — pass through via `getURI`. Avoids the `document.baseURI` fallback in browsers.
-	if (_R_SCHEME.test(link)) return getURI(link)?.href;
-
-	// Anything else — relative ref. Resolve against `url`, falling back to `root`.
-	return getURL(link, url ?? root)?.href;
+	if (isAbsolutePath(link)) return getURL(`.${link}`, root)?.href;
+	return getURI(link, url ?? root)?.href;
 }
 
 /**
  * Resolve a possible link to an absolute URI string, or throw `RequiredError` if resolution fails.
  *
- * Same classification and fallback rules as `getLink`. Use when an absolute URI is required and there's no sensible "do nothing" path for the caller.
+ * Same classification and defaults as `getLink`. Use when an absolute URI is required and there's no sensible "do nothing" path for the caller.
  *
  * @param link The link to resolve.
- * @param url The current page URL — used as the base for relative refs.
- * @param root The site root URL — used as the base for absolute paths.
+ * @param url The current page URL — base for relative refs and scheme-prefixed URIs.
+ * @param root The site root URL — base for absolute paths. Defaults to `url`.
  * @param caller Identity of the calling function for error attribution.
  * @returns An absolute URI string.
  * @throws `RequiredError` if `link` cannot be resolved.

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -1,0 +1,72 @@
+import { RequiredError } from "../error/RequiredError.js";
+import type { AnyCaller } from "./function.js";
+import { isAbsolutePath, type Path } from "./path.js";
+import { getURI, type ImmutableURI, type URIString } from "./uri.js";
+import { getURL, type ImmutableURL } from "./url.js";
+
+/**
+ * RFC 3986 scheme detector — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by a colon.
+ * - Used to distinguish a scheme-prefixed URI string (e.g. `mailto:foo`, `tel:123`, `https://x.com`) from a relative path that happens to contain a colon later on.
+ * - Avoids depending on `document.baseURI` (which `getURI` falls back to in browsers) for the classification.
+ */
+const _R_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/** Anything that can be turned into an `<a href>` value — a site/relative path, a URI string, or a `URL` instance. */
+export type PossibleLink = Path | ImmutableURI | URIString;
+
+/**
+ * Resolve a possible link to an absolute URI string, or return `undefined` if resolution fails.
+ *
+ * Classification:
+ * - **`URL` instance** → returns its `.href` directly.
+ * - **Absolute path** (starts with `/`, e.g. `/schema`) → resolved against `root` (the site root). The leading `/` is dot-prefixed first so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
+ * - **Scheme-prefixed URI string** (matches `^[a-z][a-z0-9+.-]*:`, e.g. `mailto:a@b`, `tel:123`, `https://x.com/y`) → returned as-is (via `getURI`).
+ * - **Anything else** — relative path, fragment, query, or bare segment (e.g. `./foo`, `../foo`, `foo`, `#anchor`, `?q=1`) → resolved against `url` (the current page URL).
+ *
+ * Fallbacks:
+ * - If `root` is omitted, absolute paths resolve against `url` using `new URL()`'s default semantics (host root of `url`'s origin) — the dot-prefix trick only applies when an explicit `root` is given.
+ * - If `url` is omitted, relative refs fall back to `root` so they still have somewhere to anchor.
+ *
+ * Bases are passed through to `getURL` / `getURI` lazily — neither `url` nor `root` is touched unless the chosen branch needs it, matching `getURL`'s pattern.
+ *
+ * @param link The link to resolve. Strings are classified by shape; `URL` instances pass through.
+ * @param url The current page URL — used as the base for relative refs.
+ * @param root The site root URL — used as the base for absolute paths.
+ * @returns An absolute URI string, or `undefined` if `link` is missing, not a string/URL, or cannot be resolved.
+ *
+ * @example getLink("/schema", pageURL, siteRoot) // → "https://x.com/app/schema" when siteRoot is "https://x.com/app/"
+ * @example getLink("./db", new URL("https://x.com/app/schema/")) // → "https://x.com/app/schema/db"
+ * @example getLink("mailto:a@b") // → "mailto:a@b"
+ */
+export function getLink(link: unknown, url?: ImmutableURL, root?: ImmutableURL): URIString | undefined {
+	if (!link) return;
+	if (link instanceof URL) return link.href as URIString;
+	if (typeof link !== "string") return;
+
+	// Absolute path — resolve against `root` (with dot-prefix to honor its subfolder), or against `url` with URL-spec default if no root.
+	if (isAbsolutePath(link)) return root ? getURL(`.${link}`, root)?.href : getURL(link, url)?.href;
+
+	// Scheme-prefixed URI (mailto:, tel:, https://, …) — pass through via `getURI`. Avoids the `document.baseURI` fallback in browsers.
+	if (_R_SCHEME.test(link)) return getURI(link)?.href;
+
+	// Anything else — relative ref. Resolve against `url`, falling back to `root`.
+	return getURL(link, url ?? root)?.href;
+}
+
+/**
+ * Resolve a possible link to an absolute URI string, or throw `RequiredError` if resolution fails.
+ *
+ * Same classification and fallback rules as `getLink`. Use when an absolute URI is required and there's no sensible "do nothing" path for the caller.
+ *
+ * @param link The link to resolve.
+ * @param url The current page URL — used as the base for relative refs.
+ * @param root The site root URL — used as the base for absolute paths.
+ * @param caller Identity of the calling function for error attribution.
+ * @returns An absolute URI string.
+ * @throws `RequiredError` if `link` cannot be resolved.
+ */
+export function requireLink(link: PossibleLink, url?: ImmutableURL, root?: ImmutableURL, caller: AnyCaller = requireLink): URIString {
+	const href = getLink(link, url, root);
+	if (!href) throw new RequiredError("Invalid link", { received: link, caller });
+	return href;
+}

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -12,8 +12,8 @@ export type PossibleLink = Path | ImmutableURI | URIString;
  *
  * Classification:
  * - **`URL` instance** → returns its `.href` directly.
- * - **Absolute path** (starts with `/`, e.g. `/schema`) → resolved against `root` with a dot prefix so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
- * - **Anything else** — relative ref (`./foo`, `../foo`, `foo`, `#anchor`, `?q`) or scheme-prefixed URI (`mailto:a@b`, `tel:123`, `https://x.com/y`) → fed to `getURI` with `url` as the base. Self-contained URIs ignore the base (their own scheme makes them absolute); relative refs resolve against the page URL.
+ * - **Absolute path** (single leading `/`, e.g. `/schema`) → resolved against `root` with a dot prefix so the resolution honors `root`'s subfolder — `/schema` against `https://x.com/app/` becomes `https://x.com/app/schema`, not `https://x.com/schema`.
+ * - **Anything else** — relative ref (`./foo`, `../foo`, `foo`, `#anchor`, `?q`), protocol-relative URL (`//host/path`), or scheme-prefixed URI (`mailto:a@b`, `tel:123`, `https://x.com/y`) → fed to `getURI` with `url` as the base. Self-contained URIs ignore the base (their own scheme makes them absolute); protocol-relative and relative refs resolve against the page URL.
  *
  * Defaults:
  * - `root` defaults to `url`, so passing only `url` makes absolute paths resolve under the page URL's directory (same coordinate space the page lives in).
@@ -34,7 +34,8 @@ export function getLink(link: unknown, url?: ImmutableURL, root: ImmutableURL | 
 	if (!link) return;
 	if (link instanceof URL) return link.href as URIString;
 	if (typeof link !== "string") return;
-	if (isAbsolutePath(link)) return getURL(`.${link}`, root)?.href;
+	// Single leading slash is a site-absolute path; `//` is a protocol-relative URL and falls through to `getURI`.
+	if (isAbsolutePath(link) && !link.startsWith("//")) return getURL(`.${link}`, root)?.href;
 	return getURI(link, url ?? root)?.href;
 }
 

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -75,7 +75,7 @@ export function assertURI(value: unknown, caller: AnyCaller = assertURI): assert
 /**
  * Convert a possible URI to a URI, or return `undefined` if conversion fails.
  * - When `base` is given, it's used as the resolution base for relative inputs (e.g. `getURI("./foo", "https://x.com/page/")` → URI for `https://x.com/page/foo`). Self-contained URIs with their own scheme (e.g. `mailto:a@b`) ignore the base, same as the URL constructor.
- * - When `base` is omitted, only inputs that already encode a complete URI succeed — relative inputs return `undefined` rather than silently resolving against `document.baseURI`.
+ * - When `base` is omitted, only inputs that already encode a complete URI succeed — relative inputs return `undefined`. No implicit fallback to the document or window URL; callers thread their base in explicitly (e.g. from `Meta.url` / `Meta.root` in the UI layer).
  */
 export function getURI(possible: Nullish<PossibleURI>, base?: PossibleURI): ImmutableURI | undefined {
 	if (notNullish(possible)) {

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -100,11 +100,6 @@ export function getURIString(possible: Nullish<PossibleURI>, base?: PossibleURI)
 	return getURI(possible, base)?.href;
 }
 
-/** Convert a possible URI to a URI string, or throw `RequiredError` if conversion fails. */
-export function requireURIString(possible: PossibleURI, base?: PossibleURI, caller: AnyCaller = requireURIString): URIString | undefined {
-	return requireURI(possible, base, caller).href;
-}
-
 /** Type for a set of named URL parameters. */
 export type URIParams = ImmutableDictionary<string>;
 

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -72,34 +72,37 @@ export function assertURI(value: unknown, caller: AnyCaller = assertURI): assert
 	if (!isURI(value)) throw new RequiredError("Invalid URI", { received: value, caller });
 }
 
-/** Convert a possible URI to a URI, or return `undefined` if conversion fails. */
-export function getURI(possible: Nullish<PossibleURI>): ImmutableURI | undefined {
+/**
+ * Convert a possible URI to a URI, or return `undefined` if conversion fails.
+ * - When `base` is given, it's used as the resolution base for relative inputs (e.g. `getURI("./foo", "https://x.com/page/")` → URI for `https://x.com/page/foo`). Self-contained URIs with their own scheme (e.g. `mailto:a@b`) ignore the base, same as the URL constructor.
+ * - When `base` is omitted, only inputs that already encode a complete URI succeed — relative inputs return `undefined` rather than silently resolving against `document.baseURI`.
+ */
+export function getURI(possible: Nullish<PossibleURI>, base?: PossibleURI): ImmutableURI | undefined {
 	if (notNullish(possible)) {
 		if (isURI(possible)) return possible;
 		try {
-			return new URL(possible, _BASE) as ImmutableURI;
+			return new URL(possible, base as string | URL | undefined) as ImmutableURI;
 		} catch {
 			return undefined;
 		}
 	}
 }
-const _BASE = typeof document === "object" ? document.baseURI : undefined;
 
 /** Convert a possible URI to a URI, or throw `RequiredError` if conversion fails. */
-export function requireURI(possible: PossibleURI, caller: AnyCaller = requireURI): ImmutableURI {
-	const url = getURI(possible);
+export function requireURI(possible: PossibleURI, base?: PossibleURI, caller: AnyCaller = requireURI): ImmutableURI {
+	const url = getURI(possible, base);
 	assertURI(url, caller);
 	return url;
 }
 
 /** Convert a possible URI to a URI string, or return `undefined` if conversion fails. */
-export function getURIString(possible: Nullish<PossibleURI>): URIString | undefined {
-	return getURI(possible)?.href;
+export function getURIString(possible: Nullish<PossibleURI>, base?: PossibleURI): URIString | undefined {
+	return getURI(possible, base)?.href;
 }
 
 /** Convert a possible URI to a URI string, or throw `RequiredError` if conversion fails. */
-export function requireURIString(possible: PossibleURI, caller: AnyCaller = requireURIString): URIString | undefined {
-	return requireURI(possible, caller).href;
+export function requireURIString(possible: PossibleURI, base?: PossibleURI, caller: AnyCaller = requireURIString): URIString | undefined {
+	return requireURI(possible, base, caller).href;
 }
 
 /** Type for a set of named URL parameters. */
@@ -121,7 +124,7 @@ function* getURIEntries(params: PossibleURIParams, caller: AnyCaller = getURIPar
 	if (params instanceof URLSearchParams) {
 		yield* params;
 	} else if (isString(params) || params instanceof URL) {
-		yield* requireURI(params, caller).searchParams;
+		yield* requireURI(params, undefined, caller).searchParams;
 	} else {
 		const done: MutableArray<string> = [];
 		for (const [key, value] of getDictionaryItems(params)) {
@@ -168,7 +171,7 @@ export function requireURIParam(params: PossibleURIParams, key: string, caller: 
 export function withURIParam(uri: ImmutableURL | URLString, key: string, value: unknown, caller?: AnyCaller): ImmutableURL;
 export function withURIParam(uri: PossibleURI, key: string, value: unknown, caller?: AnyCaller): ImmutableURI;
 export function withURIParam(uri: PossibleURI, key: string, value: unknown, caller: AnyCaller = withURIParam): ImmutableURI {
-	const input = requireURI(uri, caller);
+	const input = requireURI(uri, undefined, caller);
 	if (value === undefined) return input; // Ignore undefined.
 	const output = new ImmutableURI(input);
 	const str = getString(value);
@@ -189,7 +192,7 @@ export function withURIParam(uri: PossibleURI, key: string, value: unknown, call
 export function withURIParams(uri: ImmutableURL | URLString, params: Nullish<PossibleURIParams>, caller?: AnyCaller): ImmutableURL;
 export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParams>, caller?: AnyCaller): ImmutableURI;
 export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParams>, caller: AnyCaller = withURIParams): ImmutableURI {
-	const input = requireURI(uri, caller);
+	const input = requireURI(uri, undefined, caller);
 	if (!params) return input;
 	const output = new ImmutableURI(input);
 	for (const [key, str] of getURIEntries(params, caller)) output.searchParams.set(key, str);
@@ -202,7 +205,7 @@ export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParam
 export function omitURIParams(uri: ImmutableURL | URLString, ...keys: string[]): ImmutableURL;
 export function omitURIParams(uri: PossibleURI, ...keys: string[]): ImmutableURI;
 export function omitURIParams(uri: PossibleURI, ...keys: string[]): ImmutableURI {
-	const input = requireURI(uri, omitURIParams);
+	const input = requireURI(uri, undefined, omitURIParams);
 	if (!keys.length) return input;
 	const output = new ImmutableURI(input);
 	for (const key of keys) output.searchParams.delete(key);
@@ -216,7 +219,7 @@ export const omitURIParam: (uri: PossibleURI, key: string) => ImmutableURI = omi
 export function clearURIParams(uri: ImmutableURL | URLString, caller?: AnyCaller): ImmutableURL;
 export function clearURIParams(uri: PossibleURI, caller?: AnyCaller): ImmutableURI;
 export function clearURIParams(uri: PossibleURI, caller: AnyCaller = clearURIParams): ImmutableURI {
-	const input = requireURI(uri, caller);
+	const input = requireURI(uri, undefined, caller);
 	if (!input.search.length) return input;
 	const output = new URL(input);
 	output.search = "";

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -74,14 +74,14 @@ export function assertURI(value: unknown, caller: AnyCaller = assertURI): assert
 
 /**
  * Convert a possible URI to a URI, or return `undefined` if conversion fails.
- * - When `base` is given, it's used as the resolution base for relative inputs (e.g. `getURI("./foo", "https://x.com/page/")` → URI for `https://x.com/page/foo`). Self-contained URIs with their own scheme (e.g. `mailto:a@b`) ignore the base, same as the URL constructor.
- * - When `base` is omitted, only inputs that already encode a complete URI succeed — relative inputs return `undefined`. No implicit fallback to the document or window URL; callers thread their base in explicitly (e.g. from `Meta.url` / `Meta.root` in the UI layer).
+ * - Only inputs that already encode a complete URI succeed — relative inputs return `undefined`. No implicit fallback to the document or window URL.
+ * - To resolve a relative ref against a base, use `getBasedURI()` from `url.ts`.
  */
-export function getURI(possible: Nullish<PossibleURI>, base?: PossibleURI): ImmutableURI | undefined {
+export function getURI(possible: Nullish<PossibleURI>): ImmutableURI | undefined {
 	if (notNullish(possible)) {
 		if (isURI(possible)) return possible;
 		try {
-			return new URL(possible, base as string | URL | undefined) as ImmutableURI;
+			return new URL(possible) as ImmutableURI;
 		} catch {
 			return undefined;
 		}

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -3,7 +3,7 @@ import { ValueError } from "../error/ValueError.js";
 import type { ImmutableArray, MutableArray } from "./array.js";
 import { type DictionaryItem, getDictionaryItems, type ImmutableDictionary, isDictionary, type MutableDictionary } from "./dictionary.js";
 import type { AnyCaller } from "./function.js";
-import { type Nullish, notNullish } from "./null.js";
+import type { Nullish } from "./null.js";
 import { getString, isString } from "./string.js";
 import type { ImmutableURL, URLString } from "./url.js";
 
@@ -24,10 +24,9 @@ export type URIHash = `#${string}`;
 
 /**
  * Construct a correctly-typed `URI` object.
- * - This is a more correctly typed version of the builtin Javascript `URI` constructor.
- * - Requires a URI string, URI object, or path as input, and optionally a base URI.
- * - If a path is provided as input, a base URI _must_ also be provided.
- * - The returned type is
+ * - This is a more correctly typed version of the builtin Javascript `URL` constructor.
+ * - Takes a URI string or URI object that already encodes a complete URI — no base parameter, so relative inputs are not accepted.
+ * - To resolve a relative input against a base, use `getBasedURI()` from `url.ts`.
  */
 export interface ImmutableURIConstructor {
 	new (input: URIString | ImmutableURI): ImmutableURI;
@@ -78,13 +77,12 @@ export function assertURI(value: unknown, caller: AnyCaller = assertURI): assert
  * - To resolve a relative ref against a base, use `getBasedURI()` from `url.ts`.
  */
 export function getURI(possible: Nullish<PossibleURI>): ImmutableURI | undefined {
-	if (notNullish(possible)) {
-		if (isURI(possible)) return possible;
-		try {
-			return new URL(possible) as ImmutableURI;
-		} catch {
-			return undefined;
-		}
+	if (!possible) return;
+	if (isURI(possible)) return possible;
+	try {
+		return new URL(possible) as ImmutableURI;
+	} catch {
+		//
 	}
 }
 

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -95,11 +95,6 @@ export function requireURI(possible: PossibleURI, caller: AnyCaller = requireURI
 	return url;
 }
 
-/** Convert a possible URI to a URI string, or return `undefined` if conversion fails. */
-export function getURIString(possible: Nullish<PossibleURI>, base?: PossibleURI): URIString | undefined {
-	return getURI(possible, base)?.href;
-}
-
 /** Type for a set of named URL parameters. */
 export type URIParams = ImmutableDictionary<string>;
 

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -89,8 +89,8 @@ export function getURI(possible: Nullish<PossibleURI>, base?: PossibleURI): Immu
 }
 
 /** Convert a possible URI to a URI, or throw `RequiredError` if conversion fails. */
-export function requireURI(possible: PossibleURI, base?: PossibleURI, caller: AnyCaller = requireURI): ImmutableURI {
-	const url = getURI(possible, base);
+export function requireURI(possible: PossibleURI, caller: AnyCaller = requireURI): ImmutableURI {
+	const url = getURI(possible);
 	assertURI(url, caller);
 	return url;
 }
@@ -119,7 +119,7 @@ function* getURIEntries(params: PossibleURIParams, caller: AnyCaller = getURIPar
 	if (params instanceof URLSearchParams) {
 		yield* params;
 	} else if (isString(params) || params instanceof URL) {
-		yield* requireURI(params, undefined, caller).searchParams;
+		yield* requireURI(params, caller).searchParams;
 	} else {
 		const done: MutableArray<string> = [];
 		for (const [key, value] of getDictionaryItems(params)) {
@@ -166,7 +166,7 @@ export function requireURIParam(params: PossibleURIParams, key: string, caller: 
 export function withURIParam(uri: ImmutableURL | URLString, key: string, value: unknown, caller?: AnyCaller): ImmutableURL;
 export function withURIParam(uri: PossibleURI, key: string, value: unknown, caller?: AnyCaller): ImmutableURI;
 export function withURIParam(uri: PossibleURI, key: string, value: unknown, caller: AnyCaller = withURIParam): ImmutableURI {
-	const input = requireURI(uri, undefined, caller);
+	const input = requireURI(uri, caller);
 	if (value === undefined) return input; // Ignore undefined.
 	const output = new ImmutableURI(input);
 	const str = getString(value);
@@ -187,7 +187,7 @@ export function withURIParam(uri: PossibleURI, key: string, value: unknown, call
 export function withURIParams(uri: ImmutableURL | URLString, params: Nullish<PossibleURIParams>, caller?: AnyCaller): ImmutableURL;
 export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParams>, caller?: AnyCaller): ImmutableURI;
 export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParams>, caller: AnyCaller = withURIParams): ImmutableURI {
-	const input = requireURI(uri, undefined, caller);
+	const input = requireURI(uri, caller);
 	if (!params) return input;
 	const output = new ImmutableURI(input);
 	for (const [key, str] of getURIEntries(params, caller)) output.searchParams.set(key, str);
@@ -200,7 +200,7 @@ export function withURIParams(uri: PossibleURI, params: Nullish<PossibleURIParam
 export function omitURIParams(uri: ImmutableURL | URLString, ...keys: string[]): ImmutableURL;
 export function omitURIParams(uri: PossibleURI, ...keys: string[]): ImmutableURI;
 export function omitURIParams(uri: PossibleURI, ...keys: string[]): ImmutableURI {
-	const input = requireURI(uri, undefined, omitURIParams);
+	const input = requireURI(uri, omitURIParams);
 	if (!keys.length) return input;
 	const output = new ImmutableURI(input);
 	for (const key of keys) output.searchParams.delete(key);
@@ -214,7 +214,7 @@ export const omitURIParam: (uri: PossibleURI, key: string) => ImmutableURI = omi
 export function clearURIParams(uri: ImmutableURL | URLString, caller?: AnyCaller): ImmutableURL;
 export function clearURIParams(uri: PossibleURI, caller?: AnyCaller): ImmutableURI;
 export function clearURIParams(uri: PossibleURI, caller: AnyCaller = clearURIParams): ImmutableURI {
-	const input = requireURI(uri, undefined, caller);
+	const input = requireURI(uri, caller);
 	if (!input.search.length) return input;
 	const output = new URL(input);
 	output.search = "";

--- a/modules/util/url.test.ts
+++ b/modules/util/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getURL, isURL, isURLActive, isURLProud, matchURLPrefix, requireURL } from "../index.js";
+import { getBasedURI, getURL, isURL, isURLActive, isURLProud, matchURLPrefix, requireURL } from "../index.js";
 
 describe("isURL()", () => {
 	test("returns true for URL instance", () => {
@@ -53,6 +53,36 @@ describe("requireURL()", () => {
 	});
 	test("throws for invalid input", () => {
 		expect(() => requireURL("not a url")).toThrow();
+	});
+});
+describe("getBasedURI()", () => {
+	test("returns a complete URL unchanged", () => {
+		expect(getBasedURI("https://a.com/foo")?.href).toBe("https://a.com/foo");
+	});
+	test("returns a non-URL URI unchanged", () => {
+		expect(getBasedURI("mailto:a@b")?.href).toBe("mailto:a@b");
+	});
+	test("returns a URL instance as-is", () => {
+		const url = requireURL("https://a.com/foo");
+		expect(getBasedURI(url)).toBe(url);
+	});
+	test("resolves a relative ref against the base", () => {
+		expect(getBasedURI("./foo", "https://x.com/a/b/")?.href).toBe("https://x.com/a/b/foo");
+	});
+	test("treats the base as a directory even without a trailing slash", () => {
+		// Same trailing-slash normalisation as getURL — the last segment is not dropped.
+		expect(getBasedURI("./foo", "https://x.com/a/b")?.href).toBe("https://x.com/a/b/foo");
+	});
+	test("resolves a scheme-prefixed URI ignoring the base", () => {
+		expect(getBasedURI("mailto:a@b", "https://x.com/a/")?.href).toBe("mailto:a@b");
+	});
+	test("returns undefined for a relative ref with no base", () => {
+		expect(getBasedURI("./foo")).toBeUndefined();
+	});
+	test("returns undefined for nullish input", () => {
+		expect(getBasedURI(undefined)).toBeUndefined();
+		expect(getBasedURI(null)).toBeUndefined();
+		expect(getBasedURI("")).toBeUndefined();
 	});
 });
 describe("matchURLPrefix()", () => {

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -167,6 +167,7 @@ export function getBaseURL(input: Nullish<PossibleURL>): BaseURL | undefined {
 	const uri = getBasedURI(input, undefined);
 	if (!uri || !_isURL(uri)) return;
 	if (_isBaseURL(uri)) return uri;
+	// Clone before mutating: when `input` was a `URL` instance, `getBasedURI` returned that same instance, so mutating it would corrupt the caller's object. A string input always yields a fresh `uri`.
 	const base: URL = typeof input === "string" ? uri : new URL(uri);
 	base.pathname = `${uri.pathname}/`; // Add a trailing slash.
 	return base as BaseURL;

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -67,26 +67,31 @@ export function assertURL(value: unknown, caller: AnyCaller = assertURL): assert
 }
 
 /**
- * Resolve a possible URL relative to a base URL, or return `undefined` if conversion fails.
+ * Resolve a possible URI relative to a base, or return `undefined` if conversion fails.
+ * - Returns any kind of URI — not just hierarchical `scheme://host` URLs. Use `getURL()` when a true URL is specifically required.
+ * - A `URL` instance is returned as-is (already absolute, base ignored).
  *
- * Note: When resolving relative URLs this treats `base` as if it ends in a slash.
- * - e.g. if `base` is `http://p.com/a/b/c` the path will be relative to `c` as if a `/` trailing slash was present.
- * - This is different to the default behaviour of `new URL()`, but is the more natural expected result
- * - This is consistent with our e.g. `getURL()` utilities.
- *
+ * Note: the base is normalised with `getBaseURL()`, so it is always treated as if it ends in a slash.
+ * - e.g. if `base` is `http://p.com/a/b/c` the path resolves relative to `c/` as if a trailing slash was present.
+ * - This differs from the default behaviour of `new URL()`, but is the more natural expected result.
  */
-export function getURL(target: Nullish<PossibleURL>, base?: PossibleURL): ImmutableURL | undefined {
-	if (!target) return;
-	const uri = _getURL(target, base);
-	if (uri && _isURL(uri)) return uri;
-}
-function _getURL(target: PossibleURL, base?: PossibleURL): URL | undefined {
-	if (target instanceof URL) return target;
+export function getBasedURI(input: Nullish<PossibleURL>, base?: PossibleURL): ImmutableURI | undefined {
+	if (!input) return;
+	if (input instanceof URL) return input as ImmutableURI;
 	try {
-		return new URL(target, getBaseURL(base));
+		return new URL(input, getBaseURL(base)) as ImmutableURI;
 	} catch {
 		//
 	}
+}
+
+/**
+ * Resolve a possible URL relative to a base URL, or return `undefined` if conversion fails.
+ * - Like `getBasedURI()` but only succeeds for true `scheme://host` URLs — other URIs (e.g. `mailto:`) return `undefined`.
+ */
+export function getURL(target: Nullish<PossibleURL>, base?: PossibleURL): ImmutableURL | undefined {
+	const uri = getBasedURI(target, base);
+	if (uri && _isURL(uri)) return uri;
 }
 
 /** Convert a possible URL to a URL, or throw `RequiredError` if conversion fails. */
@@ -159,7 +164,7 @@ function _isBaseURL(uri: URL): uri is BaseURL {
 /** Get a Base URL. */
 export function getBaseURL(input: Nullish<PossibleURL>): BaseURL | undefined {
 	if (!input) return;
-	const uri = _getURL(input, undefined);
+	const uri = getBasedURI(input, undefined);
 	if (!uri || !_isURL(uri)) return;
 	if (_isBaseURL(uri)) return uri;
 	const base: URL = typeof input === "string" ? uri : new URL(uri);

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -83,10 +83,7 @@ export function getURL(target: Nullish<PossibleURL>, base?: PossibleURL): Immuta
 function _getURL(target: PossibleURL, base?: PossibleURL): URL | undefined {
 	if (target instanceof URL) return target;
 	try {
-		// We need a base URL to potentially parse this URL against.
-		// Use the document base (if set) as the default URL.
-		const baseURL = getBaseURL(base ?? (typeof document === "object" ? document.baseURI : undefined));
-		return new URL(target, baseURL);
+		return new URL(target, getBaseURL(base));
 	} catch {
 		//
 	}


### PR DESCRIPTION
The docs site uses modules/ as its tree root, so modules/README.md
becomes its home page. Move the project overview, install snippet, and
module index there so the docs site has a proper landing page. Strip
the root README down to badges, a one-line description, a link to the
hosted docs, and the install snippet for npm consumers.