### PR TITLE
feat(extract): derive element descriptions and show them on cards

### DIFF
--- a/modules/extract/MarkdownExtractor.test.ts
+++ b/modules/extract/MarkdownExtractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { BunFile } from "bun";
-import { MarkdownExtractor } from "./index.js";
+import { extractMarkdownDescription, MarkdownExtractor } from "./index.js";
 
 const extractor = new MarkdownExtractor();
 
@@ -42,5 +42,40 @@ describe("MarkdownExtractor", () => {
 		// `BunFile.name` is the full absolute path; the extractor uses only the basename.
 		const element = await extractor.extract(file("# Hi", "/tmp/some-dir/foo.md"));
 		expect(element.key).toBe("foo");
+	});
+
+	test("sets description to the first prose paragraph after the heading", async () => {
+		const element = await extractor.extract(file("# Title\n\nThe first paragraph.\n\nThe second paragraph."));
+		expect(element.props.description).toBe("The first paragraph.");
+	});
+
+	test("leaves description undefined when there is no prose paragraph", async () => {
+		const element = await extractor.extract(file("# Just A Heading"));
+		expect(element.props.description).toBeUndefined();
+	});
+});
+
+describe("extractMarkdownDescription", () => {
+	test("returns the first prose paragraph", () => {
+		expect(extractMarkdownDescription("# Title\n\nFirst paragraph.\n\nSecond paragraph.")).toBe("First paragraph.");
+	});
+
+	test("collapses internal whitespace onto a single line", () => {
+		expect(extractMarkdownDescription("# Title\n\nA paragraph that\nwraps across\nseveral lines.")).toBe(
+			"A paragraph that wraps across several lines.",
+		);
+	});
+
+	test("skips headings and blank lines while searching", () => {
+		expect(extractMarkdownDescription("# Title\n\n## Subheading\n\nThe prose.")).toBe("The prose.");
+	});
+
+	test("skips fenced code blocks", () => {
+		expect(extractMarkdownDescription("# Title\n\n```ts\nconst x = 1;\n```\n\nThe prose.")).toBe("The prose.");
+	});
+
+	test("returns undefined when there is no prose", () => {
+		expect(extractMarkdownDescription("# Heading\n\n## Another heading")).toBeUndefined();
+		expect(extractMarkdownDescription("")).toBeUndefined();
 	});
 });

--- a/modules/extract/MarkdownExtractor.test.ts
+++ b/modules/extract/MarkdownExtractor.test.ts
@@ -74,6 +74,12 @@ describe("extractMarkdownDescription", () => {
 		expect(extractMarkdownDescription("# Title\n\n```ts\nconst x = 1;\n```\n\nThe prose.")).toBe("The prose.");
 	});
 
+	test("strips inline markdown syntax to plain text", () => {
+		expect(extractMarkdownDescription("# Title\n\nUse `getFirst()` and *emphasis* and [a link](http://x.com).")).toBe(
+			"Use getFirst() and emphasis and a link.",
+		);
+	});
+
 	test("returns undefined when there is no prose", () => {
 		expect(extractMarkdownDescription("# Heading\n\n## Another heading")).toBeUndefined();
 		expect(extractMarkdownDescription("")).toBeUndefined();

--- a/modules/extract/MarkdownExtractor.ts
+++ b/modules/extract/MarkdownExtractor.ts
@@ -6,13 +6,14 @@ import { FileExtractor } from "./FileExtractor.js";
  * - Stores the raw markdown text as `content`; rendering happens at output time via `<Markup>`.
  * - Sets `title` from the first `# h1` heading if one is present — otherwise leaves it undefined
  *   (a confident title only).
+ * - Sets `description` to the first prose paragraph as a plain-text summary (used for card listings and `<meta>`).
  */
 export class MarkdownExtractor extends FileExtractor {
 	/** Markdown contributes the canonical title/path when merging same-key elements. */
 	override readonly priority = 10;
 
 	override extractProps(name: string, text: string): Partial<FileElementProps> & { name: string } {
-		return { name, title: extractMarkdownTitle(text), content: text };
+		return { name, title: extractMarkdownTitle(text), description: extractMarkdownDescription(text), content: text };
 	}
 }
 
@@ -23,4 +24,31 @@ export class MarkdownExtractor extends FileExtractor {
 export function extractMarkdownTitle(text: string): string | undefined {
 	const match = text.match(/^#\s+(.+?)\s*$/m);
 	return match?.[1];
+}
+
+/**
+ * Find the first prose paragraph in a markdown source string and return it as a plain-text summary, or `undefined` if none.
+ * - Skips headings, fenced code blocks, and blank lines, then collects the first ordinary paragraph.
+ * - Collapses internal whitespace so the result is a single line suitable for a `description` / `<meta>` summary.
+ */
+export function extractMarkdownDescription(text: string): string | undefined {
+	const paragraph: string[] = [];
+	let fenced = false;
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		// Toggle in/out of fenced code blocks — never treat their contents as the summary.
+		if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+			fenced = !fenced;
+			continue;
+		}
+		if (fenced) continue;
+		// A blank line or heading ends the first paragraph (or is skipped while still searching for it).
+		if (!trimmed || trimmed.startsWith("#")) {
+			if (paragraph.length) break;
+			continue;
+		}
+		paragraph.push(trimmed);
+	}
+	const summary = paragraph.join(" ").replace(/\s+/g, " ").trim();
+	return summary || undefined;
 }

--- a/modules/extract/MarkdownExtractor.ts
+++ b/modules/extract/MarkdownExtractor.ts
@@ -1,4 +1,6 @@
-import type { FileElementProps } from "../util/element.js";
+import { renderMarkup } from "../markup/render.js";
+import { MARKUP_OPTIONS } from "../markup/rule/index.js";
+import { type Elements, type FileElementProps, getElementText } from "../util/element.js";
 import { FileExtractor } from "./FileExtractor.js";
 
 /**
@@ -29,6 +31,7 @@ export function extractMarkdownTitle(text: string): string | undefined {
 /**
  * Find the first prose paragraph in a markdown source string and return it as a plain-text summary, or `undefined` if none.
  * - Skips headings, fenced code blocks, and blank lines, then collects the first ordinary paragraph.
+ * - Renders that paragraph as markup and strips every tag, so inline syntax (`` `code` ``, `*emphasis*`, links) becomes plain text.
  * - Collapses internal whitespace so the result is a single line suitable for a `description` / `<meta>` summary.
  */
 export function extractMarkdownDescription(text: string): string | undefined {
@@ -49,6 +52,9 @@ export function extractMarkdownDescription(text: string): string | undefined {
 		}
 		paragraph.push(trimmed);
 	}
-	const summary = paragraph.join(" ").replace(/\s+/g, " ").trim();
+	if (!paragraph.length) return;
+	// Render the paragraph as markup then strip every tag, so inline syntax resolves to clean plain text.
+	const rendered = renderMarkup(paragraph.join(" "), MARKUP_OPTIONS) as Elements;
+	const summary = getElementText(rendered).replace(/\s+/g, " ").trim();
 	return summary || undefined;
 }

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -286,6 +286,62 @@ export function add(a: number, b: number): number { return a + b; }
 		);
 	});
 
+	test("derives description from the first paragraph of a symbol's JSDoc", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Add two numbers together.
+ *
+ * A second paragraph with more detail that should not appear in the summary.
+ */
+export function add(a: number, b: number): number {
+	return a + b;
+}
+`),
+		);
+		const children = element.props.children as { props: { description?: string; content?: string } }[];
+		expect(children[0]?.props.description).toBe("Add two numbers together.");
+		// The full multi-paragraph text still lands in `content`.
+		expect(children[0]?.props.content).toContain("A second paragraph");
+	});
+
+	test("derives description for class members from their JSDoc", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A store. */
+export class Store {
+	/** The current value of the store. */
+	value: string;
+	/** Replace the stored value. */
+	set(v: string): void {}
+}
+`),
+		);
+		const cls = (element.props.children as { props: { children: { props: { description?: string } }[] } }[])[0];
+		expect(cls?.props.children[0]?.props.description).toBe("The current value of the store.");
+		expect(cls?.props.children[1]?.props.description).toBe("Replace the stored value.");
+	});
+
+	test("derives the file description from the file-level JSDoc", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * This module handles array utilities.
+ */
+export function first<T>(arr: T[]): T | undefined {
+	return arr[0];
+}
+`),
+		);
+		expect(element.props.description).toBe("This module handles array utilities.");
+	});
+
+	test("leaves description undefined when a symbol has no JSDoc", async () => {
+		const element = await extractor.extract(file("export const X = 1;"));
+		const children = element.props.children as { props: { description?: string } }[];
+		expect(children[0]?.props.description).toBeUndefined();
+	});
+
 	test("strips directory path from filename when computing key/name", async () => {
 		// In production, `BunFile.name` is the full absolute path (e.g. `/Users/.../modules/util/array.ts`).
 		// The extractor should use only the basename.

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -10,6 +10,7 @@ import type {
 } from "../util/element.js";
 import { requireSlug } from "../util/string.js";
 import { FileExtractor } from "./FileExtractor.js";
+import { extractMarkdownDescription } from "./MarkdownExtractor.js";
 
 /**
  * File extractor that parses a TypeScript source file into a tree element.
@@ -17,6 +18,7 @@ import { FileExtractor } from "./FileExtractor.js";
  * - Extracts exported, public, non-`_`-prefixed declarations as `tree-documentation` children.
  * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`.
  * - Top-of-file JSDoc comment becomes the file's `content`.
+ * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on the file and every `tree-documentation` child.
  * - Sets `title` on every `tree-documentation` child — `name()` for functions and methods, `name` for other kinds.
  * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
  */
@@ -36,7 +38,7 @@ export class TypescriptExtractor extends FileExtractor {
 
 		// The file element itself gets no `title` — a TS source file has no confident title source (the filename isn't one),
 		// so renderers fall back to `name`. The `tree-documentation` children each carry their own `title`.
-		return { name, content, children: Array.from(byKey.values()) };
+		return { name, description: extractMarkdownDescription(content ?? ""), content, children: Array.from(byKey.values()) };
 	}
 }
 
@@ -110,6 +112,7 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 			// Functions read as callable with `()`; other kinds use the bare name.
 			title: kind === "function" ? `${name}()` : name,
 			kind,
+			description: extractMarkdownDescription(jsDoc?.description ?? ""),
 			content: _buildJSDocContent(jsDoc?.description, jsDoc?.unhandled),
 			signatures: signature ? [signature] : undefined,
 			params,
@@ -247,7 +250,14 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile): Docum
 				members.push({
 					type: "tree-documentation",
 					key,
-					props: { name, title: `${name}()`, content, kind: "method", signatures: [signature] },
+					props: {
+						name,
+						title: `${name}()`,
+						description: extractMarkdownDescription(memberJSDoc?.description ?? ""),
+						content,
+						kind: "method",
+						signatures: [signature],
+					},
 				});
 			}
 		} else if (ts.isPropertyDeclaration(member) || ts.isPropertySignature(member)) {
@@ -255,7 +265,14 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile): Docum
 			members.push({
 				type: "tree-documentation",
 				key: requireSlug(name),
-				props: { name, title: name, content, kind: "property", signatures: type ? [type] : undefined },
+				props: {
+					name,
+					title: name,
+					description: extractMarkdownDescription(memberJSDoc?.description ?? ""),
+					content,
+					kind: "property",
+					signatures: type ? [type] : undefined,
+				},
 			});
 		}
 	}

--- a/modules/ui/docs/DirectoryCard.tsx
+++ b/modules/ui/docs/DirectoryCard.tsx
@@ -2,25 +2,20 @@ import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
-import { Prose } from "../block/Prose.js";
+import { Paragraph } from "../block/Paragraph.js";
 import { Subheading } from "../block/Subheading.js";
-import { Markup } from "../misc/Markup.js";
 
 interface DirectoryCardProps extends DirectoryElementProps {
 	path: AbsolutePath;
 }
 
-/** Card renderer for a `tree-directory` element. */
-export function DirectoryCard({ path, name, title, content }: DirectoryCardProps): ReactNode {
+/** Card renderer for a `tree-directory` element — a summary card showing the heading and description. */
+export function DirectoryCard({ path, name, title, description }: DirectoryCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
 			<Subheading>{title ?? name}</Subheading>
-			{content && (
-				<Prose>
-					<Markup>{content}</Markup>
-				</Prose>
-			)}
+			{description && <Paragraph>{description}</Paragraph>}
 		</Card>
 	);
 }

--- a/modules/ui/docs/DocumentationCard.tsx
+++ b/modules/ui/docs/DocumentationCard.tsx
@@ -3,19 +3,18 @@ import type { DocumentationElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
 import { Flex } from "../block/Flex.js";
+import { Paragraph } from "../block/Paragraph.js";
 import { Preformatted } from "../block/Preformatted.js";
-import { Prose } from "../block/Prose.js";
 import { Subheading } from "../block/Subheading.js";
 import { Code } from "../inline/Code.js";
-import { Markup } from "../misc/Markup.js";
 import { DocumentationKind } from "./DocumentationKind.js";
 
 interface DocumentationCardProps extends DocumentationElementProps {
 	path: AbsolutePath;
 }
 
-/** Card renderer for a `tree-documentation` element. */
-export function DocumentationCard({ path, title, name, kind, content, signatures }: DocumentationCardProps): ReactNode {
+/** Card renderer for a `tree-documentation` element — a summary card showing the heading, signatures, and description. */
+export function DocumentationCard({ path, title, name, kind, description, signatures }: DocumentationCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
@@ -28,11 +27,7 @@ export function DocumentationCard({ path, title, name, kind, content, signatures
 			{signatures?.map(sig => (
 				<Preformatted key={sig}>{sig}</Preformatted>
 			))}
-			{content && (
-				<Prose>
-					<Markup>{content}</Markup>
-				</Prose>
-			)}
+			{description && <Paragraph>{description}</Paragraph>}
 		</Card>
 	);
 }

--- a/modules/ui/docs/FileCard.tsx
+++ b/modules/ui/docs/FileCard.tsx
@@ -2,25 +2,20 @@ import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
 import { type AbsolutePath, joinPath } from "../../util/path.js";
 import { Card } from "../block/Card.js";
-import { Prose } from "../block/Prose.js";
+import { Paragraph } from "../block/Paragraph.js";
 import { Subheading } from "../block/Subheading.js";
-import { Markup } from "../misc/Markup.js";
 
 interface FileCardProps extends FileElementProps {
 	path: AbsolutePath;
 }
 
-/** Card renderer for a `tree-file` element. */
-export function FileCard({ path, name, title, content }: FileCardProps): ReactNode {
+/** Card renderer for a `tree-file` element — a summary card showing the heading and description. */
+export function FileCard({ path, name, title, description }: FileCardProps): ReactNode {
 	const href = joinPath(path, name);
 	return (
 		<Card href={href}>
 			<Subheading>{title ?? name}</Subheading>
-			{content && (
-				<Prose>
-					<Markup>{content}</Markup>
-				</Prose>
-			)}
+			{description && <Paragraph>{description}</Paragraph>}
 		</Card>
 	);
 }

--- a/modules/util/element.test.ts
+++ b/modules/util/element.test.ts
@@ -44,6 +44,14 @@ describe("getElementText()", () => {
 		expect(getElementText(P)).toBe("PARAGRAPH");
 		expect(getElementText(UL)).toBe("ITEM1ITEM2");
 	});
+	test("keeps loose text that sits alongside elements", () => {
+		const MIXED: Element = {
+			key: null,
+			type: "p",
+			props: { children: ["Use ", { key: null, type: "code", props: { children: "code" } }, " here."] },
+		};
+		expect(getElementText(MIXED)).toBe("Use code here.");
+	});
 });
 
 describe("walkElements()", () => {

--- a/modules/util/element.ts
+++ b/modules/util/element.ts
@@ -194,7 +194,13 @@ export function isElements(value: unknown): value is Elements {
 export function getElementText(elements: Elements): string {
 	if (typeof elements === "string") return elements;
 	if (isElement(elements)) return getElementText(elements.props.children);
-	return Array.from(walkElements(elements)).map(getElementText).join("");
+	// Iterate the collection directly — `walkElements()` skips loose strings, so it would drop text that sits alongside elements.
+	if (isIterable(elements)) {
+		let text = "";
+		for (const child of elements) text += getElementText(child);
+		return text;
+	}
+	return "";
 }
 
 /**


### PR DESCRIPTION
## Summary

Listing cards rendered the element's entire `content` (the full page body) via `<Markup>` — so a card was as long as the page it linked to. A card in a listing should be a short summary.

`description` was documented as the plain-text summary field but no extractor populated it. This PR derives it:

- **`MarkdownExtractor`** — new exported `extractMarkdownDescription()` takes the first prose paragraph (skipping headings and fenced code blocks), **renders it through the markup pipeline and strips every tag**, and collapses it onto a single line. So inline syntax (`` `code` ``, `*emphasis*`, links) resolves to genuine plain text — correct both on cards and in the `<meta name="description">` tag.
- **`TypescriptExtractor`** — reuses `extractMarkdownDescription()` to derive `description` from the first paragraph of the file-level JSDoc and of every symbol / class-member JSDoc. The full multi-paragraph JSDoc still lands in `content`.
- Directory `description` already flows from the absorbed `README.md` via `DirectoryExtractor`, so it works for free once the markdown extractor sets it.

`DocumentationCard` (heading + signatures + description), `FileCard`, and `DirectoryCard` (heading + description) now render `description` in a `<Paragraph>` instead of the full `content`. The full `content` still renders on the element's own page.

### Also fixes `getElementText`

The plain-text conversion above relies on `getElementText`, which turned out to be broken — it walked **elements only**, silently dropping loose text that sat alongside an element (so `["Use ", <code>, " here."]` became `"code"`). It now iterates the collection directly, matching its own documented JSDoc example. Untested before; a mixed-content test is added.

## Changes

- `extract/MarkdownExtractor.ts`, `extract/TypescriptExtractor.ts` (+ colocated tests)
- `util/element.ts` — `getElementText` fix (+ colocated test)
- `ui/docs/DocumentationCard.tsx`, `FileCard.tsx`, `DirectoryCard.tsx`

Closes #78

## Test plan

- [x] `bun run fix`, `test:type`, `test:unit` (1048 pass) clean
- [x] `bun run docs:build` — verified card summaries render as clean plain text (e.g. the `util/units` card no longer shows literal backticks)
- [ ] Visually confirm card listings in a browser

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV