### PR TITLE
fix: align Preformatted border-radius with Card

### DIFF
--- a/modules/ui/block/Preformatted.module.css
+++ b/modules/ui/block/Preformatted.module.css
@@ -11,7 +11,7 @@
 	color: var(--preformatted-color-text, var(--color-text));
 	background-color: var(--preformatted-color-bg, var(--color-surface));
 	border: var(--preformatted-border, var(--stroke-normal)) solid var(--preformatted-color-border, var(--color-surface));
-	border-radius: var(--preformatted-radius, var(--radius-xsmall));
+	border-radius: var(--preformatted-radius, var(--radius-normal));
 	tab-size: 2;
 
 	/* Wrap long lines by default — newlines and indentation within wrapped lines are still preserved. */


### PR DESCRIPTION
## Summary

`Preformatted` and `Card` applied different default `border-radius` values, so code blocks and cards on the docs site had visibly different corner rounding.

- `Card.module.css` — `var(--card-radius, var(--radius-normal))` → 16px
- `Preformatted.module.css` — `var(--preformatted-radius, var(--radius-xsmall))` → 8px

This points the `Preformatted` fallback at `--radius-normal` so both share 16px. Each component keeps its per-component override hook (`--card-radius` / `--preformatted-radius`).

## Test plan

- [ ] `bun run test` passes
- [ ] Code blocks and cards on the docs site show matching corner rounding

Closes #72

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta

---
_Generated by [Claude Code](https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta)_