### PR TITLE
fix: set title on extracted documentation tokens

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -29,6 +29,7 @@ export function add(a: number, b: number): number {
 				props: {
 					kind: "function",
 					name: "add",
+					title: "add()",
 					content: "Add two numbers together.",
 					signatures: ["(a: number, b: number) => number"],
 				},
@@ -44,7 +45,7 @@ export const MAX_RETRIES: number = 3;
 `),
 		);
 		expect(element.props.children).toMatchObject([
-			{ type: "tree-documentation", props: { kind: "constant", name: "MAX_RETRIES", signatures: ["number"] } },
+			{ type: "tree-documentation", props: { kind: "constant", name: "MAX_RETRIES", title: "MAX_RETRIES", signatures: ["number"] } },
 		]);
 	});
 
@@ -63,13 +64,14 @@ export class Store {
 		);
 		const children = element.props.children as unknown[];
 		expect(children).toHaveLength(1);
-		const cls = children[0] as { type: string; props: { kind: string; name: string; children: unknown[] } };
+		const cls = children[0] as { type: string; props: { kind: string; name: string; title: string; children: unknown[] } };
 		expect(cls.type).toBe("tree-documentation");
 		expect(cls.props.kind).toBe("class");
 		expect(cls.props.name).toBe("Store");
+		expect(cls.props.title).toBe("Store");
 		expect(cls.props.children).toMatchObject([
-			{ type: "tree-documentation", props: { kind: "property", name: "value", signatures: ["string"] } },
-			{ type: "tree-documentation", props: { kind: "method", name: "set" } },
+			{ type: "tree-documentation", props: { kind: "property", name: "value", title: "value", signatures: ["string"] } },
+			{ type: "tree-documentation", props: { kind: "method", name: "set", title: "set()" } },
 		]);
 	});
 
@@ -83,7 +85,9 @@ export interface ThingOptions {
 }
 `),
 		);
-		expect(element.props.children).toMatchObject([{ type: "tree-documentation", props: { kind: "interface", name: "ThingOptions" } }]);
+		expect(element.props.children).toMatchObject([
+			{ type: "tree-documentation", props: { kind: "interface", name: "ThingOptions", title: "ThingOptions" } },
+		]);
 	});
 
 	test("extracts exported type alias", async () => {
@@ -94,7 +98,10 @@ export type NullableString = string | null;
 `),
 		);
 		expect(element.props.children).toMatchObject([
-			{ type: "tree-documentation", props: { kind: "type", name: "NullableString", signatures: ["string | null"] } },
+			{
+				type: "tree-documentation",
+				props: { kind: "type", name: "NullableString", title: "NullableString", signatures: ["string | null"] },
+			},
 		]);
 	});
 
@@ -148,11 +155,47 @@ export function first<T>(arr: T[]): T | undefined {
 		expect(element.props.content).toBe("This module handles array utilities.");
 	});
 
-	test("leaves title undefined (no confident source for a TS source file)", async () => {
+	test("leaves the file element title undefined (no confident source for a TS source file)", async () => {
 		const element = await extractor.extract(file("export const X = 1;", "/tmp/array.ts"));
 		expect(element.props.title).toBeUndefined();
 		expect(element.props.name).toBe("array");
 		expect(element.key).toBe("array");
+	});
+
+	test("sets title with () for functions and methods, bare name for other kinds", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A function. */
+export function doThing(): void {}
+/** A constant. */
+export const VALUE = 1;
+/** A type. */
+export type Thing = string;
+/** A class. */
+export class Widget {
+	/** A property. */
+	size: number;
+	/** A method. */
+	resize(): void {}
+}
+`),
+		);
+		expect(element.props.children).toMatchObject([
+			{ props: { kind: "function", name: "doThing", title: "doThing()" } },
+			{ props: { kind: "constant", name: "VALUE", title: "VALUE" } },
+			{ props: { kind: "type", name: "Thing", title: "Thing" } },
+			{
+				props: {
+					kind: "class",
+					name: "Widget",
+					title: "Widget",
+					children: [
+						{ props: { kind: "property", name: "size", title: "size" } },
+						{ props: { kind: "method", name: "resize", title: "resize()" } },
+					],
+				},
+			},
+		]);
 	});
 
 	test("merges overloaded function declarations into one element with multiple signatures", async () => {
@@ -170,6 +213,7 @@ export function add(a: any, b: any): any { return a + b; }
 			type: "tree-documentation",
 			props: {
 				name: "add",
+				title: "add()",
 				kind: "function",
 				signatures: ["(a: number, b: number) => number", "(a: string, b: string) => string", "(a: any, b: any) => any"],
 			},

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -17,7 +17,8 @@ import { FileExtractor } from "./FileExtractor.js";
  * - Extracts exported, public, non-`_`-prefixed declarations as `tree-documentation` children.
  * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`.
  * - Top-of-file JSDoc comment becomes the file's `content`.
- * - Does not set `title` — TS source files have no confident title source. The renderer falls back to `name`.
+ * - Sets `title` on every `tree-documentation` child — `name()` for functions and methods, `name` for other kinds.
+ * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
  */
 export class TypescriptExtractor extends FileExtractor {
 	override extractProps(name: string, text: string): Partial<FileElementProps> & { name: string } {
@@ -33,8 +34,8 @@ export class TypescriptExtractor extends FileExtractor {
 			byKey.set(element.key, existing ? _mergeOverloads(existing, element) : element);
 		}
 
-		// No `title` — TS source files don't have a confident title source (the filename isn't one).
-		// The renderer falls back to `name` when displaying.
+		// The file element itself gets no `title` — a TS source file has no confident title source (the filename isn't one),
+		// so renderers fall back to `name`. The `tree-documentation` children each carry their own `title`.
 		return { name, content, children: Array.from(byKey.values()) };
 	}
 }
@@ -106,6 +107,8 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 		key: requireSlug(name),
 		props: {
 			name,
+			// Functions read as callable with `()`; other kinds use the bare name.
+			title: kind === "function" ? `${name}()` : name,
 			kind,
 			content: _buildJSDocContent(jsDoc?.description, jsDoc?.unhandled),
 			signatures: signature ? [signature] : undefined,
@@ -244,7 +247,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile): Docum
 				members.push({
 					type: "tree-documentation",
 					key,
-					props: { name, content, kind: "method", signatures: [signature] },
+					props: { name, title: `${name}()`, content, kind: "method", signatures: [signature] },
 				});
 			}
 		} else if (ts.isPropertyDeclaration(member) || ts.isPropertySignature(member)) {
@@ -252,7 +255,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile): Docum
 			members.push({
 				type: "tree-documentation",
 				key: requireSlug(name),
-				props: { name, content, kind: "property", signatures: type ? [type] : undefined },
+				props: { name, title: name, content, kind: "property", signatures: type ? [type] : undefined },
 			});
 		}
 	}


### PR DESCRIPTION
TypescriptExtractor now sets `title` on every `tree-documentation`
element — `name()` for functions and methods, the bare `name` for
other kinds — so renderers display callables as such at a glance.

Closes #83

https://claude.ai/code/session_01Gu6yMa2vbG7afuMDmqE9nA