### PR TITLE
fix: show the symbol title on DocumentationPage

### DIFF
--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { DocumentationElementProps } from "../../util/element.js";
 import type { AbsolutePath } from "../../util/path.js";
 import { Definition, Definitions } from "../block/Definitions.js";
+import { Flex } from "../block/Flex.js";
 import { Heading } from "../block/Heading.js";
 import { Preformatted } from "../block/Preformatted.js";
 import { Prose } from "../block/Prose.js";
@@ -38,8 +39,12 @@ export function DocumentationPage({
 	const path = (url?.pathname ?? "/") as AbsolutePath;
 	return (
 		<Page title={title ?? name} description={description}>
-			<Title>{title ?? name}</Title>
-			{kind && <DocumentationKind kind={kind} />}
+			<Title>
+				<Flex left>
+					{title ?? name}
+					{kind && <DocumentationKind kind={kind} />}
+				</Flex>
+			</Title>
 			{signatures?.map(sig => (
 				<Preformatted key={sig}>{sig}</Preformatted>
 			))}

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -37,6 +37,7 @@ export function DocumentationPage({
 	const path = (url?.pathname ?? "/") as AbsolutePath;
 	return (
 		<Page title={title ?? name} description={description}>
+			<Heading>{title ?? name}</Heading>
 			{kind && <DocumentationKind kind={kind} />}
 			{signatures?.map(sig => (
 				<Preformatted key={sig}>{sig}</Preformatted>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -6,6 +6,7 @@ import { Heading } from "../block/Heading.js";
 import { Preformatted } from "../block/Preformatted.js";
 import { Prose } from "../block/Prose.js";
 import { Section } from "../block/Section.js";
+import { Title } from "../block/Title.js";
 import { Code } from "../inline/Code.js";
 import { Markup } from "../misc/Markup.js";
 import { requireMeta } from "../misc/MetaContext.js";
@@ -37,7 +38,7 @@ export function DocumentationPage({
 	const path = (url?.pathname ?? "/") as AbsolutePath;
 	return (
 		<Page title={title ?? name} description={description}>
-			<Heading>{title ?? name}</Heading>
+			<Title>{title ?? name}</Title>
 			{kind && <DocumentationKind kind={kind} />}
 			{signatures?.map(sig => (
 				<Preformatted key={sig}>{sig}</Preformatted>
@@ -49,7 +50,7 @@ export function DocumentationPage({
 			)}
 			{params?.length && (
 				<Section>
-					<Heading level="2">Parameters</Heading>
+					<Heading>Parameters</Heading>
 					<Definitions row>
 						{params.map(({ name, type = DEFAULT_TYPE, description = "", optional }) => (
 							<Definition
@@ -69,7 +70,7 @@ export function DocumentationPage({
 			)}
 			{returns?.length && (
 				<Section>
-					<Heading level="2">Returns</Heading>
+					<Heading>Returns</Heading>
 					<Definitions row>
 						{returns.map(({ type = DEFAULT_TYPE, description = "" }) => (
 							<Definition key={`${type}-${description}`} term={<Code>{type}</Code>}>
@@ -81,7 +82,7 @@ export function DocumentationPage({
 			)}
 			{throws?.length && (
 				<Section>
-					<Heading level="2">Throws</Heading>
+					<Heading>Throws</Heading>
 					<Definitions row>
 						{throws.map(({ type = DEFAULT_TYPE, description = "" }) => (
 							<Definition key={`${type}-${description}`} term={<Code>{type}</Code>}>
@@ -93,7 +94,7 @@ export function DocumentationPage({
 			)}
 			{examples?.length && (
 				<Section>
-					<Heading level="2">Examples</Heading>
+					<Heading>Examples</Heading>
 					{examples.map(({ description }) => (
 						<Preformatted key={description}>{description}</Preformatted>
 					))}


### PR DESCRIPTION
## Summary

On a documentation page (e.g. `/schema/ArraySchema/ArraySchema`) the class/symbol name was never shown as a visible heading. `DocumentationPage` passed the name to `<Page title>`, but `Page` only feeds `title` into `<Head>` — it sets the document `<title>` and renders nothing visible.

`DocumentationPage` now renders the symbol name as a visible heading:

- The symbol title uses the new **`Title`** component (`<h1>`).
- The section headings (Parameters, Returns, Throws, Examples) use a bare `Heading` (now `<h2>` by default), dropping the redundant explicit `level="2"`.

## Stacked on #89

This PR uses the `Title` component introduced in #89, so its base branch is `claude/fix-ui-74` and the diff shows only the `DocumentationPage` change. **Merge #89 first** — GitHub will then retarget this PR to `main` automatically (it will need a rebase onto `main` once #89 lands).

## Test plan

- [ ] `bun run test` passes (type, lint, 1034 unit tests green)
- [ ] A documentation page shows the symbol name as a visible `<h1>` title
- [ ] Section headings render as `<h2>`

Closes #80

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta