### PR TITLE
fix(ui): give Notice a fixed two-zone layout with an actions row

### DIFF
--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -93,9 +93,8 @@ export interface ErrorNoticeProps extends ErrorComponentProps {}
 export function ErrorNotice({ reason }: ErrorNoticeProps): ReactElement {
 	const message = getMessage(reason) ?? "Unknown error";
 	return (
-		<Notice status="error">
-			<p>{message}</p>
-			<RetryButton small fit />
+		<Notice status="error" actions={<RetryButton small />}>
+			{message}
 		</Notice>
 	);
 }

--- a/modules/ui/notice/Notice.module.css
+++ b/modules/ui/notice/Notice.module.css
@@ -1,5 +1,8 @@
 .notice {
-	/* Box */
+	/* Box — a vertical stack: the message row, then the actions row. */
+	display: flex;
+	flex-direction: column;
+	gap: var(--notice-gap, var(--space-small));
 	border-radius: var(--notice-radius, var(--radius-xsmall));
 	border: var(--notice-border, var(--stroke-normal)) solid var(--notice-color-border, var(--color-quiet));
 	padding: var(--notice-padding, var(--space-small));
@@ -12,4 +15,36 @@
 	font-size: var(--notice-size, var(--size-normal));
 	font-weight: var(--notice-weight, var(--weight-strong));
 	text-align: start;
+}
+
+/* The icon and the message always sit beside each other on one row. */
+.body {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--notice-gap, var(--space-small));
+}
+
+/* The message grows to fill the row beside the icon. */
+.message {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+}
+
+/* Keep the icon at its intrinsic size — it never grows or shrinks. */
+.body > :where(svg, [data-slot="icon"]) {
+	flex: 0 0 auto;
+}
+
+/* Actions (e.g. buttons) get their own row below the message. */
+.actions {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: var(--notice-gap, var(--space-small));
+}
+
+/* Drop the actions row entirely when it has nothing to show (e.g. a retry button with no handler). */
+.actions:empty {
+	display: none;
 }

--- a/modules/ui/notice/Notice.tsx
+++ b/modules/ui/notice/Notice.tsx
@@ -1,40 +1,52 @@
 import type { ReactElement, ReactNode } from "react";
 import { BLOCK_CLASS } from "../block/Block.js";
-import { FLEX_CSS, type FlexVariants } from "../block/Flex.js";
 import { type ColorVariants, getColorClass } from "../misc/Color.js";
 import { getStatusClass, type Status } from "../misc/Status.js";
 import { StatusIcon } from "../misc/StatusIcon.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import NOTICE_CSS from "./Notice.module.css";
 
-export interface NoticeProps extends FlexVariants, ColorVariants {
+export interface NoticeProps extends ColorVariants {
 	/** Status for the notice. */
 	status?: Status | undefined;
-	/** Children for the notice. */
+	/** Message content for the notice. */
 	children?: ReactNode;
 	/** Icon for the notice (or `null` or `false` to hide the icon, defaults to `<StatusIcon>`). */
 	icon?: ReactElement | false | undefined;
+	/** Actions (e.g. buttons) shown on their own row below the message. */
+	actions?: ReactNode | undefined;
 }
 
+/**
+ * Status banner with an icon, a message, and optional actions.
+ * - Renders an `<aside>` with the matching status colour and ARIA role.
+ * - The icon always sits beside the message on one row; `actions` (e.g. buttons) get their own full-width row below.
+ *
+ * @example <Notice status="success">Your changes have been saved.</Notice>
+ * @example <Notice status="error" actions={<Button onClick={retry}>Retry</Button>}>Something went wrong.</Notice>
+ */
 export function Notice({
 	children,
 	status = children ? "info" : "loading",
 	icon = <StatusIcon status={status} />,
+	actions,
 	...variants
-}: NoticeProps) {
+}: NoticeProps): ReactElement {
 	return (
 		<aside
 			role={status === "danger" || status === "error" ? "alert" : "status"}
 			className={getClass(
 				BLOCK_CLASS,
 				getModuleClass(NOTICE_CSS, "notice", variants), //
-				getModuleClass(FLEX_CSS, "elements", variants),
 				getStatusClass(status), // Notices have status colours.
 				getColorClass(variants), // Notices can also have raw colour overrides.
 			)}
 		>
-			{icon}
-			{children}
+			<div className={NOTICE_CSS.body}>
+				{icon}
+				{children && <div className={NOTICE_CSS.message}>{children}</div>}
+			</div>
+			{actions && <div className={NOTICE_CSS.actions}>{actions}</div>}
 		</aside>
 	);
 }

--- a/modules/ui/notice/README.md
+++ b/modules/ui/notice/README.md
@@ -4,7 +4,7 @@ Inline and global toast-style notices for user feedback. `<Notice>` is a standal
 
 ## Concepts
 
-**`<Notice>`** renders an `<aside>` with a status icon and a message. It accepts a `status` prop (`"info"`, `"success"`, `"error"`, `"danger"`, `"loading"`, etc.) and maps it to the appropriate colour and ARIA role. The icon defaults to `<StatusIcon>` but can be replaced or hidden.
+**`<Notice>`** renders an `<aside>` with a status icon and a message. It accepts a `status` prop (`"info"`, `"success"`, `"error"`, `"danger"`, `"loading"`, etc.) and maps it to the appropriate colour and ARIA role. The icon defaults to `<StatusIcon>` but can be replaced or hidden. The icon always sits beside the message; pass an `actions` prop (e.g. a button) to add a row of actions on its own line below the message.
 
 **`<Message>`** is a lighter variant — a `<p>` tag with the same status colours, for short inline feedback inside a form or card rather than a banner.
 
@@ -25,6 +25,14 @@ import { Notice } from "shelving/ui";
 ```
 
 When `status` is omitted, `<Notice>` defaults to `"info"` if `children` is present, or `"loading"` if not.
+
+Pass `actions` to put buttons on their own row below the message.
+
+```tsx
+<Notice status="error" actions={<Button onClick={retry}>Retry</Button>}>
+  Something went wrong.
+</Notice>
+```
 
 Use `<Message>` for shorter inline feedback inside paragraphs or forms.
 


### PR DESCRIPTION
## Summary

`Notice` rendered its icon and children as direct flex children, so the `column` variant stacked **everything** — the icon ended up alone on its own row, while a button still shared a row with the message. `column` was being asked to mean two contradictory things at once.

This is the rethink #82 asked for. Rather than make `column` smarter, `Notice` now has a **fixed two-zone layout**:

- **Message row** — the icon always sits beside the message, never on its own line.
- **Actions row** — a new optional `actions` prop renders buttons/links on their own full-width row below. It collapses (`:empty`) when there is nothing to show, so an `ErrorNotice` with no retry handler doesn't leave a blank gap.

### Design decision (for review)

The open question in the issue was *how does `Notice` tell "content" children from "action" children — child order, or a dedicated slot?* I went with a **dedicated `actions` prop** — explicit, no reliance on child ordering, and it reads clearly at the call site.

As a consequence `NoticeProps` no longer extends `FlexVariants` — the layout is fixed, so `column` / `wrap` / `left` etc. no longer apply to a notice. No in-repo caller passed those. `ColorVariants` and the `--notice-*` CSS override hooks are kept. The layout lives in `Notice.module.css` (self-contained, doesn't depend on the shared `Flex` styles).

`ErrorNotice` (`Catcher.tsx`) now passes its `RetryButton` via `actions` instead of as a sibling child, and drops the manual `<p>` wrapper (the notice wraps the message itself).

## Changes

- `Notice.tsx` — fixed layout, new `actions` prop, drop `FlexVariants`.
- `Notice.module.css` — two-zone column layout; `.body` row, `.actions` row, `:empty` collapse.
- `Catcher.tsx` — `ErrorNotice` uses `actions`.
- `notice/README.md` — document `actions`.

Closes #82

## Test plan

- [x] `bun run fix`, `test:type`, `test:unit` (1035 pass) clean
- [x] `bun run docs:build` succeeds
- [ ] Visually confirm the not-found / error notice (icon beside message, retry button on its own row) in a browser
- [ ] Confirm `Notice` with no `actions` (FormNotice, QueryInput empty state) is unchanged

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV

---
_Generated by [Claude Code](https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV)_