### PR TITLE
fix: default Menu font size to normal

### DIFF
--- a/modules/ui/menu/Menu.module.css
+++ b/modules/ui/menu/Menu.module.css
@@ -9,7 +9,7 @@
 
 	/* Typography */
 	font-family: var(--menu-font, var(--font-body));
-	font-size: var(--menu-size, var(--size-small));
+	font-size: var(--menu-size, var(--size-normal));
 	line-height: var(--menu-leading, var(--leading-normal));
 	color: var(--menu-color-text, var(--color-quiet));
 }


### PR DESCRIPTION
## Summary

The docs sidebar navigation rendered smaller than normal body text. `Menu.module.css` defaulted `font-size` to `var(--menu-size, var(--size-small))` — `--size-small` is ~0.8x the base size.

The compact small default is wrong: a `Menu` should be normal body size. Changed the `--menu-size` fallback from `--size-small` to `--size-normal`, so every `Menu` (the sidebar included) renders at normal size. The `--menu-size` override hook is unchanged for any caller that genuinely wants a compact menu.

(Earlier this PR scoped a `--menu-size` override to `.sidebar`; per review that was the wrong fix — the `Menu` default itself was wrong, so this corrects the default.)

## Test plan

- [ ] `bun run test` passes (type, lint, 1035 unit tests green)
- [ ] Sidebar navigation — and any other `Menu` — renders at normal body size

Closes #77

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta