### PR TITLE
Fix docs site rendering under a sub-path

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,8 +35,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: install
         run: bun install
-      - name: build
+      # APP_URL must match where the build is actually served so links and assets resolve correctly.
+      - name: build (main)
+        if: github.event_name != 'pull_request'
         run: APP_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" bun run docs:build
+      # PR previews are served from the `pr-<number>/` sub-directory, so the build resolves against that.
+      - name: build (preview)
+        if: github.event_name == 'pull_request'
+        run: APP_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}" bun run docs:build
       - name: deploy (main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/render.tsx
+++ b/docs/render.tsx
@@ -33,7 +33,7 @@ export async function renderApp(root: TreeElement, outdir: AbsolutePath, stylesh
 			app={APP_TITLE}
 			description={APP_DESCRIPTION}
 			language={APP_LANGUAGE}
-			base={APP_URL}
+			root={APP_URL}
 			stylesheets={[stylesheet]}
 			tags={{ viewport: "width=device-width, initial-scale=1" }}
 		>
@@ -46,7 +46,8 @@ export async function renderApp(root: TreeElement, outdir: AbsolutePath, stylesh
 	const paths: AbsolutePath[] = Array.from(getElementPaths(root)).map(segments => joinPath("/", segments));
 
 	for (const path of paths) {
-		const html = `<!DOCTYPE html>${renderToString(<MetaContext value={{ url: requireURL(path, APP_URL), base: APP_URL }}>{app}</MetaContext>)}`;
+		// `path` is site-absolute (`/util`); the `.` prefix makes it resolve *under* `APP_URL`'s subfolder instead of its origin.
+		const html = `<!DOCTYPE html>${renderToString(<MetaContext value={{ url: requireURL(`.${path}`, APP_URL), root: APP_URL }}>{app}</MetaContext>)}`;
 		const filePath = path === "/" ? join(outdir, "index.html") : join(outdir, path.slice(1), "index.html");
 		await mkdir(dirname(filePath), { recursive: true });
 		await Bun.write(filePath, html);

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -1,12 +1,12 @@
 # api
 
-Typed, provider-based framework for HTTP API access. Define your routes as `Endpoint` definitions, then call them through a composable provider stack — the same pattern the [`db`](../db/README.md) module uses for databases.
+Typed, provider-based framework for HTTP API access. Define your routes as `Endpoint` definitions, then call them through a composable provider stack — the same pattern the [`db`](/db) module uses for databases.
 
 ## Concepts
 
 ### Endpoint
 
-An `Endpoint` is a declarative, typed description of a single API route. It captures the HTTP method, the URL path (with optional `{placeholder}` segments), a [schema](../schema/README.md) for the request payload, and a schema for the response. Think of it the way [`Collection`](../db/README.md) describes a database table — a shared definition both client and server reference.
+An `Endpoint` is a declarative, typed description of a single API route. It captures the HTTP method, the URL path (with optional `{placeholder}` segments), a [schema](/schema) for the request payload, and a schema for the response. Think of it the way [`Collection`](/db) describes a database table — a shared definition both client and server reference.
 
 Factory functions (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`) create endpoints concisely:
 
@@ -106,7 +106,7 @@ const user = await api.fetch(getUser, { id: "u_123" })
 
 ## React integration
 
-The [`react`](../react/README.md) module's `createAPIContext()` is the primary way to use a provider in a React app. It creates a context backed by an `APICache` and exposes typed hooks — `useEndpoint()`, `useProvider()` — that return reactive `EndpointStore` instances and suspend automatically while loading.
+The [`react`](/react) module's `createAPIContext()` is the primary way to use a provider in a React app. It creates a context backed by an `APICache` and exposes typed hooks — `useEndpoint()`, `useProvider()` — that return reactive `EndpointStore` instances and suspend automatically while loading.
 
 ```ts
 import { createAPIContext } from "shelving/react"
@@ -116,11 +116,11 @@ const provider = new ValidationAPIProvider(new APIProvider({ url: "https://api.e
 export const { APIContext, useEndpoint } = createAPIContext(provider)
 ```
 
-See the [`react`](../react/README.md) module for full usage.
+See the [`react`](/react) module for full usage.
 
 ## See also
 
-- [`schema`](../schema/README.md) — schemas for endpoint payload and result validation
-- [`db`](../db/README.md) — the parallel database provider module
-- [`store`](../store/README.md) — `Store` base class that `EndpointStore` extends
-- [`react`](../react/README.md) — `createAPIContext()` for React integration
+- [`schema`](/schema) — schemas for endpoint payload and result validation
+- [`db`](/db) — the parallel database provider module
+- [`store`](/store) — `Store` base class that `EndpointStore` extends
+- [`react`](/react) — `createAPIContext()` for React integration

--- a/modules/bun/README.md
+++ b/modules/bun/README.md
@@ -1,6 +1,6 @@
 # bun
 
-[DBProvider](../db/README.md) implementation for PostgreSQL using Bun's built-in `Bun.sql` API. No external database driver is required.
+[DBProvider](/db) implementation for PostgreSQL using Bun's built-in `Bun.sql` API. No external database driver is required.
 
 `BunPostgreSQLProvider` extends the shared `PostgreSQLProvider`, which handles SQL generation, filtering, sorting, pagination, JSONB nested key access, and partial updates. The Bun-specific layer provides the tagged-template SQL execution and wraps identifier quoting through Bun's native SQL engine for additional safety.
 

--- a/modules/cloudflare/README.md
+++ b/modules/cloudflare/README.md
@@ -1,6 +1,6 @@
 # cloudflare
 
-[DBProvider](../db/README.md) implementations for Cloudflare Workers. Two backends are available: Workers KV for simple key-value storage and D1 for relational SQL.
+[DBProvider](/db) implementations for Cloudflare Workers. Two backends are available: Workers KV for simple key-value storage and D1 for relational SQL.
 
 Both providers accept a binding object injected by the Cloudflare Workers runtime. Declare the binding in `wrangler.toml` and access it through the `env` parameter of your Worker's `fetch` handler.
 

--- a/modules/db/README.md
+++ b/modules/db/README.md
@@ -1,12 +1,12 @@
 # db
 
-Typed database provider abstraction. Define your schema once as a [`Collection`](../schema/README.md), then swap providers (in-memory, SQLite, Firestore, Cloudflare D1, …) without changing any call sites. Providers are composable wrappers — add validation, logging, or caching by stacking them in a chain.
+Typed database provider abstraction. Define your schema once as a [`Collection`](/schema), then swap providers (in-memory, SQLite, Firestore, Cloudflare D1, …) without changing any call sites. Providers are composable wrappers — add validation, logging, or caching by stacking them in a chain.
 
 ## Concepts
 
 ### Collection
 
-A `Collection` is a declarative description of a database table or collection. It extends [`DataSchema`](../schema/README.md) and carries three things: a string `name`, an `id` schema (the identifier type), and a data schema (the shape of each record).
+A `Collection` is a declarative description of a database table or collection. It extends [`DataSchema`](/schema) and carries three things: a string `name`, an `id` schema (the identifier type), and a data schema (the shape of each record).
 
 ```ts
 import { COLLECTION } from "shelving/db"
@@ -57,7 +57,7 @@ Providers are layered wrappers. Each takes a `source` and delegates to it, inter
 - **`ThroughDBProvider`** — identity wrapper; extend this to intercept only specific methods (e.g. `DebugDBProvider`).
 - **`SQLiteProvider`** / **`PostgreSQLProvider`** — SQL-backed abstract providers. Concrete subclasses bind them to a specific driver.
 
-Cloud providers live in the [`cloudflare`](../cloudflare/README.md) and [`firestore`](../firestore/README.md) sibling modules.
+Cloud providers live in the [`cloudflare`](/cloudflare) and [`firestore`](/firestore) sibling modules.
 
 ### Migrations
 
@@ -117,7 +117,7 @@ for await (const post of provider.getItemSequence(POSTS, id)) {
 
 ## React integration
 
-The [`react`](../react/README.md) module's `createDBContext()` is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — `useItem()`, `useQuery()`, `useProvider()` — that return reactive `Store` instances and suspend automatically while loading.
+The [`react`](/react) module's `createDBContext()` is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — `useItem()`, `useQuery()`, `useProvider()` — that return reactive `Store` instances and suspend automatically while loading.
 
 ```ts
 import { createDBContext } from "shelving/react"
@@ -127,12 +127,12 @@ const provider = new CacheDBProvider(new ValidationDBProvider(new MemoryDBProvid
 export const { DBContext, useItem, useQuery } = createDBContext(provider)
 ```
 
-See the [`react`](../react/README.md) module for full usage.
+See the [`react`](/react) module for full usage.
 
 ## See also
 
-- [`schema`](../schema/README.md) — `DataSchema` that `Collection` extends
-- [`store`](../store/README.md) — `Store` base class used by `ItemStore` and `QueryStore`
-- [`react`](../react/README.md) — `createDBContext()` for React integration
-- [`cloudflare`](../cloudflare/README.md) — Cloudflare KV and D1 providers
-- [`firestore`](../firestore/README.md) — Firestore providers
+- [`schema`](/schema) — `DataSchema` that `Collection` extends
+- [`store`](/store) — `Store` base class used by `ItemStore` and `QueryStore`
+- [`react`](/react) — `createDBContext()` for React integration
+- [`cloudflare`](/cloudflare) — Cloudflare KV and D1 providers
+- [`firestore`](/firestore) — Firestore providers

--- a/modules/error/README.md
+++ b/modules/error/README.md
@@ -121,5 +121,5 @@ try {
 
 ## See also
 
-- [schema](../schema/README.md) — schema validation (throws plain strings, not Error instances)
-- [util](../util/README.md) — `require*()` functions that throw `RequiredError`
+- [schema](/schema) — schema validation (throws plain strings, not Error instances)
+- [util](/util) — `require*()` functions that throw `RequiredError`

--- a/modules/firestore/README.md
+++ b/modules/firestore/README.md
@@ -1,6 +1,6 @@
 # firestore
 
-[DBProvider](../db/README.md) implementations for Google Firestore. Three variants are available, each targeting a different SDK and runtime context. Choose the one that matches where your code runs.
+[DBProvider](/db) implementations for Google Firestore. Three variants are available, each targeting a different SDK and runtime context. Choose the one that matches where your code runs.
 
 | Provider | SDK | Realtime | Bundle size |
 |---|---|---|---|

--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -51,7 +51,7 @@ const node = renderMarkup(content, {
 });
 ```
 
-Link href resolution goes through [`getLink`](../util/README.md) — site-absolute paths resolve against `root`, relative refs resolve against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
+Link href resolution goes through [`getLink`](/util) — site-absolute paths resolve against `root`, relative refs resolve against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
 
 ### Block-only or inline-only rendering
 
@@ -92,5 +92,5 @@ const node = renderMarkup(content, {
 
 ## See also
 
-- [error](../error/README.md) — error classes used elsewhere in shelving
-- [util](../util/README.md) — shared utilities including JSX types and regexp helpers
+- [error](/error) — error classes used elsewhere in shelving
+- [util](/util) — shared utilities including JSX types and regexp helpers

--- a/modules/markup/rule/link.ts
+++ b/modules/markup/rule/link.ts
@@ -17,9 +17,9 @@ function renderLinkMarkupRule(
 	key: string,
 ): Element {
 	const { url, root, schemes = HTTP_SCHEMES, rel } = options;
-	const resolved = getLink(unsafeHref, url, root);
-	const href = resolved && schemes.some(s => resolved.startsWith(s)) ? resolved : undefined;
-	const children = title ? renderMarkup(title, options, "link") : resolved ? formatURI(resolved) : "";
+	const link = getLink(unsafeHref, url, root);
+	const href = link && schemes.includes(link.protocol) ? link?.href : undefined;
+	const children = title ? renderMarkup(title, options, "link") : link ? formatURI(link) : "";
 	return {
 		key,
 		$$typeof: REACT_ELEMENT_TYPE,

--- a/modules/react/README.md
+++ b/modules/react/README.md
@@ -1,6 +1,6 @@
 # react
 
-React hooks and context helpers for integrating Shelving [stores](../store/README.md), async sequences, and API/DB providers into React components. The module is built on `useSyncExternalStore` and standard React patterns — no magic, no global state.
+React hooks and context helpers for integrating Shelving [stores](/store), async sequences, and API/DB providers into React components. The module is built on `useSyncExternalStore` and standard React patterns — no magic, no global state.
 
 ## Concepts
 
@@ -147,6 +147,6 @@ const stable = useReduce((prev, next) => {
 
 ## See also
 
-- [store](../store/README.md) — the `Store` class that `useStore` subscribes to
-- [api](../api/README.md) — `APIProvider`, `APICache`, and `EndpointStore`
-- [db](../db/README.md) — `DBProvider`, `DBCache`, `ItemStore`, and `QueryStore`
+- [store](/store) — the `Store` class that `useStore` subscribes to
+- [api](/api) — `APIProvider`, `APICache`, and `EndpointStore`
+- [db](/db) — `DBProvider`, `DBCache`, `ItemStore`, and `QueryStore`

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -157,7 +157,7 @@ NUMBERS.validate(undefined);      // []
 
 ### Item schemas
 
-`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the `Item` type in [util](../util/README.md).
+`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the `Item` type in [util](/util).
 
 ```ts
 import { ITEM, STRING, INTEGER, NUMBER } from "shelving/schema";
@@ -199,5 +199,5 @@ PARTIAL_PRODUCT.validate({ price: 4.99 }); // { price: 4.99 }
 
 ## See also
 
-- [util](../util/README.md) — `Data`, `Item`, query, and update types consumed by schemas.
-- [db](../db/README.md) — `Collection` extends `DataSchema` and uses schemas to validate stored documents.
+- [util](/util) — `Data`, `Item`, query, and update types consumed by schemas.
+- [db](/db) — `Collection` extends `DataSchema` and uses schemas to validate stored documents.

--- a/modules/sequence/README.md
+++ b/modules/sequence/README.md
@@ -12,7 +12,7 @@ Async-iterator primitives used throughout the shelving library. A "sequence" is 
 
 **ThroughSequence** and **IteratorSequence** are thin adapters for piping values between sequences.
 
-Most application code interacts with sequences indirectly via [`Store`](../store/README.md), which uses `DeferredSequence` internally. Use the sequence primitives directly only when building new reactive data sources.
+Most application code interacts with sequences indirectly via [`Store`](/store), which uses `DeferredSequence` internally. Use the sequence primitives directly only when building new reactive data sources.
 
 ## Usage
 
@@ -59,5 +59,5 @@ const next = await seq; // waits for the next resolve()
 
 ## See also
 
-- [`Store`](../store/README.md) — observable value container built on `DeferredSequence`
-- [`DB`](../db/README.md) — database providers that expose `AsyncIterable` via `getItemSequence` / `getQuerySequence`
+- [`Store`](/store) — observable value container built on `DeferredSequence`
+- [`DB`](/db) — database providers that expose `AsyncIterable` via `getItemSequence` / `getQuerySequence`

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -8,7 +8,7 @@ Observable value containers for reactive state. A `Store<T>` holds a single curr
 
 **Error state** — setting `store.reason` puts the store in an error state. Subsequent reads of `store.value` throw that reason, which React error boundaries can catch.
 
-**Async iteration** — `Store<T>` implements `AsyncIterable<T>`. Iterating with `for await...of` first emits the current value (if one exists), then emits each subsequent value as it changes. The iterator blocks between values using the store's internal [`DeferredSequence`](../sequence/README.md).
+**Async iteration** — `Store<T>` implements `AsyncIterable<T>`. Iterating with `for await...of` first emits the current value (if one exists), then emits each subsequent value as it changes. The iterator blocks between values using the store's internal [`DeferredSequence`](/sequence).
 
 **Duplicate suppression** — deep equality is checked before emitting. Setting the same value twice only triggers one emission.
 
@@ -23,7 +23,7 @@ Observable value containers for reactive state. A `Store<T>` holds a single curr
 | `ArrayStore<T>` | Stores an array; adds `.first`, `.last`, `.count`, `.add()`, `.delete()`, `.toggle()`. |
 | `BooleanStore` | Stores a boolean; adds `.toggle()`. |
 
-`ItemStore` and `QueryStore` in the [`db`](../db/README.md) module extend `OptionalDataStore` and `ArrayStore` respectively, adding database-aware refresh and subscription logic.
+`ItemStore` and `QueryStore` in the [`db`](/db) module extend `OptionalDataStore` and `ArrayStore` respectively, adding database-aware refresh and subscription logic.
 
 ## Usage
 
@@ -90,5 +90,5 @@ async function connect(stream: AsyncIterable<number>) {
 
 ## See also
 
-- [`sequence`](../sequence/README.md) — `DeferredSequence` that powers the store's async iteration
-- [`db`](../db/README.md) — `ItemStore` and `QueryStore` extend `Store` for database-backed reactive state
+- [`sequence`](/sequence) — `DeferredSequence` that powers the store's async iteration
+- [`db`](/db) — `ItemStore` and `QueryStore` extend `Store` for database-backed reactive state

--- a/modules/ui/block/Card.tsx
+++ b/modules/ui/block/Card.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
-import { type ClickableProps, getClickable } from "../form/Clickable.js";
+import { Clickable, type ClickableProps } from "../form/Clickable.js";
 import { getModuleClass } from "../util/css.js";
-import styles from "./Card.module.css";
+import CARD_CSS from "./Card.module.css";
 
 export interface CardProps extends ClickableProps {
 	children?: ReactNode;
@@ -21,11 +21,10 @@ export interface CardProps extends ClickableProps {
  * @example <Card><Heading>Static</Heading></Card>
  * @example <Card href="/foo" title="Open foo"><Heading>Clickable</Heading></Card>
  */
-export function Card({ children, disabled, href, onClick, title, target, download, ...variants }: CardProps): ReactElement {
-	const overlay =
-		href || onClick ? getClickable({ disabled, href, onClick, title, target, download, children: title ?? "Open" }, styles.overlay) : null;
+export function Card({ children, href, onClick, title = "Open", ...props }: CardProps): ReactElement {
+	const overlay = (href || onClick) && <Clickable title={title} href={href} onClick={onClick} {...props} className={CARD_CSS.overlay} />;
 	return (
-		<article className={getModuleClass(styles, "card", variants)}>
+		<article className={getModuleClass(CARD_CSS, "card", props)}>
 			{overlay}
 			{overlay ? <div>{children}</div> : children}
 		</article>

--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,16 +1,12 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
-import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
-import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
 import { TreeCards } from "../tree/TreeCards.js";
 
 /** Page renderer for a `tree-directory` element — shows title, content, and child cards. */
 export function DirectoryPage({ title, name, description, content, children }: DirectoryElementProps): ReactNode {
-	const { url } = requireMeta();
-	const path = (url?.pathname ?? "/") as AbsolutePath;
 	return (
 		<Page title={title ?? name} description={description}>
 			{content && (
@@ -18,7 +14,7 @@ export function DirectoryPage({ title, name, description, content, children }: D
 					<Markup>{content}</Markup>
 				</Prose>
 			)}
-			<TreeCards path={path}>{children}</TreeCards>
+			<TreeCards>{children}</TreeCards>
 		</Page>
 	);
 }

--- a/modules/ui/form/ArrayInput.tsx
+++ b/modules/ui/form/ArrayInput.tsx
@@ -6,7 +6,8 @@ import { splitMessage } from "../../util/error.js";
 import { formatUnit } from "../../util/format.js";
 import { Flex } from "../block/Flex.js";
 import { Button } from "./Button.js";
-import { Input, type ValueInputProps } from "./Input.js";
+import { ButtonInput } from "./ButtonInput.js";
+import type { ValueInputProps } from "./Input.js";
 import { SchemaInput } from "./SchemaInput.js";
 
 export interface ArrayInputProps<T> extends ValueInputProps<ImmutableArray<T>> {
@@ -64,9 +65,9 @@ export function ArrayInput({
 					);
 				})
 			) : (
-				<Input onClick={addNewItem} name={name} required={required && min > 1} disabled={disabled}>
+				<ButtonInput onClick={addNewItem} name={name} required={required && min > 1} disabled={disabled}>
 					{placeholder}
-				</Input>
+				</ButtonInput>
 			)}
 			<Flex>
 				<Button //

--- a/modules/ui/form/Button.tsx
+++ b/modules/ui/form/Button.tsx
@@ -4,7 +4,7 @@ import { type ColorVariants, getColorClass } from "../misc/Color.js";
 import { getStatusClass, type StatusVariants } from "../misc/Status.js";
 import { type Classes, getClass, getModuleClass } from "../util/css.js";
 import BUTTON_CSS from "./Button.module.css";
-import { type ClickableProps, getClickable } from "./Clickable.js";
+import { Clickable, type ClickableProps } from "./Clickable.js";
 
 /** Variants for buttons. */
 export interface ButtonVariants extends FlexVariants, StatusVariants, ColorVariants {
@@ -23,19 +23,8 @@ export interface ButtonVariants extends FlexVariants, StatusVariants, ColorVaria
 interface ButtonProps extends ButtonVariants, ClickableProps {}
 
 /** Return either a `<button>` or an `<a href="">` styled as an button, based on whether an `onClick` or `href` prop is provided. */
-export function Button({ disabled, href, onClick, title, target, download, children, ...variants }: ButtonProps): ReactElement {
-	return getClickable(
-		{
-			disabled,
-			href,
-			onClick,
-			title,
-			target,
-			download,
-			children,
-		},
-		getButtonClass(variants),
-	);
+export function Button(props: ButtonProps): ReactElement {
+	return <Clickable {...props} className={getButtonClass(props)} />;
 }
 
 /** Get the full className for a button. */

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -1,33 +1,16 @@
 import type { ReactElement } from "react";
 import { notNullish } from "../../util/null.js";
-import { type ClickableProps, getClickable } from "./Clickable.js";
-import { ELEMENTS_BUTTON_INPUT_CLASS, type InputProps, PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS } from "./Input.js";
+import { Clickable, type ClickableProps } from "./Clickable.js";
+import { FLEX_BUTTON_INPUT_CLASS, type InputProps, PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS } from "./Input.js";
 
 export interface ButtonInputProps extends InputProps, ClickableProps {}
 
 /** Return either a `<button>` or an `<a href="">` styled as an input, based on whether an `onClick` or `href` prop is provided. */
-export function ButtonInput({
-	// name,
-	title,
-	placeholder,
-	disabled,
-	href,
-	onClick,
-	target,
-	// message = "",
-	download,
-	children = title,
-}: ButtonInputProps): ReactElement {
+export function ButtonInput({ title, placeholder, children = title, ...props }: ButtonInputProps): ReactElement {
 	const hasChildren = notNullish(children);
-	return getClickable(
-		{
-			disabled,
-			href,
-			onClick,
-			target,
-			download,
-			children: hasChildren ? children : placeholder,
-		},
-		hasChildren ? ELEMENTS_BUTTON_INPUT_CLASS : PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS,
+	return (
+		<Clickable {...props} className={hasChildren ? FLEX_BUTTON_INPUT_CLASS : PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS}>
+			{hasChildren ? children : placeholder}
+		</Clickable>
 	);
 }

--- a/modules/ui/form/CheckboxInput.tsx
+++ b/modules/ui/form/CheckboxInput.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { notNullish } from "../../util/null.js";
-import { CHECKBOX_CLASS, ELEMENTS_LABEL_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { CHECKBOX_CLASS, FLEX_LABEL_INPUT_CLASS, type ValueInputProps } from "./Input.js";
 
 export interface CheckboxProps extends ValueInputProps<boolean> {
 	children?: ReactNode | undefined;
@@ -20,7 +20,7 @@ export function CheckboxInput({
 }: CheckboxProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={ELEMENTS_LABEL_INPUT_CLASS} aria-invalid={!!message}>
+		<label className={FLEX_LABEL_INPUT_CLASS} aria-invalid={!!message}>
 			<input
 				name={name}
 				type="checkbox"

--- a/modules/ui/form/Clickable.tsx
+++ b/modules/ui/form/Clickable.tsx
@@ -2,9 +2,12 @@ import type { MouseEvent, ReactElement, ReactNode } from "react";
 import { useInstance } from "../../react/useInstance.js";
 import { useStore } from "../../react/useStore.js";
 import { BusyStore } from "../../store/BusyStore.js";
+import { isURLActive } from "../../util/index.js";
+import { getLink } from "../../util/link.js";
 import type { Path } from "../../util/path.js";
-import { type ImmutableURI, isURI, type URIString } from "../../util/uri.js";
+import type { ImmutableURI, URIString } from "../../util/uri.js";
 import { LOADING } from "../misc/Loading.js";
+import { requireMeta } from "../misc/MetaContext.js";
 import { callNotifiedElement } from "../util/notice.js";
 
 /***
@@ -32,13 +35,17 @@ export interface ClickableProps {
 	children?: ReactNode | undefined;
 }
 
+export interface StylableClickableProps extends ClickableProps {
+	className?: string | undefined;
+}
+
 /** Return either a `<button>` or an `<a href="">` based on whether an `onClick` or `href` prop is provided. */
-export function getClickable(props: ClickableProps, className?: string): ReactElement {
-	return props.href ? <LinkClickable {...props} className={className} /> : <ButtonClickable {...props} className={className} />;
+export function Clickable(props: StylableClickableProps): ReactElement {
+	return props.href ? <LinkClickable {...props} /> : <ButtonClickable {...props} />;
 }
 
 /** Return an `<a href="">` element. */
-function LinkClickable({
+export function LinkClickable({
 	disabled = false,
 	href,
 	title,
@@ -46,23 +53,20 @@ function LinkClickable({
 	download,
 	children = "Go",
 	className,
-}: ClickableProps & { className: string | undefined }): ReactElement {
-	const link: string | undefined = disabled ? undefined : isURI(href) ? href.href : href;
+}: StylableClickableProps): ReactElement {
+	// Resolve `href` against the current page URL and site root so site-absolute paths (`/foo`) honour the base subfolder.
+	const { url, root } = requireMeta();
+	const link = disabled ? undefined : getLink(href, url, root);
+	const active = isURLActive(link, url);
 	return (
-		<a href={link} title={title} download={download} target={target} className={className}>
+		<a href={link?.href} title={title} download={download} target={target} className={className} aria-current={active ? "page" : undefined}>
 			{children}
 		</a>
 	);
 }
 
 /** Return a `<button>` element. */
-function ButtonClickable({
-	disabled = false,
-	onClick,
-	title,
-	children = "Click",
-	className,
-}: ClickableProps & { className: string | undefined }): ReactElement {
+export function ButtonClickable({ disabled = false, onClick, title, children = "Click", className }: StylableClickableProps): ReactElement {
 	// Create a `BusyStore<undefined>` to keep track of the `onClick` call and any thrown errors.
 	const store = useInstance(BusyStore, undefined);
 

--- a/modules/ui/form/DictionaryInput.tsx
+++ b/modules/ui/form/DictionaryInput.tsx
@@ -8,7 +8,8 @@ import { formatUnit } from "../../util/format.js";
 import { omitProp } from "../../util/object.js";
 import { Flex } from "../block/Flex.js";
 import { Button } from "./Button.js";
-import { Input, type ValueInputProps } from "./Input.js";
+import { ButtonInput } from "./ButtonInput.js";
+import type { ValueInputProps } from "./Input.js";
 import { SchemaInput } from "./SchemaInput.js";
 import { TextInput } from "./TextInput.js";
 
@@ -80,9 +81,9 @@ export function DictionaryInput({
 					);
 				})
 			) : (
-				<Input onClick={addNewItem} name={name} required={required && min > 1} disabled={disabled}>
+				<ButtonInput onClick={addNewItem} name={name} required={required && min > 1} disabled={disabled}>
 					{placeholder}
-				</Input>
+				</ButtonInput>
 			)}
 			<Flex>
 				<Button //

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -2,7 +2,6 @@ import type { ReactElement, ReactNode } from "react";
 import { FLEX_CSS } from "../block/Flex.js";
 import { LOADING } from "../misc/Loading.js";
 import { getClass } from "../util/css.js";
-import { type ClickableProps, getClickable } from "./Clickable.js";
 import INPUT_CSS from "./Input.module.css";
 
 // Precomposed classes.
@@ -15,11 +14,11 @@ export const MULTILINE_TEXT_INPUT_CLASS = getClass(TEXT_INPUT_CLASS, INPUT_CSS.m
 export const SELECT_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.select);
 export const EMPTY_OPTION_INPUT_CLASS = INPUT_CSS.empty;
 export const VALUE_OPTION_INPUT_CLASS = INPUT_CSS.value;
-export const ELEMENTS_INPUT_CLASS = getClass(INPUT_CSS.input, FLEX_CSS.elements, FLEX_CSS.center);
-export const ELEMENTS_BUTTON_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.button, FLEX_CSS.elements, FLEX_CSS.center);
-export const PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS = getClass(ELEMENTS_BUTTON_INPUT_CLASS, INPUT_CSS.placeholder);
-export const ELEMENTS_LABEL_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.label, FLEX_CSS.elements, FLEX_CSS.left);
-export const PLACEHOLDER_ELEMENTS_LABEL_INPUT_CLASS = getClass(ELEMENTS_LABEL_INPUT_CLASS, INPUT_CSS.placeholder);
+export const FLEX_INPUT_CLASS = getClass(INPUT_CSS.input, FLEX_CSS.elements, FLEX_CSS.center);
+export const FLEX_BUTTON_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.button, FLEX_CSS.elements, FLEX_CSS.center);
+export const PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS = getClass(FLEX_BUTTON_INPUT_CLASS, INPUT_CSS.placeholder);
+export const FLEX_LABEL_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.label, FLEX_CSS.elements, FLEX_CSS.left);
+export const PLACEHOLDER_FLEX_LABEL_INPUT_CLASS = getClass(FLEX_LABEL_INPUT_CLASS, INPUT_CSS.placeholder);
 export const WRAPPER_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.wrapper);
 
 /** Props all inputs allow. */
@@ -46,36 +45,13 @@ export interface ValueInputProps<O, I = never> extends InputProps {
 	onValue(value: O | undefined): void;
 }
 
-/** Return either a `<button>` or an `<a href="">` styled as an input, based on whether an `onClick` or `href` prop is provided. */
-export function Input({
-	// name,
-	title,
-	placeholder = title,
-	// message,
-	disabled,
-	href,
-	onClick,
-	target,
-	download,
-	children,
-}: InputProps & ClickableProps): ReactElement {
-	return getClickable(
-		{
-			disabled,
-			href,
-			onClick,
-			target,
-			download,
-			children: children || placeholder,
-		},
-		getClass(INPUT_CSS.input, INPUT_CSS.button, children ? undefined : INPUT_CSS.placeholder),
-	);
-}
-
 /** Input that is loading. */
-export const LOADING_INPUT = <div className={ELEMENTS_INPUT_CLASS}>{LOADING}</div>;
+export const LOADING_INPUT = <div className={FLEX_INPUT_CLASS}>{LOADING}</div>;
 
-/** Wraps an input with support for absolutely-positioned `data-slot` icon elements on either side. */
+/**
+ * Wraps an input with support for absolutely-positioned `data-slot` icon elements on either side.
+ * - This is so you can put an icon before or after an input.
+ */
 export function InputWrapper({ children }: { children: ReactNode }): ReactElement {
 	return <div className={WRAPPER_INPUT_CLASS}>{children}</div>;
 }

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement, ReactNode } from "react";
+import { notNullish } from "../../util/index.js";
+import { FLEX_BUTTON_INPUT_CLASS, type InputProps, PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS } from "./Input.js";
+
+export interface OutputInputProps extends InputProps {
+	children?: ReactNode;
+}
+
+/** Return static "output" styled as an input, based on whether an `onClick` or `href` prop is provided. */
+export function OutputInput({ title, placeholder, children = title, ...props }: OutputInputProps): ReactElement {
+	const hasChildren = notNullish(children);
+	return (
+		<output {...props} className={hasChildren ? FLEX_BUTTON_INPUT_CLASS : PLACEHOLDER_ELEMENTS_BUTTON_INPUT_CLASS}>
+			{hasChildren ? children : placeholder}
+		</output>
+	);
+}

--- a/modules/ui/form/RadioInput.tsx
+++ b/modules/ui/form/RadioInput.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { notNullish } from "../../util/null.js";
-import { ELEMENTS_LABEL_INPUT_CLASS, PLACEHOLDER_ELEMENTS_LABEL_INPUT_CLASS, RADIO_CLASS, type ValueInputProps } from "./Input.js";
+import { FLEX_LABEL_INPUT_CLASS, PLACEHOLDER_FLEX_LABEL_INPUT_CLASS, RADIO_CLASS, type ValueInputProps } from "./Input.js";
 
 export interface RadioInputProps extends ValueInputProps<boolean> {
 	children?: ReactNode | undefined;
@@ -20,7 +20,7 @@ export function RadioInput({
 }: RadioInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={hasChildren ? ELEMENTS_LABEL_INPUT_CLASS : PLACEHOLDER_ELEMENTS_LABEL_INPUT_CLASS}>
+		<label className={hasChildren ? FLEX_LABEL_INPUT_CLASS : PLACEHOLDER_FLEX_LABEL_INPUT_CLASS}>
 			<input
 				className={RADIO_CLASS}
 				type="radio"

--- a/modules/ui/form/index.ts
+++ b/modules/ui/form/index.ts
@@ -23,6 +23,7 @@ export * from "./FormNotify.js";
 export * from "./FormStore.js";
 export * from "./Input.js";
 export * from "./NumberInput.js";
+export * from "./OutputInput.js";
 export * from "./Popover.js";
 export * from "./Progress.js";
 export * from "./QueryInput.js";

--- a/modules/ui/inline/Link.tsx
+++ b/modules/ui/inline/Link.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement } from "react";
-import { type ClickableProps, getClickable } from "../form/Clickable.js";
+import { Clickable, type ClickableProps } from "../form/Clickable.js";
 import styles from "./Link.module.css";
 
 export interface LinkProps extends ClickableProps {}
 
 export function Link(props: LinkProps): ReactElement {
-	return getClickable(props, styles.link);
+	return <Clickable {...props} className={styles.link} />;
 }

--- a/modules/ui/menu/MenuItem.tsx
+++ b/modules/ui/menu/MenuItem.tsx
@@ -1,17 +1,16 @@
 import type { ReactNode } from "react";
-import { type AbsolutePath, isPathActive, isPathProud } from "../../util/path.js";
+import { getLink, isArray, isURLProud } from "../../util/index.js";
+import { Clickable, type ClickableProps } from "../form/Clickable.js";
 import { requireMeta } from "../misc/MetaContext.js";
 import { getModuleClass } from "../util/css.js";
 import MENU_CSS from "./Menu.module.css";
 
-export interface MenuItemProps {
-	/** Link target — rendered as the `<a>`'s `href`. */
-	readonly href?: AbsolutePath | undefined;
+export interface MenuItemProps extends ClickableProps {
 	/**
 	 * The first child becomes the link label (rendered inside the `<a>`).
 	 * - Any additional children form the submenu — only rendered when this item is "proud" (an ancestor of the current page). The caller is responsible for wrapping the submenu in a nested `<Menu>` if it wants the CSS `.menu .menu` descendant rules to apply.
 	 */
-	readonly children?: ReactNode;
+	readonly children: ReactNode | [ReactNode, ...ReactNode[]];
 }
 
 /**
@@ -19,18 +18,16 @@ export interface MenuItemProps {
  * - Reads the current page URL from `<Meta>` and computes `active` / `proud` against its own `href`.
  * - Splits `children` into `[label, ...after]`: label goes inside the `<a>`; `after` is rendered as siblings below it, only when proud.
  */
-export function MenuItem({ href, children }: MenuItemProps): ReactNode {
-	const { url } = requireMeta();
-	const current = url?.pathname;
-	const active = !!href && !!current && isPathActive(current, href);
-	const proud = !!href && !!current && isPathProud(current, href);
-	const list = Array.isArray(children) ? children : [children];
-	const [label, ...after] = list;
+export function MenuItem({ href, children, ...props }: MenuItemProps): ReactNode {
+	const { url, root } = requireMeta();
+	const link = getLink(href, url, root);
+	const proud = isURLProud(url, link);
+	const [label, ...after] = isArray(children) ? children : [children];
 	return (
 		<li className={getModuleClass(MENU_CSS, "item", { proud })}>
-			<a className={getModuleClass(MENU_CSS, "link")} href={href} aria-current={active ? "page" : undefined}>
+			<Clickable href={href} {...props} className={getModuleClass(MENU_CSS, "link")}>
 				{label}
-			</a>
+			</Clickable>
 			{proud && after}
 		</li>
 	);

--- a/modules/ui/misc/Color.tsx
+++ b/modules/ui/misc/Color.tsx
@@ -2,7 +2,7 @@ import { getModuleClass } from "../util/css.js";
 import COLOR_CSS from "./Color.module.css";
 
 /** Variants for raw colours — pure hue overrides independent of semantic status. */
-export type ColorVariants = {
+export interface ColorVariants {
 	/** Element has primary colors. */
 	primary?: boolean | undefined;
 	/** Element has secondary colors. */
@@ -27,7 +27,7 @@ export type ColorVariants = {
 	purple?: boolean | undefined;
 	/** Element has pink colours. */
 	pink?: boolean | undefined;
-};
+}
 
 /** Possible colour strings. */
 export type Color = keyof ColorVariants;

--- a/modules/ui/misc/Markup.tsx
+++ b/modules/ui/misc/Markup.tsx
@@ -2,8 +2,9 @@ import type { ReactNode } from "react";
 import { renderMarkup } from "../../markup/render.js";
 import { MARKUP_OPTIONS } from "../../markup/rule/index.js";
 import type { MarkupOptions } from "../../markup/util/options.js";
+import { requireMeta } from "./MetaContext.js";
 
-/** Props for `<Markup>` — extends `MarkupOptions` so callers can override `rules`, `rel`, `base`, or `schemes` directly. */
+/** Props for `<Markup>` — extends `MarkupOptions` so callers can override `rules`, `rel`, `url`, `root`, or `schemes` directly. */
 export interface MarkupProps extends Partial<MarkupOptions> {
 	/** The source string to parse and render. */
 	children?: string | undefined;
@@ -11,13 +12,16 @@ export interface MarkupProps extends Partial<MarkupOptions> {
 
 /**
  * Parse a markup string and render the resulting elements inline.
- * - Defaults to `MARKUP_OPTIONS` (full block + inline rule set). Pass `rules`, `rel`, `base`, or `schemes` as props to override.
+ * - Defaults to `MARKUP_OPTIONS` (full block + inline rule set). Pass `rules`, `rel`, `url`, `root`, or `schemes` as props to override.
+ * - `url`/`root` default to the current `<Meta>` context so link rules resolve site-absolute and relative hrefs.
  * - Renders inside whatever ancestor element the caller provides — wrap in `<Prose>` to get the standard prose typography for the produced `<p>` / `<ul>` / `<pre>` / etc.
  *
  * @example <Prose><Markup>{`A *bold* word with \`code\`.`}</Markup></Prose>
  */
 export function Markup({ children, ...overrides }: MarkupProps): ReactNode {
 	if (!children) return null;
-	const options: MarkupOptions = { ...MARKUP_OPTIONS, ...overrides };
+	// Thread the current page URL + site root from `<Meta>` so link rules can resolve site-absolute and relative hrefs.
+	const { url, root: base } = requireMeta();
+	const options: MarkupOptions = { ...MARKUP_OPTIONS, url, root: base, ...overrides };
 	return renderMarkup(children, options);
 }

--- a/modules/ui/misc/Status.tsx
+++ b/modules/ui/misc/Status.tsx
@@ -2,7 +2,7 @@ import { getModuleClass } from "../util/css.js";
 import STATUS_CSS from "./Status.module.css";
 
 /** Variants for statuses. */
-export type StatusVariants = {
+export interface StatusVariants {
 	/** Element has loading status. */
 	loading?: boolean | undefined;
 	/** Element has info status. */
@@ -15,7 +15,7 @@ export type StatusVariants = {
 	warning?: boolean | undefined;
 	/** Element has success status. */
 	success?: boolean | undefined;
-};
+}
 
 /** Possible status strings. */
 export type Status = keyof StatusVariants;

--- a/modules/ui/misc/Tag.tsx
+++ b/modules/ui/misc/Tag.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from "react";
-import { type ClickableProps, getClickable } from "../form/Clickable.js";
+import { Clickable, type ClickableProps } from "../form/Clickable.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import { type ColorVariants, getColorClass } from "./Color.js";
 import { getStatusClass, type StatusVariants } from "./Status.js";
@@ -23,16 +23,15 @@ export interface TagProps extends TagVariants, ClickableProps {
  * @example <Tag success>Active</Tag>
  * @example <Tag purple href="/beta">Beta</Tag>
  */
-export function Tag({ disabled, href, onClick, title, target, download, children, ...variants }: TagProps): ReactElement {
-	return getClickable(
-		{ disabled, href, onClick, title, target, download, children },
-		getClass(
-			TAG_CSS.tag, //
-			getModuleClass(TAG_CSS, variants),
-			getStatusClass(variants),
-			getColorClass(variants),
-		),
-	);
+export function Tag(props: TagProps): ReactElement {
+	return <Clickable {...props} className={getTagClass(props)} />;
 }
 
-export { TAG_CSS };
+export function getTagClass(variants: TagVariants): string {
+	return getClass(
+		TAG_CSS.tag, //
+		getModuleClass(TAG_CSS, variants),
+		getStatusClass(variants),
+		getColorClass(variants),
+	);
+}

--- a/modules/ui/page/HTML.tsx
+++ b/modules/ui/page/HTML.tsx
@@ -12,7 +12,7 @@ export interface HTMLProps extends PossibleMeta {
  */
 export function HTML({ children, ...meta }: HTMLProps): ReactElement {
 	const merged = requireMeta(meta);
-	const { language, base, app } = merged;
+	const { language, root: base, app } = merged;
 	return (
 		<html lang={language}>
 			<head>

--- a/modules/ui/page/Head.tsx
+++ b/modules/ui/page/Head.tsx
@@ -1,6 +1,5 @@
 import { type ReactElement, useEffect } from "react";
 import type { ArrayItem } from "../../util/array.js";
-import { isNullish, notNullish } from "../../util/null.js";
 import { getProps, type Prop } from "../../util/object.js";
 import { requireMeta } from "../misc/MetaContext.js";
 import { joinTitles, type MetaAssets, type MetaLinks, type MetaTags } from "../util/meta.js";
@@ -38,31 +37,26 @@ export function Head(): ReactElement {
 }
 
 function _renderTag([k, x]: Prop<MetaTags>): ReactElement | null {
-	if (notNullish(x)) {
-		const y = x === true ? "yes" : x === false ? "no" : x;
-		if (k.startsWith("og:")) return <meta key={k} property={k} content={y} />; // Tags that start with `og:` use `property=""`
-		if (k.match(R_HTTP_EQUIV)) return <meta key={k} httpEquiv={k} content={y} />; // Tags that are in `Snake-Case` use `http-equiv=""`
-		return <meta key={k} name={k} content={y} />; // All other tags use `content=""`
-	}
-	return null;
+	if (x === null || x === undefined) return null;
+	const y = x === true ? "yes" : x === false ? "no" : x;
+	if (k.startsWith("og:")) return <meta key={k} property={k} content={y} />; // Tags that start with `og:` use `property=""`
+	if (k.match(R_HTTP_EQUIV)) return <meta key={k} httpEquiv={k} content={y} />; // Tags that are in `Snake-Case` use `http-equiv=""`
+	return <meta key={k} name={k} content={y} />; // All other tags use `content=""`
 }
 
-function _renderLink([k, v]: Prop<MetaLinks>): ReactElement | null {
-	if (notNullish(v)) {
-		const type = k.endsWith("icon") ? "image/x-icon" : "text/css";
-		return <link key={k} rel={k} href={v} type={type} />;
-	}
-	return null;
+function _renderLink([k, { href }]: Prop<MetaLinks>): ReactElement | null {
+	const type = k.endsWith("icon") ? "image/x-icon" : "text/css";
+	return <link key={k} rel={k} href={href} type={type} />;
 }
 
-function _renderStylesheet(v: ArrayItem<MetaAssets>): ReactElement | null {
-	return isNullish(v) ? null : <link key={v} rel="stylesheet" type="text/css" href={v} precedence="default" />;
+function _renderStylesheet({ href }: ArrayItem<MetaAssets>): ReactElement | null {
+	return <link key={href} rel="stylesheet" type="text/css" href={href} precedence="default" />;
 }
 
-function _renderModule(v: ArrayItem<MetaAssets>): ReactElement | null {
-	return isNullish(v) ? null : <script key={v} type="module" src={v} async={true} />;
+function _renderModule({ href }: ArrayItem<MetaAssets>): ReactElement | null {
+	return <script key={href} type="module" src={href} async={true} />;
 }
 
-function _renderScript(v: ArrayItem<MetaAssets>): ReactElement | null {
-	return isNullish(v) ? null : <script key={v} type="text/javascript" src={v} async={true} />;
+function _renderScript({ href }: ArrayItem<MetaAssets>): ReactElement | null {
+	return <script key={href} type="text/javascript" src={href} async={true} />;
 }

--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -22,7 +22,7 @@ export interface NavigationProps extends PossibleMeta {
  * TODO: switch click/popstate handling to the browser Navigation API when broadly supported.
  */
 export function Navigation({ children, ...meta }: NavigationProps): ReactElement {
-	const { url, base, ...merged } = requireMeta(meta);
+	const { url, root: base, ...merged } = requireMeta(meta);
 	const nav = useInstance(NavigationStore, url, base);
 	useStore(nav);
 
@@ -56,7 +56,7 @@ export function Navigation({ children, ...meta }: NavigationProps): ReactElement
 
 	return (
 		<NavigationContext value={nav}>
-			<MetaContext value={{ base, url: nav.value, ...merged }}>{children}</MetaContext>
+			<MetaContext value={{ root: base, url: nav.value, ...merged }}>{children}</MetaContext>
 		</NavigationContext>
 	);
 }

--- a/modules/ui/router/Router.tsx
+++ b/modules/ui/router/Router.tsx
@@ -21,7 +21,7 @@ export interface RouterProps extends PossibleMeta {
  * - Returns `null` when there's no URL in context or the URL is outside the base.
  */
 export function Router({ routes, ...meta }: RouterProps): ReactElement | null {
-	const { url, base } = requireMeta(meta);
+	const { url, root: base } = requireMeta(meta);
 	if (!url) return null;
 	const path = base ? matchURLPrefix(url, base) : url.pathname;
 	if (!path) return null;

--- a/modules/ui/util/css.ts
+++ b/modules/ui/util/css.ts
@@ -1,4 +1,4 @@
-import { type ImmutableArray, isArray } from "../../util/array.js";
+import { isArray } from "../../util/array.js";
 import { getDictionaryItems, type ImmutableDictionary, isDictionary } from "../../util/dictionary.js";
 
 /**
@@ -7,12 +7,20 @@ import { getDictionaryItems, type ImmutableDictionary, isDictionary } from "../.
  * - `string` — used directly as a classname.
  * - `null` or `undefined` — ignored.
  * - Array of classnames — recursively parsed.
- * - Dictionary of classnames — recursively parsed.
- *     - `true` or `false` item values in dictionaries use the string `key` of the item if the value is `true`, or ignore it if the value is `false`
  */
-export type Classes = string | null | undefined | ClassesArray | ClassesDictionary;
-export interface ClassesArray extends ImmutableArray<Classes> {}
-export interface ClassesDictionary extends ImmutableDictionary<Classes | boolean> {}
+export type Classes = string | null | undefined | readonly Classes[] | Variants;
+
+/**
+ * Variants list is a dictionary of booleans.
+ * - `true` or `false` item values in dictionaries use the string `key` of the item if the value is `true`, or ignore it if the value is falsy.
+ * - Anything that is not `true` has no effect, so other values can be passed in and will be ignored. This means you can pass the entire `props` into this and it'll work just fine.
+ *
+ * Typed as `object` (not `Data`/`Record<string, unknown>`) so plain `interface` types are accepted —
+ * interfaces lack an implicit string index signature, so they don't satisfy index-signature types.
+ */
+export interface Variants {
+	readonly [key: string]: boolean;
+}
 
 /** CSS modules mapping of local class names to hashed runtime class names. */
 export type CSSModule = ImmutableDictionary<string | undefined>;
@@ -24,12 +32,12 @@ export type CSSModule = ImmutableDictionary<string | undefined>;
  * @param classes The input set of classes to merge.
  * @returns The merged string classname.
  */
-export function getClass(...classes: Classes[]): string {
+export function getClass(...classes: unknown[]): string {
 	return Array.from(getClasses(classes)).join(" ");
 }
 
 /** Yield the items in a list of possible `className` strings. */
-function* getClasses(classes: Classes): Iterable<string> {
+function* getClasses(classes: unknown): Iterable<string> {
 	if (!classes) return;
 
 	if (typeof classes === "string") {
@@ -44,16 +52,9 @@ function* getClasses(classes: Classes): Iterable<string> {
 	}
 
 	if (isDictionary(classes)) {
-		for (const [k, v] of getDictionaryItems(classes as ClassesDictionary)) {
-			if (!v) continue;
-			if (v === true) {
-				yield k;
-			} else if (typeof v === "string") {
-				yield v;
-			} else {
-				yield* getClasses(v);
-			}
-		}
+		// If `v` is `true`, return the keyname as a classname.
+		// Anything else is ignored or not processed.
+		for (const [k, v] of getDictionaryItems(classes)) if (v === true) yield k;
 	}
 }
 
@@ -68,12 +69,12 @@ function* getClasses(classes: Classes): Iterable<string> {
  * @param classes Class keys/values to merge.
  * @returns The merged string classname.
  */
-export function getModuleClass(module: CSSModule | string, ...classes: Classes[]): string | undefined {
+export function getModuleClass(module: CSSModule | string, ...classes: unknown[]): string | undefined {
 	if (isDictionary(module)) return Array.from(getModuleClasses(module, classes)).join(" ");
 }
 
 /** Yield the items in a list of possible `className` strings that match a `CSSModule` dictionary. */
-function* getModuleClasses(module: CSSModule, classes: Classes[]): Iterable<string> {
+function* getModuleClasses(module: CSSModule, classes: unknown): Iterable<string> {
 	for (const x of getClasses(classes)) {
 		const y = module[x];
 		if (y) yield y;

--- a/modules/ui/util/meta.ts
+++ b/modules/ui/util/meta.ts
@@ -1,18 +1,25 @@
 import type { ImmutableArray } from "../../util/array.js";
-import type { ImmutableDictionary } from "../../util/dictionary.js";
+import { type DictionaryItem, getDictionaryItems, type ImmutableDictionary } from "../../util/dictionary.js";
 import type { AnyCaller } from "../../util/function.js";
+import { type PossibleLink, requireLink } from "../../util/link.js";
 import type { Nullish } from "../../util/null.js";
-import { type PossibleURIParams, withURIParams } from "../../util/uri.js";
-import { type ImmutableURL, type PossibleURL, requireURL } from "../../util/url.js";
+import { type ImmutableURI, type PossibleURI, type PossibleURIParams, withURIParams } from "../../util/uri.js";
+import { type ImmutableURL, requireURL } from "../../util/url.js";
 
-/** Set of named meta `<meta />` tags in `{ rel: href }` format. */
-export type MetaTags = ImmutableDictionary<Nullish<string | boolean>>;
+/** Set of named meta `<meta />` tags in `{ name: content }` format. */
+export type MetaTags = ImmutableDictionary<string | boolean | null | undefined>;
 
 /** Set of named meta `<link />` tags in `{ rel: href }` format. */
-export type MetaLinks = ImmutableDictionary<Nullish<string>>;
+export type MetaLinks = ImmutableDictionary<ImmutableURI>;
+
+/** Set of named meta `<link />` tags in `{ rel: href }` format. */
+export type PossibleMetaLinks = ImmutableDictionary<Nullish<PossibleLink>>;
 
 /** Set of linked assets in `(href)[]` format. */
-export type MetaAssets = ImmutableArray<Nullish<string>>;
+export type MetaAssets = ImmutableArray<ImmutableURI>;
+
+/** Set of linked assets in `(href)[]` format. */
+export type PossibleMetaAssets = ImmutableArray<Nullish<PossibleLink>>;
 
 /** Type for a meta `Content-Security-Policy` tag in `{ resource: string[] }` format. */
 export type MetaCSP = { readonly [resource: string]: string[] };
@@ -20,7 +27,7 @@ export type MetaCSP = { readonly [resource: string]: string[] };
 /** Combined meta data for a website page. */
 export interface Meta {
 	/** Base URL for the app (used to resolve `url` and set as `<base>` tag in `<Head>`). */
-	readonly base?: ImmutableURL | undefined;
+	readonly root?: ImmutableURL | undefined;
 	/** URL of the current page (used to update history API and as the initial URL for routing). */
 	readonly url?: ImmutableURL | undefined;
 	/** Title of the entire application. */
@@ -32,8 +39,12 @@ export interface Meta {
 	readonly image?: string | undefined;
 	/** Language code (used for `lang` tag in HTML). */
 	readonly language?: string | undefined;
+
+	// Meta.
 	readonly csp?: MetaCSP | undefined;
 	readonly tags?: MetaTags | undefined;
+
+	// Links and assets.
 	readonly links?: MetaLinks | undefined;
 	readonly modules?: MetaAssets | undefined;
 	readonly scripts?: MetaAssets | undefined;
@@ -41,18 +52,25 @@ export interface Meta {
 }
 
 /** Input metadata that can be parsed and converted to proper metadata. */
-export interface PossibleMeta extends Omit<Meta, "url"> {
+export interface PossibleMeta extends Omit<Meta, "url" | "links" | "scripts" | "modules" | "stylesheets"> {
 	/**
 	 * New URL for the page.
-	 * - Resolved using `requireURL()` if set relative to `base`
+	 * - Resolved using `requireURL()` if set relative to `root`
 	 */
-	readonly url?: PossibleURL | undefined;
+	readonly url?: PossibleURI | undefined;
+
 	/**
 	 * Set the params in the URL (not merged with existing params).
 	 * - Added to `url` after it is resolved.
 	 * - Baseically
 	 */
 	readonly params?: PossibleURIParams | undefined;
+
+	// Possible links and assets.
+	readonly links?: PossibleMetaLinks | undefined;
+	readonly modules?: PossibleMetaAssets | undefined;
+	readonly scripts?: PossibleMetaAssets | undefined;
+	readonly stylesheets?: PossibleMetaAssets | undefined;
 }
 
 /** Turn a deconstructed CSP into a string. */
@@ -71,14 +89,26 @@ export function joinTitles(...titles: (string | undefined)[]): string {
  * Merge two `MetaData` objects.
  * - `title` is merged.
  * - `URL` is resolved to an absolute URL, e.g. `./d/e/f` + `/a/b/c` becomes `https://d.com/a/b/c/d/e/f`
+ * - `stylesheets` and `links` hrefs newly set in `meta2` are absolutified against the merged `url`/`base`, so they stay correct no matter where they are later rendered.
  */
 export function mergeMeta(meta1: Meta, meta2: PossibleMeta, caller: AnyCaller = mergeMeta): Meta {
 	const title = joinTitles(meta2.title, meta1.title);
 
-	const base = mergeMetaURL(undefined, meta1.base, meta2.base, undefined, caller);
-	const url = mergeMetaURL(base, meta1.url, meta2.url, meta2.params, caller);
+	const root = mergeMetaURL(undefined, meta1.root, meta2.root, undefined, caller);
+	const url = mergeMetaURL(root, meta1.url, meta2.url, meta2.params, caller);
 
-	return { ...meta1, ...meta2, base, url, title };
+	return {
+		...meta1,
+		...meta2,
+		root,
+		url,
+		title,
+		tags: mergeMetaTags(meta1.tags, meta2.tags),
+		links: mergeMetaLinks(meta1.links, meta2.links, url, root, caller),
+		modules: mergeMetaAssets(meta1.modules, meta2.modules, url, root, caller),
+		scripts: mergeMetaAssets(meta1.scripts, meta2.scripts, url, root, caller),
+		stylesheets: mergeMetaAssets(meta1.stylesheets, meta2.stylesheets, url, root, caller),
+	};
 }
 
 /**
@@ -88,10 +118,66 @@ export function mergeMeta(meta1: Meta, meta2: PossibleMeta, caller: AnyCaller = 
 export function mergeMetaURL(
 	base: ImmutableURL | undefined,
 	current: ImmutableURL | undefined,
-	next: PossibleURL | undefined,
+	next: PossibleURI | undefined,
 	params: PossibleURIParams | undefined,
 	caller: AnyCaller = mergeMetaURL,
 ): ImmutableURL | undefined {
 	const url = next ? requireURL(next, base, caller) : current;
 	return url && params ? withURIParams(url, params, caller) : url;
+}
+
+/**
+ * Merge two metadata tags.
+ * - New assets are resolved relative to current URL (relative paths) and root URL (absolute paths).
+ */
+export function mergeMetaTags(current: MetaTags | undefined, next: MetaTags | undefined): MetaTags | undefined {
+	return current && next ? { ...current, ...next } : current || next;
+}
+
+/**
+ * Merge two metadata link lists.
+ * - New assets are resolved relative to current URL (relative paths) and root URL (absolute paths).
+ */
+export function mergeMetaLinks(
+	current: MetaLinks | undefined,
+	next: PossibleMetaLinks | undefined,
+	url: ImmutableURL | undefined,
+	root: ImmutableURL | undefined,
+	caller: AnyCaller = mergeMetaLinks,
+): MetaLinks | undefined {
+	return next ? { ...current, ..._yieldMetaLinkEntries(next, url, root, caller) } : current;
+}
+function* _yieldMetaLinkEntries(
+	links: PossibleMetaLinks,
+	url: ImmutableURL | undefined,
+	root: ImmutableURL | undefined,
+	caller: AnyCaller,
+): Iterable<DictionaryItem<ImmutableURI>> {
+	for (const [k, link] of getDictionaryItems(links)) if (link) yield [k, requireLink(link, url, root, caller)];
+}
+
+/**
+ * Merge two metadata asset lists.
+ * - New assets are resolved relative to current URL (relative paths) and root URL (absolute paths).
+ */
+export function mergeMetaAssets(
+	current: MetaAssets | undefined,
+	next: PossibleMetaAssets | undefined,
+	url: ImmutableURL | undefined,
+	root: ImmutableURL | undefined,
+	caller: AnyCaller = mergeMetaAssets,
+): MetaAssets | undefined {
+	if (next) {
+		const mapped = _yieldMetaAssets(next, url, root, caller);
+		return current ? [...current, ...mapped] : Array.from(mapped);
+	}
+	return current;
+}
+function* _yieldMetaAssets(
+	assets: PossibleMetaAssets,
+	url: ImmutableURL | undefined,
+	root: ImmutableURL | undefined,
+	caller: AnyCaller,
+): Iterable<ImmutableURI> {
+	for (const asset of assets) if (asset) yield requireLink(asset, url, root, caller);
 }

--- a/modules/util/README.md
+++ b/modules/util/README.md
@@ -208,5 +208,5 @@ isArrayWith(["x", "y"], "x");           // true
 
 ## See also
 
-- [schema](../schema/README.md) — Schema validation built on the `Data` and `Item` types from this module.
-- [db](../db/README.md) — Database layer that uses `Query`, `Updates`, and `Item` from this module.
+- [schema](/schema) — Schema validation built on the `Data` and `Item` types from this module.
+- [db](/db) — Database layer that uses `Query`, `Updates`, and `Item` from this module.

--- a/modules/util/link.test.ts
+++ b/modules/util/link.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { RequiredError } from "../error/RequiredError.js";
-import { getLink, requireLink, requireURL } from "../index.js";
+import { getLink, type ImmutableURI, RequiredError, requireLink, requireURL } from "../index.js";
 
 const ROOT = requireURL("https://x.com/app/");
 const ROOT_NO_SLASH = requireURL("https://x.com/app");
@@ -9,36 +8,36 @@ const PAGE = requireURL("https://x.com/app/schema/");
 describe("getLink()", () => {
 	describe("URL instance", () => {
 		test("returns its href", () => {
-			expect(getLink(requireURL("https://other.com/foo"))).toBe("https://other.com/foo");
+			expect(getLink(requireURL("https://other.com/foo"))).toEqual(new URL("https://other.com/foo") as ImmutableURI);
 		});
 		test("returns its href ignoring url and root", () => {
-			expect(getLink(requireURL("https://other.com/foo"), PAGE, ROOT)).toBe("https://other.com/foo");
+			expect(getLink(requireURL("https://other.com/foo"), PAGE, ROOT)).toEqual(new URL("https://other.com/foo") as ImmutableURI);
 		});
 		test("returns mailto: href as-is", () => {
-			expect(getLink(new URL("mailto:a@b"))).toBe("mailto:a@b");
+			expect(getLink(new URL("mailto:a@b"))).toEqual(new URL("mailto:a@b") as ImmutableURI);
 		});
 	});
 
 	describe("absolute path", () => {
 		test("resolves against root honoring its subfolder", () => {
-			expect(getLink("/schema", PAGE, ROOT)).toBe("https://x.com/app/schema");
+			expect(getLink("/schema", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema") as ImmutableURI);
 		});
 		test("resolves nested absolute path against root", () => {
-			expect(getLink("/schema/db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+			expect(getLink("/schema/db", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema/db") as ImmutableURI);
 		});
 		test("resolves root against root", () => {
-			expect(getLink("/", PAGE, ROOT)).toBe("https://x.com/app/");
+			expect(getLink("/", PAGE, ROOT)).toEqual(new URL("https://x.com/app/") as ImmutableURI);
 		});
 		test("handles root without trailing slash", () => {
 			// getURL normalises base to a trailing-slash BaseURL internally.
-			expect(getLink("/schema", PAGE, ROOT_NO_SLASH)).toBe("https://x.com/app/schema");
+			expect(getLink("/schema", PAGE, ROOT_NO_SLASH)).toEqual(new URL("https://x.com/app/schema") as ImmutableURI);
 		});
 		test("ignores url when root is given", () => {
-			expect(getLink("/schema", requireURL("https://other.com/page/"), ROOT)).toBe("https://x.com/app/schema");
+			expect(getLink("/schema", requireURL("https://other.com/page/"), ROOT)).toEqual(new URL("https://x.com/app/schema") as ImmutableURI);
 		});
 		test("defaults root to url when root is omitted, resolving under url's directory", () => {
 			// PAGE is "https://x.com/app/schema/" — absolute paths resolve under it.
-			expect(getLink("/db", PAGE)).toBe("https://x.com/app/schema/db");
+			expect(getLink("/db", PAGE)).toEqual(new URL("https://x.com/app/schema/db") as ImmutableURI);
 		});
 		test("returns undefined when neither url nor root given", () => {
 			expect(getLink("/schema")).toBeUndefined();
@@ -47,45 +46,45 @@ describe("getLink()", () => {
 
 	describe("scheme-prefixed URI", () => {
 		test("returns mailto: as-is", () => {
-			expect(getLink("mailto:a@b", PAGE, ROOT)).toBe("mailto:a@b");
+			expect(getLink("mailto:a@b", PAGE, ROOT)).toEqual(new URL("mailto:a@b") as ImmutableURI);
 		});
 		test("returns tel: as-is", () => {
-			expect(getLink("tel:+44123", PAGE, ROOT)).toBe("tel:+44123");
+			expect(getLink("tel:+44123", PAGE, ROOT)).toEqual(new URL("tel:+44123") as ImmutableURI);
 		});
 		test("returns external https URL as-is", () => {
-			expect(getLink("https://other.com/foo", PAGE, ROOT)).toBe("https://other.com/foo");
+			expect(getLink("https://other.com/foo", PAGE, ROOT)).toEqual(new URL("https://other.com/foo") as ImmutableURI);
 		});
 		test("returns http URL ignoring url and root", () => {
-			expect(getLink("http://other.com/foo", PAGE, ROOT)).toBe("http://other.com/foo");
+			expect(getLink("http://other.com/foo", PAGE, ROOT)).toEqual(new URL("http://other.com/foo") as ImmutableURI);
 		});
 		test("resolves protocol-relative URL against url's protocol", () => {
-			expect(getLink("//other.com/foo", PAGE, ROOT)).toBe("https://other.com/foo");
+			expect(getLink("//other.com/foo", PAGE, ROOT)).toEqual(new URL("https://other.com/foo") as ImmutableURI);
 		});
 		test("ignores document base for scheme classification", () => {
 			// Even though a relative path containing a colon could resolve via document.baseURI in browsers,
 			// scheme detection should be deterministic — only true scheme-prefixed strings pass through.
-			expect(getLink("mailto:a@b")).toBe("mailto:a@b");
+			expect(getLink("mailto:a@b")).toEqual(new URL("mailto:a@b") as ImmutableURI);
 		});
 	});
 
 	describe("relative ref", () => {
 		test("resolves ./foo against url", () => {
-			expect(getLink("./db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+			expect(getLink("./db", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema/db") as ImmutableURI);
 		});
 		test("resolves ../foo against url", () => {
-			expect(getLink("../other", PAGE, ROOT)).toBe("https://x.com/app/other");
+			expect(getLink("../other", PAGE, ROOT)).toEqual(new URL("https://x.com/app/other") as ImmutableURI);
 		});
 		test("resolves bare segment against url", () => {
-			expect(getLink("db", PAGE, ROOT)).toBe("https://x.com/app/schema/db");
+			expect(getLink("db", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema/db") as ImmutableURI);
 		});
 		test("resolves fragment against url", () => {
-			expect(getLink("#anchor", PAGE, ROOT)).toBe("https://x.com/app/schema/#anchor");
+			expect(getLink("#anchor", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema/#anchor") as ImmutableURI);
 		});
 		test("resolves query against url", () => {
-			expect(getLink("?q=1", PAGE, ROOT)).toBe("https://x.com/app/schema/?q=1");
+			expect(getLink("?q=1", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema/?q=1") as ImmutableURI);
 		});
 		test("falls back to root when no url given", () => {
-			expect(getLink("./db", undefined, ROOT)).toBe("https://x.com/app/db");
+			expect(getLink("./db", undefined, ROOT)).toEqual(new URL("https://x.com/app/db") as ImmutableURI);
 		});
 		test("returns undefined when neither url nor root given", () => {
 			expect(getLink("./db")).toBeUndefined();
@@ -113,10 +112,10 @@ describe("getLink()", () => {
 
 describe("requireLink()", () => {
 	test("returns resolved href", () => {
-		expect(requireLink("/schema", PAGE, ROOT)).toBe("https://x.com/app/schema");
+		expect(requireLink("/schema", PAGE, ROOT)).toEqual(new URL("https://x.com/app/schema") as ImmutableURI);
 	});
 	test("returns mailto: as-is", () => {
-		expect(requireLink("mailto:a@b", PAGE, ROOT)).toBe("mailto:a@b");
+		expect(requireLink("mailto:a@b", PAGE, ROOT)).toEqual(new URL("mailto:a@b") as ImmutableURI);
 	});
 	test("throws RequiredError for empty string", () => {
 		expect(() => requireLink("" as never, PAGE, ROOT)).toThrow(RequiredError);

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -1,7 +1,7 @@
 import { RequiredError } from "../error/RequiredError.js";
 import type { AnyCaller } from "./function.js";
 import { isAbsolutePath, type Path } from "./path.js";
-import type { ImmutableURI, URIString } from "./uri.js";
+import { type ImmutableURI, isURI, type URIString } from "./uri.js";
 import { getBasedURI, getURL, type ImmutableURL } from "./url.js";
 
 /** Anything that can be turned into an `<a href>` value — a site/relative path, a URI string, or a `URL` instance. */
@@ -21,22 +21,22 @@ export type PossibleLink = Path | ImmutableURI | URIString;
  *
  * Bases are passed through to `getURL` / `getBasedURI` lazily — neither `url` nor `root` is materialised into a normalised base until the chosen branch needs it.
  *
- * @param link The link to resolve. Strings are classified by shape; `URL` instances pass through.
+ * @param href The link to resolve. Strings are classified by shape; `URL` instances pass through.
  * @param url The current page URL — base for relative refs and scheme-prefixed URIs.
  * @param root The site root URL — base for absolute paths. Defaults to `url`.
- * @returns An absolute URI string, or `undefined` if `link` is missing, not a string/URL, or cannot be resolved.
+ * @returns An absolute URI object, or `undefined` if `link` is missing, not a string/URL, or cannot be resolved.
  *
  * @example getLink("/schema", pageURL, siteRoot) // → "https://x.com/app/schema" when siteRoot is "https://x.com/app/"
  * @example getLink("./db", new URL("https://x.com/app/schema/")) // → "https://x.com/app/schema/db"
  * @example getLink("mailto:a@b") // → "mailto:a@b"
  */
-export function getLink(link: unknown, url?: ImmutableURL, root: ImmutableURL | undefined = url): URIString | undefined {
-	if (!link) return;
-	if (link instanceof URL) return link.href as URIString;
-	if (typeof link !== "string") return;
+export function getLink(href: unknown, url?: ImmutableURL, root: ImmutableURL | undefined = url): ImmutableURI | undefined {
+	if (!href) return;
+	if (isURI(href)) return href;
+	if (typeof href !== "string") return;
 	// Single leading slash is a site-absolute path; `//` is a protocol-relative URL and falls through to `getBasedURI`.
-	if (isAbsolutePath(link) && !link.startsWith("//")) return getURL(`.${link}`, root)?.href;
-	return getBasedURI(link, url ?? root)?.href;
+	if (isAbsolutePath(href) && !href.startsWith("//")) return getURL(`.${href}`, root);
+	return getBasedURI(href, url ?? root);
 }
 
 /**
@@ -44,15 +44,15 @@ export function getLink(link: unknown, url?: ImmutableURL, root: ImmutableURL | 
  *
  * Same classification and defaults as `getLink`. Use when an absolute URI is required and there's no sensible "do nothing" path for the caller.
  *
- * @param link The link to resolve.
+ * @param href The link to resolve.
  * @param url The current page URL — base for relative refs and scheme-prefixed URIs.
  * @param root The site root URL — base for absolute paths. Defaults to `url`.
  * @param caller Identity of the calling function for error attribution.
  * @returns An absolute URI string.
  * @throws `RequiredError` if `link` cannot be resolved.
  */
-export function requireLink(link: PossibleLink, url?: ImmutableURL, root?: ImmutableURL, caller: AnyCaller = requireLink): URIString {
-	const href = getLink(link, url, root);
-	if (!href) throw new RequiredError("Invalid link", { received: link, caller });
-	return href;
+export function requireLink(href: PossibleLink, url?: ImmutableURL, root?: ImmutableURL, caller: AnyCaller = requireLink): ImmutableURI {
+	const uri = getLink(href, url, root);
+	if (!uri) throw new RequiredError("Invalid link", { received: href, caller });
+	return uri;
 }

--- a/modules/util/transform.ts
+++ b/modules/util/transform.ts
@@ -1,5 +1,5 @@
 import type { ImmutableArray } from "./array.js";
-import type { DictionaryItem, ImmutableDictionary } from "./dictionary.js";
+import type { ImmutableDictionary } from "./dictionary.js";
 import { getDictionaryItems } from "./dictionary.js";
 import type { Entry } from "./entry.js";
 import type { Arguments } from "./function.js";
@@ -37,10 +37,10 @@ export function mapProps<I extends ImmutableObject, O extends ImmutableObject, A
 /** Modify the _values_ of a dictionary using a transform. */
 export function mapDictionary<I, O, A extends Arguments = []>(
 	dictionary: ImmutableDictionary<I>,
-	transform: (item: DictionaryItem<I>, ...args: A) => O,
+	transform: (value: I, ...args: A) => O,
 	...args: A
 ): ImmutableDictionary<O> {
-	return Object.fromEntries(mapEntries(getDictionaryItems(dictionary), transform, ...args));
+	return Object.fromEntries(mapEntryValues(getDictionaryItems(dictionary), transform, ...args));
 }
 
 /** Modify the _values_ of a set of entries using a transform. */
@@ -50,6 +50,15 @@ export function* mapEntries<K, I, O, A extends Arguments = []>(
 	...args: A
 ): Iterable<Entry<K, O>> {
 	for (const e of entries) yield [e[0], transform(e, ...args)];
+}
+
+/** Modify the _values_ of a set of entries using a transform. */
+export function* mapEntryValues<K, I, O, A extends Arguments = []>(
+	entries: Iterable<Entry<K, I>>,
+	transform: (value: I, ...args: A) => O,
+	...args: A
+): Iterable<Entry<K, O>> {
+	for (const e of entries) yield [e[0], transform(e[1], ...args)];
 }
 
 /**

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -112,15 +112,22 @@ export function requireURL(target: PossibleURL, base?: PossibleURL, caller: AnyC
  *
  * @returns Absolute path starting with `/`, or `undefined` for origin mismatches or non-matching paths.
  */
-export function matchURLPrefix(target: PossibleURL, base: PossibleURL, caller: AnyCaller = matchURLPrefix): AbsolutePath | undefined {
-	const baseURL = requireBaseURL(base, caller);
+export function matchURLPrefix(
+	target: PossibleURL | undefined,
+	base: PossibleURL | undefined,
+	caller: AnyCaller = matchURLPrefix,
+): AbsolutePath | undefined {
+	if (!target || !base) return;
+	const baseURL = requireURL(base, undefined, caller);
 	const targetURL = requireURL(target, baseURL, caller);
 	if (targetURL.origin !== baseURL.origin) return;
 	const basePath = baseURL.pathname;
 	const targetPath = targetURL.pathname;
 	if (basePath === "/") return targetPath;
-	if (targetPath === basePath.slice(0, -1)) return "/"; // e.g. `/abc` and `/abc/`
-	if (targetPath.startsWith(basePath)) return targetPath.slice(basePath.length - 1) as AbsolutePath;
+	// `basePath` may or may not have a trailing slash, so strip it and re-assert the directory boundary explicitly.
+	const bareBase = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
+	if (targetPath === bareBase) return "/"; // e.g. `/abc` matches base `/abc` or `/abc/`
+	if (targetPath.startsWith(bareBase) && targetPath[bareBase.length] === "/") return targetPath.slice(bareBase.length) as AbsolutePath;
 }
 
 /**
@@ -131,8 +138,8 @@ export function matchURLPrefix(target: PossibleURL, base: PossibleURL, caller: A
  * @param target URL whose status to test — relative paths resolve against `base`.
  * @param base Base URL to test against.
  */
-export function isURLActive(target: PossibleURL, base: PossibleURL, caller: AnyCaller = isURLActive): boolean {
-	return matchURLPrefix(target, base, caller) === "/";
+export function isURLActive(target: PossibleURL | undefined, base: PossibleURL | undefined, caller: AnyCaller = isURLActive): boolean {
+	return !!target && !!base && matchURLPrefix(target, base, caller) === "/";
 }
 
 /**
@@ -144,8 +151,8 @@ export function isURLActive(target: PossibleURL, base: PossibleURL, caller: AnyC
  * @param target URL whose status to test — relative paths resolve against `base`.
  * @param base Base URL to test against.
  */
-export function isURLProud(target: PossibleURL, base: PossibleURL, caller: AnyCaller = isURLProud): boolean {
-	return matchURLPrefix(target, base, caller) !== undefined;
+export function isURLProud(target: PossibleURL | undefined, base: PossibleURL | undefined, caller: AnyCaller = isURLProud): boolean {
+	return !!target && !!base && matchURLPrefix(target, base, caller) !== undefined;
 }
 
 /** BaseURL is a URL with a guaranteed trailing slash on pathname. */

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"build": "bun run --sequential build:*",
 		"build:0:setup": "rm -rf ./dist && mkdir -p ./dist",
 		"build:1:copy": "cp package.json dist/package.json && cp LICENSE.md dist/LICENSE.md && cp README.md dist/README.md && cp .npmignore dist/.npmignore && cp -r modules/ui dist/ui",
-		"build:2:emit": "tsgo",
+		"build:2:emit": "tsgo -p tsconfig.build.json",
 		"build:3:syntax": "bun run ./dist/index.js",
 		"build:4:unit": "bun test ./dist/**/*.test.js --concurrent --only-failures --bail"
 	},

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"declaration": true,
+		"noEmit": false,
+		"noEmitOnError": true,
+		"outDir": "./dist",
+		"rootDir": "./modules"
+	},
+	"include": ["./modules/**/*", "./**/*.json"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,24 +2,20 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"composite": true,
-		"declaration": true,
 		"erasableSyntaxOnly": true,
 		"exactOptionalPropertyTypes": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",
 		"lib": ["esnext", "dom"],
 		"module": "nodenext",
-		"noEmitOnError": true,
+		"noEmit": true,
 		"noErrorTruncation": true,
 		"noImplicitOverride": true,
 		"noUncheckedIndexedAccess": true,
-		"outDir": "./dist",
-		"rootDir": "./modules",
 		"skipLibCheck": true,
 		"target": "esnext",
 		"verbatimModuleSyntax": true
 	},
-	"include": ["./modules/**/*", "./**/*.json"],
+	"include": ["./modules/**/*", "./docs/**/*", "./**/*.json"],
 	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- The docs site rendered blank, unstyled pages with broken links when hosted under a sub-path (GitHub Pages serves it at `/shelving/`). Per-page URLs were built origin-relative, so the router's base-prefix strip matched nothing and rendered `null`; component, markup and asset hrefs were never resolved against the site root.
- Wires site-root resolution through the whole rendering pipeline: page URLs (`render.tsx`), `Clickable`/`MenuItem`/`Markup` hrefs via `getLink`, and stylesheet/link/asset hrefs absolutified + merged in `mergeMeta` at set-time.
- Converts the module READMEs from relative `../x/README.md` links to site-absolute `/x` links.
- Reworks `Clickable` and adapts the form components to it; adds `OutputInput`.

## Test plan

- [x] `bun run test` — lint, types, and 1020 unit tests pass
- [x] `APP_URL=https://dhoulb.github.io/shelving bun run docs:build` — pages render with styles, content, and correct single-`/shelving` absolute links
- [x] `bun run docs:build` (localhost, no sub-path) still works
- [ ] Check the deploy preview renders correctly once CI posts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)