### PR TITLE
feat: sidebar menu toggle button with dimming overlay

### DIFF
--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -7,7 +7,8 @@
  * layout padding, safe-area insets, and `overflow: hidden auto` scroll behaviour.
  *
  * On narrow viewports the sidebar becomes an off-canvas drawer that slides off the left edge of the
- * screen; the `.show` / `.close` buttons toggle it (both are hidden entirely on wide viewports).
+ * screen; the `.toggle` button opens/closes it and the `.overlay` dims the page behind the open
+ * drawer (both are hidden entirely on wide viewports).
  */
 
 .main {
@@ -37,16 +38,25 @@
 	margin: 0 auto;
 }
 
-/* Wrappers for the menu toggle buttons — hidden on wide viewports, shown on narrow ones (see media query). */
-.show,
-.close {
+/* Wrapper for the menu toggle button — hidden on wide viewports, shown on narrow ones (see media query). */
+.toggle {
 	display: none;
-	margin-bottom: var(--space-xsmall);
+	width: fit-content;
+	margin: 0 0 0 auto;
 }
 
-/* The close button sits at the top of the sidebar, aligned to its trailing edge. */
-.close {
-	justify-content: flex-end;
+/* Full-page dimmer behind the open drawer — hidden on wide viewports. */
+.overlay {
+	display: none;
+}
+
+@keyframes overlay-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 
 /* On narrow viewports the sidebar becomes an off-canvas drawer that slides in from the left. */
@@ -68,15 +78,24 @@
 		transform: translateX(0);
 		box-shadow: 0 0 1.5rem var(--color-overlay);
 	}
-	.show,
-	.close {
-		display: flex;
-	}
-	/* Pin the menu button so it stays reachable while the content column scrolls. */
-	.show {
+	/* Pin the toggle button to the top-right so it stays reachable while the content column scrolls. */
+	.toggle {
+		display: block;
 		position: sticky;
 		top: 0;
-		z-index: 50;
-		background: var(--color-bg);
+		z-index: 110;
+	}
+	/* Dim the page behind the open drawer; clicking the overlay closes it. */
+	.overlay {
+		display: block;
+		position: fixed;
+		inset: 0;
+		z-index: 90;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: var(--color-overlay);
+		cursor: pointer;
+		animation: overlay-fade-in var(--duration-normal) ease-in-out;
 	}
 }

--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -72,4 +72,11 @@
 	.close {
 		display: flex;
 	}
+	/* Pin the menu button so it stays reachable while the content column scrolls. */
+	.show {
+		position: sticky;
+		top: 0;
+		z-index: 50;
+		background: var(--color-bg);
+	}
 }

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -19,7 +19,8 @@ export interface SidebarLayoutProps {
 /**
  * Layout with a fixed-width side column (typically navigation) next to a scrollable main content column.
  * - The sidebar is rendered as `<nav>` — it almost always contains the page's primary navigation.
- * - On narrow viewports the sidebar becomes an off-canvas drawer toggled by the "show menu" / "close" buttons.
+ * - On narrow viewports the sidebar becomes an off-canvas drawer toggled by a single menu button that switches between a burger and a close icon.
+ * - While the drawer is open an overlay dims the rest of the page; clicking the overlay closes the drawer.
  * - Inside a `<Navigation>` the drawer closes itself whenever the route changes (e.g. tapping a sidebar link).
  * - Use the `--sidebar-layout-width` and `--sidebar-layout-bg` custom properties to override defaults.
  */
@@ -34,26 +35,26 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 
 	const sidebarEl = (
 		<nav key="sidebar" className={getClass(SIDEBAR_LAYOUT_CSS.sidebar, open && SIDEBAR_LAYOUT_CSS.open)}>
-			<div className={SIDEBAR_LAYOUT_CSS.close}>
-				<Button plain fit title="Close menu" onClick={() => setOpen(false)}>
-					<XMarkIcon />
-				</Button>
-			</div>
 			{sidebar}
 		</nav>
 	);
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
-			<div className={SIDEBAR_LAYOUT_CSS.show}>
-				<Button plain fit title="Show menu" onClick={() => setOpen(true)}>
-					<Bars3Icon />
+			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
+				<Button fit cyan={!open} title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
+					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>
 			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
 		</div>
 	);
+	const overlayEl = open && (
+		<button key="overlay" type="button" className={SIDEBAR_LAYOUT_CSS.overlay} aria-label="Close menu" onClick={() => setOpen(false)} />
+	);
 	return (
-		<main className={getClass(SIDEBAR_LAYOUT_CSS.main, LAYOUT_CSS.layout)}>{right ? [contentEl, sidebarEl] : [sidebarEl, contentEl]}</main>
+		<main className={getClass(SIDEBAR_LAYOUT_CSS.main, LAYOUT_CSS.layout)}>
+			{right ? [contentEl, sidebarEl, overlayEl] : [sidebarEl, contentEl, overlayEl]}
+		</main>
 	);
 }
 

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -41,7 +41,7 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
 			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
-				<Button fit cyan={!open} title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
+				<Button fit cyan={!open} orange={open} plain title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>

--- a/modules/ui/misc/Color.module.css
+++ b/modules/ui/misc/Color.module.css
@@ -3,61 +3,91 @@
 	--primary-text: var(--color-blue);
 	--primary-contrast: var(--color-white);
 	--primary-surface: color-mix(in srgb, var(--primary-text) 12%, white);
+	--primary-border: color-mix(in srgb, var(--primary-text) 40%, transparent);
 
 	/* Secondary colors */
 	--secondary-text: var(--color-purple);
 	--secondary-contrast: var(--color-white);
 	--secondary-surface: color-mix(in srgb, var(--secondary-text) 12%, white);
+	--secondary-border: color-mix(in srgb, var(--secondary-text) 40%, transparent);
 
 	/* Tertiary colors */
 	--tertiary-text: var(--color-cyan);
 	--tertiary-contrast: var(--color-white);
 	--tertiary-surface: color-mix(in srgb, var(--tertiary-text) 12%, white);
+	--tertiary-border: color-mix(in srgb, var(--tertiary-text) 40%, transparent);
 
 	/* Quiet colors */
 	--quiet-text: var(--color-quiet);
 	--quiet-contrast: var(--color-contrast);
-	--quiet-surface: var(--color-surface);
+	--quiet-surface: color-mix(in srgb, var(--quiet-text) 12%, white);
+	--quiet-border: color-mix(in srgb, var(--quiet-text) 40%, transparent);
+
+	/* Black */
+	--black-text: var(--color-black);
+	--black-contrast: var(--color-white);
+	--black-surface: color-mix(in srgb, var(--black-text) 12%, white);
+	--black-border: color-mix(in srgb, var(--black-text) 40%, transparent);
+
+	/* White */
+	--white-text: var(--color-white);
+	--white-contrast: var(--color-black);
+	--white-surface: color-mix(in srgb, var(--white-text) 12%, white);
+	--white-border: color-mix(in srgb, var(--white-text) 40%, transparent);
+
+	/* Gray */
+	--gray-text: var(--color-gray);
+	--gray-contrast: var(--color-white);
+	--gray-surface: color-mix(in srgb, var(--gray-text) 12%, white);
+	--gray-border: color-mix(in srgb, var(--gray-text) 40%, transparent);
 
 	/* Red */
 	--red-text: var(--color-red);
 	--red-contrast: var(--color-white);
 	--red-surface: color-mix(in srgb, var(--red-text) 12%, white);
+	--red-border: color-mix(in srgb, var(--red-text) 40%, transparent);
 
 	/* Orange */
 	--orange-text: var(--color-orange);
-	--orange-contrast: var(--color-black);
+	--orange-contrast: var(--color-white);
 	--orange-surface: color-mix(in srgb, var(--orange-text) 12%, white);
+	--orange-border: color-mix(in srgb, var(--orange-text) 40%, transparent);
 
 	/* Yellow */
 	--yellow-text: var(--color-yellow);
 	--yellow-contrast: var(--color-black);
 	--yellow-surface: color-mix(in srgb, var(--yellow-text) 12%, white);
+	--yellow-border: color-mix(in srgb, var(--yellow-text) 40%, transparent);
 
 	/* Green */
 	--green-text: var(--color-green);
 	--green-contrast: var(--color-black);
 	--green-surface: color-mix(in srgb, var(--green-text) 12%, white);
+	--green-border: color-mix(in srgb, var(--green-text) 40%, transparent);
 
 	/* Cyan */
 	--cyan-text: var(--color-cyan);
 	--cyan-contrast: var(--color-black);
 	--cyan-surface: color-mix(in srgb, var(--cyan-text) 12%, white);
+	--cyan-border: color-mix(in srgb, var(--cyan-text) 40%, transparent);
 
 	/* Blue */
 	--blue-text: var(--color-blue);
 	--blue-contrast: var(--color-white);
 	--blue-surface: color-mix(in srgb, var(--blue-text) 12%, white);
+	--blue-border: color-mix(in srgb, var(--blue-text) 40%, transparent);
 
 	/* Purple */
 	--purple-text: var(--color-purple);
 	--purple-contrast: var(--color-white);
 	--purple-surface: color-mix(in srgb, var(--purple-text) 12%, white);
+	--purple-border: color-mix(in srgb, var(--purple-text) 40%, transparent);
 
 	/* Pink */
 	--pink-text: var(--color-pink);
 	--pink-contrast: var(--color-white);
 	--pink-surface: color-mix(in srgb, var(--pink-text) 12%, white);
+	--pink-border: color-mix(in srgb, var(--pink-text) 40%, transparent);
 }
 
 .primary {
@@ -66,6 +96,7 @@
 	--color-link: var(--primary-text);
 	--color-quiet: var(--primary-text);
 	--color-surface: var(--primary-surface);
+	--color-border: var(--primary-border);
 }
 
 .secondary {
@@ -74,6 +105,7 @@
 	--color-link: var(--secondary-text);
 	--color-quiet: var(--secondary-text);
 	--color-surface: var(--secondary-surface);
+	--color-border: var(--secondary-border);
 }
 
 .tertiary {
@@ -82,6 +114,7 @@
 	--color-link: var(--tertiary-text);
 	--color-quiet: var(--tertiary-text);
 	--color-surface: var(--tertiary-surface);
+	--color-border: var(--tertiary-border);
 }
 
 .quiet {
@@ -90,6 +123,7 @@
 	--color-link: var(--quiet-text);
 	--color-quiet: var(--quiet-text);
 	--color-surface: var(--quiet-surface);
+	--color-border: var(--quiet-border);
 }
 
 .red {
@@ -98,6 +132,7 @@
 	--color-link: var(--red-text);
 	--color-quiet: var(--red-text);
 	--color-surface: var(--red-surface);
+	--color-border: var(--red-border);
 }
 
 .orange {
@@ -106,6 +141,7 @@
 	--color-link: var(--orange-text);
 	--color-quiet: var(--orange-text);
 	--color-surface: var(--orange-surface);
+	--color-border: var(--orange-border);
 }
 
 .yellow {
@@ -114,6 +150,7 @@
 	--color-link: var(--yellow-text);
 	--color-quiet: var(--yellow-text);
 	--color-surface: var(--yellow-surface);
+	--color-border: var(--yellow-border);
 }
 
 .green {
@@ -122,6 +159,7 @@
 	--color-link: var(--green-text);
 	--color-quiet: var(--green-text);
 	--color-surface: var(--green-surface);
+	--color-border: var(--green-border);
 }
 
 .cyan {
@@ -130,6 +168,7 @@
 	--color-link: var(--cyan-text);
 	--color-quiet: var(--cyan-text);
 	--color-surface: var(--cyan-surface);
+	--color-border: var(--cyan-border);
 }
 
 .blue {
@@ -138,6 +177,7 @@
 	--color-link: var(--blue-text);
 	--color-quiet: var(--blue-text);
 	--color-surface: var(--blue-surface);
+	--color-border: var(--blue-border);
 }
 
 .purple {
@@ -146,6 +186,7 @@
 	--color-link: var(--purple-text);
 	--color-quiet: var(--purple-text);
 	--color-surface: var(--purple-surface);
+	--color-border: var(--purple-border);
 }
 
 .pink {
@@ -154,4 +195,5 @@
 	--color-link: var(--pink-text);
 	--color-quiet: var(--pink-text);
 	--color-surface: var(--pink-surface);
+	--color-border: var(--pink-border);
 }


### PR DESCRIPTION
## Summary

On narrow viewports the menu button used to scroll out of view, and opening/closing the drawer was split across two separate buttons. This reworks it into a single pinned toggle plus a dimming overlay.

- **Pinned toggle** — the menu button is `position: sticky` at the top of the content scroll area (`z-index` above page content, below the drawer), so it stays reachable while the content scrolls. It is right-aligned via `width: fit-content` + `margin-inline-start: auto`.
- **Single toggle button** — shows a burger when closed and a close (X) icon when open, driven by the drawer's open state. It carries the `cyan` colour variant only while closed.
- **Removed the in-sidebar close button** — the toggle now handles closing, so the separate `.close` button inside the drawer is gone.
- **Dimming overlay** — while the drawer is open, an overlay fades the rest of the page to `--color-overlay`; clicking anywhere on it closes the drawer.

### Notes

- The overlay is a `<button type="button">` (not a bare `<div>`) so the click-to-close target is keyboard- and lint-accessible; functionally it is the overlay described in the issue.
- `margin-inline-start: auto` (i.e. `margin: 0 0 0 auto`) is used to right-align the toggle — `margin: 0 0 auto 0` as literally written keeps it left-aligned, so I read that as a typo for the stated "aligned to the right" intent.

## Test plan

- [ ] `bun run test` passes
- [ ] Narrow viewport: the menu button stays pinned top-right while scrolling
- [ ] Clicking the button toggles burger ⇄ close icon and opens/closes the drawer
- [ ] The button is cyan when closed, not cyan when open
- [ ] The page dims behind the open drawer; clicking the dimmed area closes it

Closes #73

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta