### PR TITLE
Fix base URL handling for preview deployments

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: build (preview)
         if: github.event_name == 'pull_request'
         run: APP_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}" bun run docs:build
+      # `keep_files: true` leaves every existing `pr-<number>/` preview untouched. Do NOT add
+      # `exclude_assets: pr-*` here — peaceiris's `exclude_assets` runs `rm -rf` on matching
+      # paths in the publish branch, so it would delete every PR preview on each main deploy.
       - name: deploy (main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
@@ -51,7 +54,6 @@ jobs:
           publish_dir: ./.build/docs
           publish_branch: docs
           keep_files: true
-          exclude_assets: pr-*
       - name: deploy (preview)
         if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/env.ts
+++ b/docs/env.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import { requireURL } from "../modules/util/index.js";
+import { requireBaseURL } from "../modules/util/index.js";
 import type { AbsolutePath } from "../modules/util/path.js";
 
 export const DOCS_DIR = resolve(import.meta.dir) as AbsolutePath;
@@ -10,4 +10,7 @@ export const OUTPUT_DIR = resolve(ROOT_DIR, ".build/docs") as AbsolutePath;
 export const APP_TITLE = "Shelving";
 export const APP_DESCRIPTION = "TypeScript data toolkit";
 export const APP_LANGUAGE = "en";
-export const APP_URL = requireURL(process.env.APP_URL ?? "http://localhost:3456");
+// `APP_URL` is the site root, so it must end in `/` — otherwise the `<base href>` tag and
+// site-root-relative links resolve against its parent directory and drop the final path
+// segment (e.g. the `/pr-<number>/` preview subfolder). `requireBaseURL` guarantees the slash.
+export const APP_URL = requireBaseURL(process.env.APP_URL ?? "http://localhost:3456", requireBaseURL);


### PR DESCRIPTION
## Summary
Fixes base URL configuration to ensure preview deployments work correctly by guaranteeing trailing slashes, and removes a problematic `exclude_assets` configuration that would delete all PR previews during main branch deployments.

## Changes
- **docs/env.ts**: 
  - Renamed `requireURL` to `requireBaseURL` to better reflect its purpose of ensuring a trailing slash
  - Added explanatory comment clarifying why the trailing slash is critical for `<base href>` tag resolution and site-root-relative links in preview subdirectories (e.g., `/pr-<number>/`)
  - Updated `APP_URL` export to use the renamed function

- **.github/workflows/docs.yaml**:
  - Removed `exclude_assets: pr-*` from the main branch deployment step
  - Added detailed comment explaining why this exclusion was problematic: peaceiris's `exclude_assets` uses `rm -rf` on matching paths in the publish branch, which would delete every PR preview during each main deploy
  - Kept `keep_files: true` to preserve existing PR preview directories

## Implementation Details
The trailing slash requirement ensures that when the site is deployed to a subdirectory like `https://owner.github.io/repo/pr-123/`, relative and site-root-relative links resolve correctly. Without the trailing slash, the `<base href>` tag would resolve against the parent directory, causing path segments to be dropped.

https://claude.ai/code/session_01FMULLktnA2XN2UrVtew6hD