### PR TITLE
refactor(util): declare Element/ElementProps as type aliases

### DIFF
--- a/modules/extract/Extractor.ts
+++ b/modules/extract/Extractor.ts
@@ -32,8 +32,6 @@ export function mergeTreeElements(primary: TreeElement, secondary: TreeElement):
 		key: primary.key,
 		props: {
 			...primary.props,
-			title: primary.props.title,
-			source: primary.props.source,
 			description: primary.props.description ?? secondary.props.description,
 			content: _mergeContent(primary.props.content, secondary.props.content),
 			children: mergeElements(primary.props.children, secondary.props.children),

--- a/modules/markup/rule/link.test.ts
+++ b/modules/markup/rule/link.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { Element } from "../../util/element.js";
+import type { Element, ElementProps } from "../../util/element.js";
 import { requireURL } from "../../util/url.js";
 import { MARKUP_RULES, renderMarkup } from "../index.js";
 
@@ -72,7 +72,7 @@ test("AUTOLINK_RULE", () => {
 		type: "a",
 		props: { children: "dave@shax.com" },
 	});
-	expect((renderMarkup("mailto:dave@shax.com", OPTIONS, "inline") as Element).props.href).toBe(undefined);
+	expect((renderMarkup("mailto:dave@shax.com", OPTIONS, "inline") as Element<ElementProps & { href?: string }>).props.href).toBe(undefined);
 
 	// Links using schemes in whitelist are linked.
 	expect(renderMarkup("ftp://localhost/a/b", { ...OPTIONS, schemes: ["ftp:"] }, "inline")).toMatchObject({
@@ -115,13 +115,13 @@ test("LINK_RULE", () => {
 		type: "a",
 		props: { children: "LINK" },
 	});
-	expect((renderMarkup("[LINK]()", OPTIONS, "inline") as Element).props.href).toBe(undefined);
+	expect((renderMarkup("[LINK]()", OPTIONS, "inline") as Element<ElementProps & { href?: string }>).props.href).toBe(undefined);
 	expect(renderMarkup("[]()", OPTIONS, "inline")).toMatchObject({
 		$$typeof,
 		type: "a",
 		props: { children: "" },
 	});
-	expect((renderMarkup("[]()", OPTIONS, "inline") as Element).props.href).toBe(undefined);
+	expect((renderMarkup("[]()", OPTIONS, "inline") as Element<ElementProps & { href?: string }>).props.href).toBe(undefined);
 
 	// `href` strips whitespace.
 	expect(renderMarkup("[Google](\t  http://google.com  \t)", OPTIONS, "inline")).toMatchObject({
@@ -173,7 +173,9 @@ test("LINK_RULE", () => {
 		type: "a",
 		props: { children: "NOPE" },
 	});
-	expect((renderMarkup("[NOPE](mailto:dave@shax.com)", OPTIONS, "inline") as Element).props.href).toBe(undefined);
+	expect((renderMarkup("[NOPE](mailto:dave@shax.com)", OPTIONS, "inline") as Element<ElementProps & { href?: string }>).props.href).toBe(
+		undefined,
+	);
 
 	// Links using schemes in whitelist are linked.
 	expect(renderMarkup("[YEP](mailto:dave@shax.com)", { ...OPTIONS, schemes: ["mailto:"] }, "inline")).toMatchObject({

--- a/modules/util/data.test.ts
+++ b/modules/util/data.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { BranchData, ImmutableDictionary, LeafData } from "../index.js";
+import type { BranchData, Data, ImmutableDictionary, LeafData } from "../index.js";
 import { getDataProp } from "../index.js";
 
 type T = {
@@ -109,4 +109,60 @@ test("getDataProp()", () => {
 	expect(getDataProp(obj, "a")).toBe("A");
 	expect(getDataProp(obj, "b")).toBe(obj.b);
 	expect(getDataProp(obj, "b.b2")).toBe("B");
+});
+
+// Empirical assignability matrix — what satisfies `Data` (string index signature) vs `object`.
+interface DataInterface {
+	readonly a: number;
+}
+class DataClass {
+	readonly a = 1;
+}
+
+// Empirical result — `Data` accepts ONLY plain-object-literal and `type`-alias object types; it rejects
+// interfaces, arrays, `Map`, and class instances (none get the implicit string index signature). `object`
+// accepts every object shape and rejects only primitives. So `Data` is really an "object literal / type
+// alias, not an interface or class" filter — a syntactic distinction, not a true "plain object" guard.
+test("Data vs object assignability", () => {
+	// Plain inline object — accepted by both.
+	const plain = { a: 1 };
+	const plainData: Data = plain;
+	const plainObject: object = plain;
+
+	// `type`-alias object — accepted by both (type aliases get an implicit string index signature).
+	type AliasObject = { readonly a: number };
+	const alias: AliasObject = { a: 1 };
+	const aliasData: Data = alias;
+	const aliasObject: object = alias;
+
+	// `interface` object — rejected by `Data` (interfaces get no implicit index signature), accepted by `object`.
+	const iface: DataInterface = { a: 1 };
+	// @ts-expect-error `Data` rejects interfaces — no implicit string index signature.
+	const ifaceData: Data = iface;
+	const ifaceObject: object = iface;
+
+	// Array — rejected by `Data`, accepted by `object`.
+	const arr: readonly number[] = [1, 2, 3];
+	// @ts-expect-error `Data` rejects arrays — no string index signature.
+	const arrData: Data = arr;
+	const arrObject: object = arr;
+
+	// `Map` — rejected by `Data`, accepted by `object`.
+	const map = new Map<string, number>();
+	// @ts-expect-error `Data` rejects `Map` — no string index signature.
+	const mapData: Data = map;
+	const mapObject: object = map;
+
+	// Class instance — rejected by `Data`, accepted by `object`.
+	const inst = new DataClass();
+	// @ts-expect-error `Data` rejects class instances — no string index signature.
+	const instData: Data = inst;
+	const instObject: object = inst;
+
+	// Primitive — rejected by both.
+	const prim = "x";
+	// @ts-expect-error `Data` rejects primitives.
+	const primData: Data = prim;
+	// @ts-expect-error `object` rejects primitives.
+	const primObject: object = prim;
 });

--- a/modules/util/element.test.ts
+++ b/modules/util/element.test.ts
@@ -33,6 +33,12 @@ const b2: ReactNode = b1;
 const c1: Element = { type: "div", key: null, props: {} };
 const c2: Data = c1;
 
+// `Element` → `ReactElement` works (see `a2` above). The reverse does NOT: `ReactElement` lacks the
+// string index signature `Element` needs for `Data`, and even with that removed `Element`'s `Elements`
+// content model is narrower than React's `ReactNode` (no `number` / `boolean` / `Promise`).
+// @ts-expect-error — documents the one-way gap; remove this line if `Element` is ever unified with `ReactElement`.
+const d1: Element = {} as ReactElement;
+
 describe("getElementText()", () => {
 	test("elements can be converted to plain text", () => {
 		expect(getElementText(P)).toBe("PARAGRAPH");

--- a/modules/util/element.ts
+++ b/modules/util/element.ts
@@ -6,19 +6,20 @@ import type { Query } from "./query.js";
 import { queryItems } from "./query.js";
 
 /** Set of valid props for an element. */
-export interface ElementProps {
-	readonly [key: string]: unknown;
+export type ElementProps = {
 	readonly children?: Elements;
-}
+};
 
-/** Element with a type, props, and optional key (compatible with `React.ReactElement`). */
-export interface Element<P extends ElementProps = ElementProps> {
-	readonly [key: string]: unknown;
+/**
+ * Element with a type, props, and optional key (compatible with `React.ReactElement`).
+ * - Declared as a `type`, not an `interface`, so its implicit index signature lets it satisfy `Data` — `queryElements()` runs elements through `queryItems<T extends Data>`.
+ */
+export type Element<P extends ElementProps = ElementProps> = {
 	readonly type: string | ((props: P) => Elements | null);
 	readonly props: P;
 	readonly key: string | null;
 	readonly $$typeof?: symbol;
-}
+};
 
 /** Collection of elements (compatible with `React.ReactNode`). */
 export type Elements<T extends Element = Element> = undefined | null | string | T | Iterable<Elements<T>>;


### PR DESCRIPTION
## Summary

- Converts `Element` and `ElementProps` from `interface` to `type` aliases, dropping the workaround `readonly [key: string]: unknown` index signatures. Interfaces never receive TypeScript's *implicit* index signature; type aliases of object literals do — so the conversion keeps these types satisfying `Data` (required by `queryElements()` → `queryItems<T extends Data>`) without the explicit hack.
- Removes redundant `title`/`source` lines in `mergeTreeElements` (`Extractor.ts`) — the `...primary.props` spread already copies them; `source` only compiled before because it leaked through the dropped index signature.
- Adds an empirical `Data` vs `object` assignability matrix to `data.test.ts` documenting which object shapes satisfy each.
- Documents the one-way `Element`/`ReactElement` gap in `element.test.ts`.

`TreeElement`/`TreeElementProps` and the directory/file/documentation element prop interfaces are left as `interface` — only the two types that flow into `Data`-constrained code needed converting.

## Test plan

- [x] `bun run test:type` clean
- [x] `bun run test` — 1034 pass, 0 fail
- [ ] Review the markup docs preview deploy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)