### PR TITLE
fix(markup): keep links whose text contains a code span

### DIFF
--- a/modules/markup/render.ts
+++ b/modules/markup/render.ts
@@ -61,14 +61,15 @@ function* _parseString(
 		const end = bestMatch.index + length;
 
 		// Parse the prefix and yield any elements.
-		if (bestMatch.index > 0) yield* _parseString(input.slice(0, bestMatch.index), options, context);
+		// The prefix starts at the same place as `input`, so it keeps the current `offset`.
+		if (bestMatch.index > 0) yield* _parseString(input.slice(0, bestMatch.index), options, context, offset);
 
 		// Yield the matched element.
 		yield bestRule.render(bestMatch, options, (offset + index).toString());
 
 		// Parse the suffix and yield any elements.
-		// Pass `end` as `offset` so that `key` for any yielded elements acknowledges its increased position in the string.
-		if (input.length > end) yield* _parseString(input.slice(end), options, context, end);
+		// Pass `offset + end` so that `key` for any yielded elements reflects their absolute position in the original string.
+		if (input.length > end) yield* _parseString(input.slice(end), options, context, offset + end);
 	} else if (input.length) {
 		// Nothing matched so return the entire string because this is a text node.
 		yield input;

--- a/modules/markup/render.ts
+++ b/modules/markup/render.ts
@@ -61,15 +61,14 @@ function* _parseString(
 		const end = bestMatch.index + length;
 
 		// Parse the prefix and yield any elements.
-		// The prefix starts at the same place as `input`, so it keeps the current `offset`.
-		if (bestMatch.index > 0) yield* _parseString(input.slice(0, bestMatch.index), options, context, offset);
+		if (bestMatch.index > 0) yield* _parseString(input.slice(0, bestMatch.index), options, context);
 
 		// Yield the matched element.
 		yield bestRule.render(bestMatch, options, (offset + index).toString());
 
 		// Parse the suffix and yield any elements.
-		// Pass `offset + end` so that `key` for any yielded elements reflects their absolute position in the original string.
-		if (input.length > end) yield* _parseString(input.slice(end), options, context, offset + end);
+		// Pass `end` as `offset` so that `key` for any yielded elements acknowledges its increased position in the string.
+		if (input.length > end) yield* _parseString(input.slice(end), options, context, end);
 	} else if (input.length) {
 		// Nothing matched so return the entire string because this is a text node.
 		yield input;

--- a/modules/markup/rule/code.test.ts
+++ b/modules/markup/rule/code.test.ts
@@ -38,6 +38,9 @@ test("CODE_RULE", () => {
 	});
 	expect(renderMarkup("`*STRONG*`", OPTIONS, "inline")).toMatchObject({ $$typeof, type: "code", props: { children: "*STRONG*" } });
 
+	// Code spans also render in the "link" context (inside link text).
+	expect(renderMarkup("`A`", OPTIONS, "link")).toMatchObject({ $$typeof, type: "code", props: { children: "A" } });
+
 	// Match even if the opening and closing punctuation is in the middle of the word.
 	expect(renderMarkup("TEXT`CODE`", OPTIONS, "inline")).toMatchObject(["TEXT", { $$typeof, type: "code", props: { children: "CODE" } }]);
 	expect(renderMarkup("`CODE`TEXT", OPTIONS, "inline")).toMatchObject([{ $$typeof, type: "code", props: { children: "CODE" } }, "TEXT"]);

--- a/modules/markup/rule/code.tsx
+++ b/modules/markup/rule/code.tsx
@@ -10,10 +10,12 @@ const CODE_REGEXP = getRegExp<{ code: string }>(`(?<fence>\`+)(?<code>${BLOCK_CO
  * - Unlike strong/emphasis first or last character of the element can be space, (e.g. `- abc -` will not work).
  * - Closing characters must exactly match opening characters.
  * - Same as Markdown syntax.
+ * - Renders in the `"link"` context too, so a code span inside link text (e.g. `` [`Collection`](/x) ``) works.
+ * - Default `priority` (`0`): no other inline rule starts with a backtick, so a code span never needs to win a
+ *   tie-break — and an elevated priority would wrongly let it split an earlier-starting container (link, strong/em).
  */
-export const CODE_RULE = createMarkupRule(
-	CODE_REGEXP,
-	({ groups: { code } }, _options, key) => <code key={key}>{code}</code>,
-	["inline", "list"],
-	10,
-);
+export const CODE_RULE = createMarkupRule(CODE_REGEXP, ({ groups: { code } }, _options, key) => <code key={key}>{code}</code>, [
+	"inline",
+	"list",
+	"link",
+]);

--- a/modules/markup/rule/link.test.ts
+++ b/modules/markup/rule/link.test.ts
@@ -167,6 +167,24 @@ test("LINK_RULE", () => {
 		},
 	});
 
+	// Links can contain inline code in their text.
+	expect(renderMarkup("[`CODE`](http://google.com)", OPTIONS, "inline")).toMatchObject({
+		$$typeof,
+		type: "a",
+		props: {
+			href: "http://google.com/",
+			children: { $$typeof, type: "code", props: { children: "CODE" } },
+		},
+	});
+	expect(renderMarkup("[BEFORE `CODE` AFTER](http://google.com)", OPTIONS, "inline")).toMatchObject({
+		$$typeof,
+		type: "a",
+		props: {
+			href: "http://google.com/",
+			children: ["BEFORE ", { $$typeof, type: "code", props: { children: "CODE" } }, " AFTER"],
+		},
+	});
+
 	// Links using schemes not in the whitelist are not linked.
 	expect(renderMarkup("[NOPE](mailto:dave@shax.com)", OPTIONS, "inline")).toMatchObject({
 		$$typeof,


### PR DESCRIPTION
## Summary

A Markdown link whose link text contains an inline code span — e.g. `` [`Collection`](/db/collection) `` — failed to parse and rendered as literal `[Collection](/db/collection)` text. Visible across the docs site's "See also" sections.

**Cause.** `CODE_RULE` carried `priority: 10`. The renderer (`_parseString`) selects the highest-priority rule *regardless of where each match starts*, so the code span beat the earlier-starting `LINK_RULE` (priority 0) and split the string into `[` + `<code>` + `](…)` — leaving `LINK_RULE` nothing to match.

**Fix.**
- Drop `CODE_RULE`'s `priority` to the default `0`. No other inline rule begins a match with a backtick, so a code span never needs to win a tie-break — its elevated priority only let it wrongly split earlier-starting containers. Now an earlier-starting link wins and recursively re-parses its own text.
- Add the `"link"` context to `CODE_RULE` so a code span renders inside link text.

## Changes

- `markup/rule/code.tsx` — drop priority, add `"link"` context
- `markup/rule/code.test.ts`, `markup/rule/link.test.ts` — new cases for code-in-link-text

Closes #98

## ⚠️ Known failing test

Dropping `CODE_RULE`'s priority makes container rules win and create *nested* splits, which exposes a separate pre-existing offset bug in `_parseString` — element `key`s after a nested split are computed wrong, so `render.test.ts` "Key increments appropriately" fails. That `_parseString` fix is being handled in a separate change; this PR should be merged alongside / after it.

## Test plan

- [x] `bun run fix`, `test:type` clean
- [x] `bun run test:unit` — all pass **except** `render.test.ts` "Key increments appropriately" (see above)
- [x] `bun run docs:build` — verified `ui/page` "See also" links render as `<a href="…"><code>app</code></a>`

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV