### PR TITLE
fix: make inline code inherit weight and use a modern mono stack

### DIFF
--- a/modules/ui/app/App.module.css
+++ b/modules/ui/app/App.module.css
@@ -14,7 +14,7 @@
 
 	/* Font faces */
 	--font-sans: system-ui;
-	--font-mono: "Courier New", "Courier", monospace;
+	--font-mono: ui-monospace, "SF Mono", "Consolas", "Menlo", monospace;
 	--font-serif: "Palatino", "Garamond", serif;
 
 	/* Semantic font faces */

--- a/modules/ui/inline/Code.module.css
+++ b/modules/ui/inline/Code.module.css
@@ -10,6 +10,6 @@
 	background-color: var(--color-surface);
 
 	/* Typography */
-	font-weight: var(--weight-normal);
+	font-weight: inherit;
 	font-size: var(--size-smaller);
 }


### PR DESCRIPTION
## Summary

Two related typography problems with inline `<code>`:

1. **Code didn't inherit bold.** `Code.module.css` hard-coded `font-weight: var(--weight-normal)` (400), so a `<code>` inside a heading stayed un-bold against bold surrounding text — visible on every docs card title. Changed to `font-weight: inherit` so code goes bold in bold contexts and stays normal in body text.
2. **Monospace rendered too thin.** The default `--font-mono` stack (`"Courier New", "Courier", monospace`) renders light next to body text. Switched to a modern system stack: `ui-monospace, "SF Mono", "Consolas", "Menlo", monospace`.

## Test plan

- [ ] `bun run test` passes
- [ ] Inline code inside headings renders bold; body code stays normal
- [ ] Code and code blocks render with the heavier modern monospace font

Closes #76

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta

---
_Generated by [Claude Code](https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta)_