### PR TITLE
feat: add Title component and decide heading sizes per component

### DIFF
--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -21,7 +21,7 @@ A few conventions run through every component (see also the React Components sec
 
 | Folder | What's inside |
 |---|---|
-| [block](/ui/block) | Block-level content — `Card`, `Section`, `Heading`, `Table`, `List`, `Prose`, `Figure`, `Flex` |
+| [block](/ui/block) | Block-level content — `Card`, `Section`, `Title`, `Heading`, `Table`, `List`, `Prose`, `Figure`, `Flex` |
 | [inline](/ui/inline) | Inline content — `Code`, `Strong`, `Emphasis`, `Link`, `Mark`, `Small` |
 | [misc](/ui/misc) | Cross-cutting pieces — `Markup`, `Tag`, `Status`, `Loading`, `Color`, `Catcher`, `Mapper` |
 
@@ -57,14 +57,14 @@ A few conventions run through every component (see also the React Components sec
 A minimal single-screen app:
 
 ```tsx
-import { App, CenteredLayout, Section, Heading, Paragraph } from "shelving/ui";
+import { App, CenteredLayout, Section, Title, Paragraph } from "shelving/ui";
 
 function HelloApp() {
   return (
     <App app="My app">
       <CenteredLayout>
         <Section narrow>
-          <Heading>Hello</Heading>
+          <Title>Hello</Title>
           <Paragraph>Welcome to the app.</Paragraph>
         </Section>
       </CenteredLayout>

--- a/modules/ui/block/Card.module.css
+++ b/modules/ui/block/Card.module.css
@@ -45,6 +45,11 @@
 		position: relative;
 		z-index: 2;
 	}
+
+	/* Headings render one size down inside a card — a page-level heading is oversized in this context. */
+	:where(& .heading) {
+		--heading-font-size: var(--size-large);
+	}
 }
 
 .overlay {

--- a/modules/ui/block/Card.module.css
+++ b/modules/ui/block/Card.module.css
@@ -45,11 +45,6 @@
 		position: relative;
 		z-index: 2;
 	}
-
-	/* Headings render one size down inside a card — a page-level heading is oversized in this context. */
-	:where(& .heading) {
-		--heading-font-size: var(--size-large);
-	}
 }
 
 .overlay {

--- a/modules/ui/block/Card.tsx
+++ b/modules/ui/block/Card.tsx
@@ -18,8 +18,8 @@ export interface CardProps extends ClickableProps {
  * - When `href` or `onClick` is set the card becomes navigable: a stretched overlay `<a>` / `<button>` covers the entire card while the children render normally inside.
  * - Real interactive elements inside the card (e.g. inline `<a>` links) stay clickable thanks to `position: relative; z-index: 2` rules in the stylesheet.
  *
- * @example <Card><Heading>Static</Heading></Card>
- * @example <Card href="/foo" title="Open foo"><Heading>Clickable</Heading></Card>
+ * @example <Card><Subheading>Static</Subheading></Card>
+ * @example <Card href="/foo" title="Open foo"><Subheading>Clickable</Subheading></Card>
  */
 export function Card({ children, href, onClick, title = "Open", ...props }: CardProps): ReactElement {
 	const overlay = (href || onClick) && <Clickable title={title} href={href} onClick={onClick} {...props} className={CARD_CSS.overlay} />;

--- a/modules/ui/block/Heading.module.css
+++ b/modules/ui/block/Heading.module.css
@@ -1,22 +1,19 @@
 .heading,
-.prose h1 {
+.prose h2 {
 	/* Box */
 	display: block;
 	inline-size: 100%;
 	margin-inline: 0;
-	margin-block: var(--heading-spacing, var(--space-normal));
+	/* `em` top margin scales with font-size, so larger headings get proportionally more space above them. */
+	margin-block-start: var(--heading-spacing-before, 1.5em);
+	margin-block-end: var(--heading-spacing, var(--space-normal));
 
 	/* Style */
 	font-family: var(--heading-font, var(--font-body));
 	font-weight: var(--heading-weight, var(--weight-strong));
 	line-height: var(--heading-leading, var(--leading));
 	color: var(--heading-color, var(--color-text));
-
-	/*
-	 * Default font-size — applies to h1 (the `<Heading>` default) and to `.prose h1`.
-	 * Per-level rules below override for `<Heading level="2-6">` cases.
-	 */
-	font-size: var(--heading-font-size, var(--size-xxxlarge));
+	font-size: var(--heading-font-size, var(--size-xxlarge));
 
 	/* Psuedo-classes */
 	&:first-child {
@@ -25,15 +22,4 @@
 	&:last-child {
 		margin-block-end: 0;
 	}
-}
-
-/* Per-level font-size scaling — `<Heading level="N">` sizes itself by its tag. */
-.heading:is(h2) {
-	font-size: var(--heading-font-size, var(--size-xxlarge));
-}
-.heading:is(h3) {
-	font-size: var(--heading-font-size, var(--size-xlarge));
-}
-.heading:is(h4, h5, h6) {
-	font-size: var(--heading-font-size, var(--size-large));
 }

--- a/modules/ui/block/Heading.tsx
+++ b/modules/ui/block/Heading.tsx
@@ -1,13 +1,23 @@
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { getModuleClass } from "../util/css.js";
 import styles from "./Heading.module.css";
 
+/** Props shared by `Title`, `Heading`, and `Subheading`. */
 export interface HeadingProps {
+	/**
+	 * Heading level (`1`–`6`) — sets the rendered `<h1>`–`<h6>` tag.
+	 * Avoid overriding this in practice: pick the component that matches the level — `Title` (`<h1>`), `Heading` (`<h2>`), or `Subheading` (`<h3>`) — so the visual size and the document outline stay in step.
+	 */
 	level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;
+	/** Heading content. */
 	children: ReactNode;
 }
 
-export function Heading({ level = "1", children, ...variants }: HeadingProps) {
+/**
+ * Section heading — renders an `<h2>`.
+ * - Sits between `Title` (`<h1>`) and `Subheading` (`<h3>`) in the heading hierarchy.
+ */
+export function Heading({ level = "2", children, ...variants }: HeadingProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;
 	return <Element className={getModuleClass(styles, "heading", variants)}>{children}</Element>;
 }

--- a/modules/ui/block/README.md
+++ b/modules/ui/block/README.md
@@ -31,10 +31,10 @@ Some block components ship multiple pieces intended to compose:
 ### Content card with a heading
 
 ```tsx
-import { Card, Heading, Paragraph } from "shelving/ui";
+import { Card, Paragraph, Subheading } from "shelving/ui";
 
 <Card href="/products/42" title="Open product">
-  <Heading level={2}>Widget Pro</Heading>
+  <Subheading>Widget Pro</Subheading>
   <Paragraph>The best widget on the market.</Paragraph>
 </Card>
 ```
@@ -56,7 +56,7 @@ import { Section, Heading, Definitions, Definition } from "shelving/ui";
 </Section>
 ```
 
-`<Subheading>` uses the same `level` prop as `<Heading>` but applies secondary typography styles — use it for in-section labels and panel titles.
+`<Title>`, `<Heading>`, and `<Subheading>` render `<h1>`, `<h2>`, and `<h3>` respectively — pick the component that matches the level rather than overriding it with the `level` prop. Use `<Subheading>` for card titles, in-section labels, and panel titles.
 
 ### Prose content from a renderer
 
@@ -73,12 +73,12 @@ Wrap `<Markup>` (or any component that emits raw HTML elements) in `<Prose>` to 
 ### Flex row of cards
 
 ```tsx
-import { Flex, Card, Heading } from "shelving/ui";
+import { Card, Flex, Subheading } from "shelving/ui";
 
 <Flex wrap>
   {products.map(p => (
     <Card key={p.id} href={`/products/${p.id}`}>
-      <Heading level={3}>{p.name}</Heading>
+      <Subheading>{p.name}</Subheading>
     </Card>
   ))}
 </Flex>

--- a/modules/ui/block/Subheading.module.css
+++ b/modules/ui/block/Subheading.module.css
@@ -1,22 +1,19 @@
 .subheading,
-.prose :is(h2, h3, h4, h5, h6) {
+.prose :is(h3, h4, h5, h6) {
 	/* Box */
 	display: block;
 	inline-size: 100%;
 	margin-inline: 0;
-	margin-block: var(--subheading-spacing, var(--space-normal));
+	/* `em` top margin scales with font-size, so larger headings get proportionally more space above them. */
+	margin-block-start: var(--subheading-spacing-before, 1.5em);
+	margin-block-end: var(--subheading-spacing, var(--space-normal));
 
 	/* Style */
 	font-family: var(--subheading-font, var(--font-body));
 	font-weight: var(--subheading-weight, var(--weight-strong));
 	line-height: var(--subheading-leading, var(--leading));
 	color: var(--subheading-color, var(--color-text));
-
-	/*
-	 * Default font-size — applies to h2 (the `<Subheading>` default).
-	 * Per-level rules below override for `<Subheading level="3-6">` cases and for `.prose` headings.
-	 */
-	font-size: var(--subheading-font-size, var(--size-xxlarge));
+	font-size: var(--subheading-font-size, var(--size-large));
 
 	/* Psuedo-classes */
 	&:first-child {
@@ -25,14 +22,4 @@
 	&:last-child {
 		margin-block-end: 0;
 	}
-}
-
-/* Per-level font-size scaling — `<Subheading level="N">` (and prose headings) size by tag. */
-.subheading:is(h3),
-.prose h3 {
-	font-size: var(--subheading-font-size, var(--size-xlarge));
-}
-.subheading:is(h4, h5, h6),
-.prose :is(h4, h5, h6) {
-	font-size: var(--subheading-font-size, var(--size-large));
 }

--- a/modules/ui/block/Subheading.tsx
+++ b/modules/ui/block/Subheading.tsx
@@ -1,10 +1,16 @@
+import type { ReactElement } from "react";
 import { getModuleClass } from "../util/css.js";
 import type { HeadingProps } from "./Heading.js";
 import styles from "./Subheading.module.css";
 
+/** Props for `Subheading` — identical to `HeadingProps`. */
 export type SubheadingProps = HeadingProps;
 
-export function Subheading({ level = "2", children, ...variants }: SubheadingProps) {
+/**
+ * Subsection heading — renders an `<h3>`.
+ * - Only marginally larger than body text; its bold weight is the main differentiator.
+ */
+export function Subheading({ level = "3", children, ...variants }: SubheadingProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;
 	return <Element className={getModuleClass(styles, "subheading", variants)}>{children}</Element>;
 }

--- a/modules/ui/block/Title.module.css
+++ b/modules/ui/block/Title.module.css
@@ -1,0 +1,25 @@
+.title,
+.prose h1 {
+	/* Box */
+	display: block;
+	inline-size: 100%;
+	margin-inline: 0;
+	/* `em` top margin scales with font-size, so larger headings get proportionally more space above them. */
+	margin-block-start: var(--title-spacing-before, 1.5em);
+	margin-block-end: var(--title-spacing, var(--space-normal));
+
+	/* Style */
+	font-family: var(--title-font, var(--font-body));
+	font-weight: var(--title-weight, var(--weight-strong));
+	line-height: var(--title-leading, var(--leading));
+	color: var(--title-color, var(--color-text));
+	font-size: var(--title-font-size, var(--size-xxxlarge));
+
+	/* Psuedo-classes */
+	&:first-child {
+		margin-block-start: 0;
+	}
+	&:last-child {
+		margin-block-end: 0;
+	}
+}

--- a/modules/ui/block/Title.tsx
+++ b/modules/ui/block/Title.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from "react";
+import { getModuleClass } from "../util/css.js";
+import type { HeadingProps } from "./Heading.js";
+import styles from "./Title.module.css";
+
+/** Props for `Title` — identical to `HeadingProps`. */
+export type TitleProps = HeadingProps;
+
+/**
+ * Page title — renders an `<h1>`.
+ * - The most prominent heading on a page; there should normally be exactly one.
+ */
+export function Title({ level = "1", children, ...variants }: TitleProps): ReactElement {
+	const Element: `h${typeof level}` = `h${level}`;
+	return <Element className={getModuleClass(styles, "title", variants)}>{children}</Element>;
+}

--- a/modules/ui/block/index.ts
+++ b/modules/ui/block/index.ts
@@ -15,4 +15,5 @@ export * from "./Prose.js";
 export * from "./Section.js";
 export * from "./Subheading.js";
 export * from "./Table.js";
+export * from "./Title.js";
 export * from "./Video.js";

--- a/modules/ui/docs/DirectoryCard.tsx
+++ b/modules/ui/docs/DirectoryCard.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
-import { Heading } from "../block/Heading.js";
 import { Prose } from "../block/Prose.js";
+import { Subheading } from "../block/Subheading.js";
 import { Markup } from "../misc/Markup.js";
 
 interface DirectoryCardProps extends DirectoryElementProps {
@@ -15,7 +15,7 @@ export function DirectoryCard({ path = "/", title, name, content }: DirectoryCar
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
-			<Heading level="3">{title ?? name}</Heading>
+			<Subheading>{title ?? name}</Subheading>
 			{content && (
 				<Prose>
 					<Markup>{content}</Markup>

--- a/modules/ui/docs/DocumentationCard.tsx
+++ b/modules/ui/docs/DocumentationCard.tsx
@@ -3,9 +3,9 @@ import type { DocumentationElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
 import { Flex } from "../block/Flex.js";
-import { Heading } from "../block/Heading.js";
 import { Preformatted } from "../block/Preformatted.js";
 import { Prose } from "../block/Prose.js";
+import { Subheading } from "../block/Subheading.js";
 import { Code } from "../inline/Code.js";
 import { Markup } from "../misc/Markup.js";
 import { DocumentationKind } from "./DocumentationKind.js";
@@ -19,12 +19,12 @@ export function DocumentationCard({ path = "/", title, name, kind, content, sign
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
-			<Heading level="3">
+			<Subheading>
 				<Flex left>
 					<Code>{title ?? name}</Code>
 					{kind && <DocumentationKind kind={kind} />}
 				</Flex>
-			</Heading>
+			</Subheading>
 			{signatures?.map(sig => (
 				<Preformatted key={sig}>{sig}</Preformatted>
 			))}

--- a/modules/ui/docs/FileCard.tsx
+++ b/modules/ui/docs/FileCard.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
-import { Heading } from "../block/Heading.js";
 import { Prose } from "../block/Prose.js";
+import { Subheading } from "../block/Subheading.js";
 import { Markup } from "../misc/Markup.js";
 
 interface FileCardProps extends FileElementProps {
@@ -15,7 +15,7 @@ export function FileCard({ path = "/", title, name, content }: FileCardProps): R
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
-			<Heading level="3">{title ?? name}</Heading>
+			<Subheading>{title ?? name}</Subheading>
 			{content && (
 				<Prose>
 					<Markup>{content}</Markup>


### PR DESCRIPTION
## Summary

Headings inside docs cards rendered too large. The first attempt here had `Card.module.css` override `--heading-font-size` on a descendant `.heading` — that crosses module concerns and doesn't work, since `.heading` gets a module-scoped suffix `Card.module.css` can't target. That change is reverted; this fixes it properly at the component level.

### A three-component heading hierarchy

- **New `Title` component** — renders `<h1>`, default size `--size-xxxlarge`.
- **`Heading`** — now renders `<h2>`, default size `--size-xxlarge` (two scale steps above a subheading, for clear contrast).
- **`Subheading`** — now renders `<h3>`, default size `--size-large` — only marginally above body text, with bold weight as the main differentiator.

All three share `HeadingProps` and keep a `level` prop to override the rendered tag. Font size is fixed per component — `level` only changes the semantic tag, not the visual size — and its JSDoc says to avoid overriding it in practice (pick the component that matches the level).

### Heading margins

`margin-block-start` now defaults to `1.5em` — em-based, so larger headings get proportionally more breathing room above — overridable via `--title-spacing-before` / `--heading-spacing-before` / `--subheading-spacing-before`. `margin-block-end` stays `--space-normal`, overridable via `--title-spacing` / `--heading-spacing` / `--subheading-spacing`. The `:first-child` / `:last-child` rules still strip these at container edges.

### Cards

`DocumentationCard`, `FileCard`, and `DirectoryCard` now use `Subheading` instead of `<Heading level="3">`. `block` and `ui` READMEs updated to match the new model.

### Notes for review

- Prose headings stay coupled into each heading CSS file (the existing `Heading.module.css` pattern): `.prose h1` → title size, `.prose h2` → heading size, `.prose :is(h3,h4,h5,h6)` → subheading size. Decoupling those into `Prose.module.css` would be a separate change.
- `Heading`'s default level changes from `1` to `2`; `Subheading`'s from `2` to `3`. No existing in-repo callers pass a bare `<Heading>`/`<Subheading>`, so nothing in the repo breaks — but this is a behaviour change for external consumers (kept within the v0 non-major release flow).

## Test plan

- [ ] `bun run test` passes (type, lint, 1034 unit tests green)
- [ ] Card titles render at subheading size
- [ ] Page/section/subsection headings show clear size contrast
- [ ] Larger headings have proportionally more space above them

Closes #74

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta