### PR TITLE
feat(ui): collapse SidebarLayout into a toggleable drawer on narrow viewports

### DIFF
--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -6,8 +6,9 @@
  * The inner `.content` element reuses the `.layout` class too so it picks up the standard
  * layout padding, safe-area insets, and `overflow: hidden auto` scroll behaviour.
  *
- * On narrow viewports the sidebar becomes an off-canvas drawer: it slides off the left edge of
- * the screen and is toggled with the `.show` / `.close` buttons (both hidden on wide viewports).
+ * On narrow viewports the sidebar becomes an off-canvas drawer: it slides off the left edge of the
+ * screen and is toggled by the hidden `.toggle` checkbox via its `.show` / `.close` `<label>` buttons.
+ * Driving the drawer with a checkbox + CSS means it works even when the page ships no client-side JS.
  */
 
 .main {
@@ -37,6 +38,11 @@
 	margin: 0 auto;
 }
 
+/* Toggle checkbox — hidden entirely on wide viewports (see media query for the narrow-viewport state). */
+.toggle {
+	display: none;
+}
+
 /* Menu toggle buttons — hidden by default, only shown on narrow viewports (see media query below). */
 .show,
 .close {
@@ -46,9 +52,7 @@
 	align-items: center;
 	justify-content: center;
 	padding: var(--space-small);
-	border: none;
 	border-radius: var(--radius-xsmall);
-	background: transparent;
 	color: var(--color-text);
 	cursor: pointer;
 
@@ -57,7 +61,7 @@
 		height: var(--size-icon);
 	}
 
-	&:where(:hover, :focus-visible) {
+	&:hover {
 		background: var(--color-surface);
 	}
 }
@@ -83,12 +87,28 @@
 		transform: translateX(-100%);
 		transition: transform var(--duration-normal) ease-in-out;
 	}
-	.sidebar.open {
+	/* Checked checkbox → drawer slides on screen. */
+	.toggle:checked ~ .sidebar {
 		transform: translateX(0);
 		box-shadow: 0 0 1.5rem var(--color-overlay);
+	}
+	/* Keep the checkbox visually hidden but still focusable for keyboard users. */
+	.toggle {
+		display: block;
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		clip-path: inset(50%);
 	}
 	.show,
 	.close {
 		display: flex;
+	}
+	/* Forward the checkbox's keyboard focus ring to whichever toggle button is on screen. */
+	.toggle:focus-visible ~ .content .show,
+	.toggle:focus-visible ~ .sidebar .close {
+		outline: var(--stroke-focus) solid var(--color-focus);
+		outline-offset: 2px;
 	}
 }

--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -5,6 +5,9 @@
  * here we override its block-level behaviour so the sidebar and content each scroll independently.
  * The inner `.content` element reuses the `.layout` class too so it picks up the standard
  * layout padding, safe-area insets, and `overflow: hidden auto` scroll behaviour.
+ *
+ * On narrow viewports the sidebar becomes an off-canvas drawer: it slides off the left edge of
+ * the screen and is toggled with the `.show` / `.close` buttons (both hidden on wide viewports).
  */
 
 .main {
@@ -34,14 +37,58 @@
 	margin: 0 auto;
 }
 
-/* On narrow viewports collapse to a single column with the sidebar above. */
+/* Menu toggle buttons — hidden by default, only shown on narrow viewports (see media query below). */
+.show,
+.close {
+	display: none;
+	width: fit-content;
+	margin: 0;
+	align-items: center;
+	justify-content: center;
+	padding: var(--space-small);
+	border: none;
+	border-radius: var(--radius-xsmall);
+	background: transparent;
+	color: var(--color-text);
+	cursor: pointer;
+
+	& svg {
+		width: var(--size-icon);
+		height: var(--size-icon);
+	}
+
+	&:where(:hover, :focus-visible) {
+		background: var(--color-surface);
+	}
+}
+
+/* The close button sits at the top of the sidebar, aligned to its trailing edge. */
+.close {
+	margin-inline-start: auto;
+	margin-bottom: var(--space-xsmall);
+}
+
+/* On narrow viewports the sidebar becomes an off-canvas drawer that slides in from the left. */
 @media (max-width: 48rem) {
 	.main {
 		grid-template-columns: 1fr;
 	}
 	.sidebar {
-		border-right: none;
-		border-bottom: 1px solid var(--color-border);
-		max-height: 50vh;
+		position: fixed;
+		z-index: 100;
+		inset-block: 0;
+		left: 0;
+		width: var(--sidebar-layout-width, 17.5rem);
+		max-width: 85vw;
+		transform: translateX(-100%);
+		transition: transform var(--duration-normal) ease-in-out;
+	}
+	.sidebar.open {
+		transform: translateX(0);
+		box-shadow: 0 0 1.5rem var(--color-overlay);
+	}
+	.show,
+	.close {
+		display: flex;
 	}
 }

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -1,4 +1,5 @@
-import type { ReactElement, ReactNode } from "react";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
+import { type ReactElement, type ReactNode, useState } from "react";
 import { getClass } from "../util/css.js";
 import { LAYOUT_CSS } from "./Layout.js";
 import SIDEBAR_LAYOUT_CSS from "./SidebarLayout.module.css";
@@ -15,17 +16,26 @@ export interface SidebarLayoutProps {
 /**
  * Layout with a fixed-width side column (typically navigation) next to a scrollable main content column.
  * - The sidebar is rendered as `<nav>` — it almost always contains the page's primary navigation.
- * - The sidebar collapses above the main content on narrow viewports.
+ * - On narrow viewports the sidebar slides off the left of the screen and is toggled with a "show menu" button.
  * - Use the `--sidebar-layout-width` and `--sidebar-layout-bg` custom properties to override defaults.
  */
 export function SidebarLayout({ sidebar, children, right = false }: SidebarLayoutProps): ReactElement {
+	// Whether the sidebar drawer is open — only has an effect on narrow viewports.
+	const [open, setOpen] = useState(false);
+
 	const sidebarEl = (
-		<nav key="sidebar" className={SIDEBAR_LAYOUT_CSS.sidebar}>
+		<nav key="sidebar" className={getClass(SIDEBAR_LAYOUT_CSS.sidebar, open && SIDEBAR_LAYOUT_CSS.open)}>
+			<button type="button" title="Close menu" className={SIDEBAR_LAYOUT_CSS.close} onClick={() => setOpen(false)}>
+				<XMarkIcon />
+			</button>
 			{sidebar}
 		</nav>
 	);
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
+			<button type="button" title="Show menu" className={SIDEBAR_LAYOUT_CSS.show} onClick={() => setOpen(true)}>
+				<Bars3Icon />
+			</button>
 			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
 		</div>
 	);

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -1,5 +1,5 @@
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
-import { type ReactElement, type ReactNode, useState } from "react";
+import { type ReactElement, type ReactNode, useId } from "react";
 import { getClass } from "../util/css.js";
 import { LAYOUT_CSS } from "./Layout.js";
 import SIDEBAR_LAYOUT_CSS from "./SidebarLayout.module.css";
@@ -17,30 +17,34 @@ export interface SidebarLayoutProps {
  * Layout with a fixed-width side column (typically navigation) next to a scrollable main content column.
  * - The sidebar is rendered as `<nav>` — it almost always contains the page's primary navigation.
  * - On narrow viewports the sidebar slides off the left of the screen and is toggled with a "show menu" button.
+ * - The toggle is driven by a hidden checkbox and pure CSS, so it works even when the page ships no client-side JavaScript.
  * - Use the `--sidebar-layout-width` and `--sidebar-layout-bg` custom properties to override defaults.
  */
 export function SidebarLayout({ sidebar, children, right = false }: SidebarLayoutProps): ReactElement {
-	// Whether the sidebar drawer is open — only has an effect on narrow viewports.
-	const [open, setOpen] = useState(false);
+	// Ties the toggle checkbox to its `<label>` buttons — `useId()` is stable during static (non-hydrated) rendering.
+	const id = useId();
 
 	const sidebarEl = (
-		<nav key="sidebar" className={getClass(SIDEBAR_LAYOUT_CSS.sidebar, open && SIDEBAR_LAYOUT_CSS.open)}>
-			<button type="button" title="Close menu" className={SIDEBAR_LAYOUT_CSS.close} onClick={() => setOpen(false)}>
+		<nav key="sidebar" className={SIDEBAR_LAYOUT_CSS.sidebar}>
+			<label htmlFor={id} title="Close menu" className={SIDEBAR_LAYOUT_CSS.close}>
 				<XMarkIcon />
-			</button>
+			</label>
 			{sidebar}
 		</nav>
 	);
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
-			<button type="button" title="Show menu" className={SIDEBAR_LAYOUT_CSS.show} onClick={() => setOpen(true)}>
+			<label htmlFor={id} title="Show menu" className={SIDEBAR_LAYOUT_CSS.show}>
 				<Bars3Icon />
-			</button>
+			</label>
 			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
 		</div>
 	);
 	return (
-		<main className={getClass(SIDEBAR_LAYOUT_CSS.main, LAYOUT_CSS.layout)}>{right ? [contentEl, sidebarEl] : [sidebarEl, contentEl]}</main>
+		<main className={getClass(SIDEBAR_LAYOUT_CSS.main, LAYOUT_CSS.layout)}>
+			<input type="checkbox" id={id} className={SIDEBAR_LAYOUT_CSS.toggle} aria-label="Show or hide menu" />
+			{right ? [contentEl, sidebarEl] : [sidebarEl, contentEl]}
+		</main>
 	);
 }
 


### PR DESCRIPTION
On narrow/mobile viewports the sidebar now slides off the left edge of the
screen and is opened with a "show menu" button and closed with an in-drawer
close button, using a CSS transform transition. All logic and styling stays
within the SidebarLayout component.

https://claude.ai/code/session_013P2nkfgthJ99NoiGLh3xUz