### PR TITLE
fix(ui): apply the .flex class so &lt;Flex&gt; actually flexes

### DIFF
--- a/modules/ui/block/Flex.tsx
+++ b/modules/ui/block/Flex.tsx
@@ -33,7 +33,7 @@ export function Flex({ children, ...variants }: FlexProps): ReactElement {
 		<div
 			className={getClass(
 				BLOCK_CLASS, //
-				getModuleClass(FLEX_CSS, "elements", variants),
+				getModuleClass(FLEX_CSS, "flex", variants),
 			)}
 		>
 			{children}


### PR DESCRIPTION
## Summary

`Flex` called `getModuleClass(FLEX_CSS, "elements", variants)`, but the CSS module class is `.flex` — `FLEX_CSS["elements"]` is `undefined`, so the lookup silently missed. `<Flex>` therefore never received `display: flex` or any of its variant styles (`column`, `wrap`, `left`, `center`, …) and rendered as a plain block everywhere it's used (e.g. the title + kind-badge rows in docs cards and pages stacked instead of sitting in a row).

`"elements"` is a stale leftover from the `<Elements>` → `<Flex>` component rename — `Button` already passes the correct `"flex"` key. One-character-class fix: `"elements"` → `"flex"`.

## Note

`Notice.tsx` carries the **same** typo (`getModuleClass(FLEX_CSS, "elements", …)`), but it's left untouched here because PR #101 rewrites `Notice` with a self-contained layout that drops the `FLEX_CSS` usage entirely — fixing it here would just conflict with that PR.

## Changes

- `ui/block/Flex.tsx` — `"elements"` → `"flex"`

## Test plan

- [x] `bun run fix`, `test:type`, `test:unit` (1035 pass) clean
- [x] `bun run docs:build` succeeds — `<Flex>` rows now render as actual flex rows
- [ ] Visually confirm `<Flex>` layouts (card/page title + kind badge sit on one row) in a browser

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV

---
_Generated by [Claude Code](https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV)_