### PR TITLE
fix: pass current path to DirectoryPage cards

### DIFF
--- a/modules/ui/docs/DirectoryCard.tsx
+++ b/modules/ui/docs/DirectoryCard.tsx
@@ -7,11 +7,11 @@ import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
 
 interface DirectoryCardProps extends DirectoryElementProps {
-	path?: AbsolutePath | undefined;
+	path: AbsolutePath;
 }
 
 /** Card renderer for a `tree-directory` element. */
-export function DirectoryCard({ path = "/", title, name, content }: DirectoryCardProps): ReactNode {
+export function DirectoryCard({ path, name, title, content }: DirectoryCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>

--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
-import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
 import { requireMeta } from "../misc/MetaContext.js";
@@ -10,7 +9,7 @@ import { TreeCards } from "../tree/TreeCards.js";
 /** Page renderer for a `tree-directory` element — shows title, content, and child cards. */
 export function DirectoryPage({ title, name, description, content, children }: DirectoryElementProps): ReactNode {
 	const { url } = requireMeta();
-	const path = (url?.pathname ?? "/") as AbsolutePath;
+	const path = url?.pathname ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
 			{content && (

--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,12 +1,16 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
+import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
+import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
 import { TreeCards } from "../tree/TreeCards.js";
 
 /** Page renderer for a `tree-directory` element — shows title, content, and child cards. */
 export function DirectoryPage({ title, name, description, content, children }: DirectoryElementProps): ReactNode {
+	const { url } = requireMeta();
+	const path = (url?.pathname ?? "/") as AbsolutePath;
 	return (
 		<Page title={title ?? name} description={description}>
 			{content && (
@@ -14,7 +18,7 @@ export function DirectoryPage({ title, name, description, content, children }: D
 					<Markup>{content}</Markup>
 				</Prose>
 			)}
-			<TreeCards>{children}</TreeCards>
+			<TreeCards path={path}>{children}</TreeCards>
 		</Page>
 	);
 }

--- a/modules/ui/docs/DocumentationCard.tsx
+++ b/modules/ui/docs/DocumentationCard.tsx
@@ -11,11 +11,11 @@ import { Markup } from "../misc/Markup.js";
 import { DocumentationKind } from "./DocumentationKind.js";
 
 interface DocumentationCardProps extends DocumentationElementProps {
-	path?: AbsolutePath | undefined;
+	path: AbsolutePath;
 }
 
 /** Card renderer for a `tree-documentation` element. */
-export function DocumentationCard({ path = "/", title, name, kind, content, signatures }: DocumentationCardProps): ReactNode {
+export function DocumentationCard({ path, title, name, kind, content, signatures }: DocumentationCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>

--- a/modules/ui/docs/FileCard.tsx
+++ b/modules/ui/docs/FileCard.tsx
@@ -7,11 +7,11 @@ import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
 
 interface FileCardProps extends FileElementProps {
-	path?: AbsolutePath | undefined;
+	path: AbsolutePath;
 }
 
 /** Card renderer for a `tree-file` element. */
-export function FileCard({ path = "/", title, name, content }: FileCardProps): ReactNode {
+export function FileCard({ path, name, title, content }: FileCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>

--- a/modules/ui/docs/FilePage.tsx
+++ b/modules/ui/docs/FilePage.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
-import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Markup } from "../misc/Markup.js";
 import { requireMeta } from "../misc/MetaContext.js";
@@ -10,7 +9,7 @@ import { TreeCards } from "../tree/TreeCards.js";
 /** Page renderer for a `tree-file` element — shows title, content, and child code symbols. */
 export function FilePage({ title, name, description, content, children }: FileElementProps): ReactNode {
 	const { url } = requireMeta();
-	const path = (url?.pathname ?? "/") as AbsolutePath;
+	const path = url?.pathname ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
 			{content && (

--- a/modules/ui/tree/TreeCards.tsx
+++ b/modules/ui/tree/TreeCards.tsx
@@ -8,7 +8,7 @@ import { createMapper } from "../misc/Mapper.js";
 
 /** Extras threaded through `TreeCardMapper` to every card — currently just the parent URL path. */
 export interface TreeCardExtras {
-	/** URL path of the parent element. Each card computes its own path as `path + mapped.key`. Defaults to `/`. */
+	/** URL path of the parent element. Each card computes its own path as `path + mapped.name`. Defaults to `/`. */
 	readonly path?: AbsolutePath | undefined;
 }
 
@@ -22,14 +22,14 @@ export const [TreeCardMapping, TreeCardMapper] = createMapper<TreeCardExtras>({
 export interface TreeCardsProps {
 	/** The children to render as cards. */
 	readonly children?: TreeElements;
-	/** URL path of the parent element. Each card appends its own key to compute its href. */
+	/** URL path of the parent element. Each card appends its own name to compute its href. */
 	readonly path?: AbsolutePath | undefined;
 }
 
 /**
  * Render a list of tree elements as a stack of cards.
  * - Each element is dispatched via `<TreeCardMapper>` to its registered renderer.
- * - `path` is threaded through to each card so it can compute its href as `path + key`.
+ * - `path` is threaded through to each card so it can compute its href as `path + name`.
  * - To override the renderer for a specific element type, wrap in `<TreeCardMapping mapping={…}>`.
  */
 export function TreeCards({ children, path }: TreeCardsProps): ReactNode {

--- a/modules/ui/tree/TreeCards.tsx
+++ b/modules/ui/tree/TreeCards.tsx
@@ -9,7 +9,7 @@ import { createMapper } from "../misc/Mapper.js";
 /** Extras threaded through `TreeCardMapper` to every card — currently just the parent URL path. */
 export interface TreeCardExtras {
 	/** URL path of the parent element. Each card computes its own path as `path + mapped.name`. Defaults to `/`. */
-	readonly path?: AbsolutePath | undefined;
+	readonly path: AbsolutePath;
 }
 
 /** Mapping + Mapper pair for tree cards — wrap children in `<TreeCardMapping>` to override. */
@@ -32,6 +32,6 @@ export interface TreeCardsProps {
  * - `path` is threaded through to each card so it can compute its href as `path + name`.
  * - To override the renderer for a specific element type, wrap in `<TreeCardMapping mapping={…}>`.
  */
-export function TreeCards({ children, path }: TreeCardsProps): ReactNode {
+export function TreeCards({ path = "/", children }: TreeCardsProps): ReactNode {
 	return <TreeCardMapper path={path}>{walkElements(children)}</TreeCardMapper>;
 }

--- a/modules/ui/tree/TreeMenu.tsx
+++ b/modules/ui/tree/TreeMenu.tsx
@@ -12,7 +12,7 @@ export const MENU_QUERY: Query<{ type: string }> = { type: ["tree-directory", "t
 /** Extras threaded through `TreeMenuMapper` to every menu item — the parent's URL path. */
 interface TreeMenuExtras {
 	/** URL path of the parent element. Each item appends its own `name` to compute its own path. Defaults to `/`. */
-	readonly path?: AbsolutePath | undefined;
+	readonly path: AbsolutePath;
 }
 
 /**
@@ -54,7 +54,7 @@ export interface TreeMenuProps {
  * - To customise renderers for specific types, wrap in `<TreeMenuMapping mapping={…}>`.
  * - Only directories and files appear — code symbols are kept off the navigation.
  */
-export function TreeMenu({ tree, path = "/" }: TreeMenuProps): ReactNode {
+export function TreeMenu({ path = "/", tree }: TreeMenuProps): ReactNode {
 	return (
 		<Menu>
 			<TreeMenuMapper path={path}>{queryElements(tree.props.children, MENU_QUERY)}</TreeMenuMapper>


### PR DESCRIPTION
## Summary

Clicking a card on a directory / module index page (e.g. `/schema`) navigated to a non-existent URL and showed the "Element not found" error.

Card hrefs are computed as `joinPath(path, name)`, where `path` is threaded in from the page via `<TreeCards path={…}>`. `FilePage` and `DocumentationPage` both pass the current page path, but `DirectoryPage` rendered `<TreeCards>` with **no `path`** — so cards fell back to the `TreeCards` default `path = "/"` and linked to e.g. `/ArraySchema` instead of `/schema/ArraySchema`, which can't be resolved.

`DirectoryPage` now resolves the current path from `requireMeta()` and threads it through, exactly like `FilePage` / `DocumentationPage`.

Also corrects `TreeCards` docstrings/comments that said cards append their `key` — the card code (and `resolveElementPath` / `getElementPaths`) all key off `name`.

## Test plan

- [ ] `bun run test` passes
- [ ] Cards on a directory page (e.g. `/schema`) link to the correct nested URL

Closes #81

https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta

---
_Generated by [Claude Code](https://claude.ai/code/session_0179P27DZjsrkrSE3u8Qufta)_