### PR TITLE
fix(ui): lighten cards and sidebar so inset surfaces have contrast

### DIFF
--- a/modules/ui/block/Card.module.css
+++ b/modules/ui/block/Card.module.css
@@ -5,12 +5,12 @@
 	margin-block: var(--card-spacing, var(--space-normal));
 
 	/* Style */
-	background: var(--card-color-bg, var(--color-surface));
+	background: var(--card-color-bg, var(--color-bg));
 	border: var(--card-border, var(--stroke-normal)) solid var(--card-color-border, var(--color-border));
 	padding: var(--card-padding, var(--space-normal));
 	color: var(--card-color-text, var(--color-text));
 	border-radius: var(--card-radius, var(--radius-normal));
-	box-shadow: var(--card-shadow, none);
+	box-shadow: var(--card-shadow, var(--shadow-xsmall));
 	transition: border-color var(--duration-fast);
 
 	/* Psuedo-classes */

--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -23,7 +23,7 @@
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	padding: var(--space-normal);
-	background: var(--sidebar-layout-bg, var(--color-surface));
+	background: var(--sidebar-layout-bg, var(--color-bg));
 	border-right: 1px solid var(--color-border);
 }
 


### PR DESCRIPTION
## Summary

Cards, the sidebar, and inset detail elements (inline `<code>`, buttons, notices, nested cards) all shared the same `--color-surface` token — a faint grey — so a grey element inside a grey card had nothing separating it.

This moves cards and the sidebar onto the page background and keeps `--color-surface` for the inset elements, which now stand out.

- `Card.module.css` — background fallback `--color-surface` → `--color-bg`; default `--card-shadow` `none` → `--shadow-xsmall` so white-on-white cards still read as raised (alongside the existing border).
- `SidebarLayout.module.css` — background fallback `--color-surface` → `--color-bg`.

`--color-surface` is left untouched as the inset/detail surface for `Code`, `Preformatted`, buttons, and `Notice`. Both `--card-color-bg` / `--card-shadow` / `--sidebar-layout-bg` override hooks are preserved.

Menu hover (`color-mix(--color-surface 60%)`) and active (`--color-surface`) states were checked — both still read against the now-white sidebar.

Closes #79

## Test plan

- [x] `bun run fix` clean
- [x] `bun run docs:build` succeeds (2824 pages)
- [ ] Visually confirm card / sidebar / nested-card contrast in a browser

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV

---
_Generated by [Claude Code](https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV)_