### PR TITLE
feat(ui): add NoticeCard, a chunky card-style status panel

### DIFF
--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -5,6 +5,7 @@ import type { Callback } from "../../util/function.js";
 import { Button, type ButtonVariants } from "../form/Button.js";
 import { CenteredLayout } from "../layout/CenteredLayout.js";
 import { Notice } from "../notice/Notice.js";
+import { NoticeCard } from "../notice/NoticeCard.js";
 import { Page } from "../page/Page.js";
 
 const RetryContext = createContext<Callback | undefined>(undefined);
@@ -102,12 +103,16 @@ export function ErrorNotice({ reason }: ErrorNoticeProps): ReactElement {
 
 export interface ErrorPageProps extends ErrorComponentProps {}
 
-/** Output a `<Page>` with a `<Notice>` for an unknown error reason. */
+/** Output a `<Page>` with a prominent `<NoticeCard>` for an unknown error reason. */
 export function ErrorPage({ reason }: ErrorPageProps): ReactElement {
+	const message = getMessage(reason) ?? "Unknown error";
 	return (
 		<Page title="Error">
 			<CenteredLayout>
-				<ErrorNotice reason={reason} />
+				<NoticeCard status="error">
+					{message}
+					<RetryButton />
+				</NoticeCard>
 			</CenteredLayout>
 		</Page>
 	);

--- a/modules/ui/notice/NoticeCard.module.css
+++ b/modules/ui/notice/NoticeCard.module.css
@@ -1,0 +1,36 @@
+/* Chunky, card-like status panel — Card box treatment combined with Notice status styling. */
+.card {
+	/* Box — a centered column of icon + content. */
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--notice-card-gap, var(--space-normal));
+	margin-inline: 0;
+	margin-block: var(--notice-card-spacing, var(--space-normal));
+	padding: var(--notice-card-padding, var(--space-large));
+
+	/* Style */
+	border-radius: var(--notice-card-radius, var(--radius-normal));
+	border: var(--notice-card-border, var(--stroke-normal)) solid var(--notice-card-color-border, var(--color-quiet));
+	box-shadow: var(--notice-card-shadow, var(--shadow-xsmall));
+	color: var(--notice-card-color-text, var(--color-quiet));
+	background: var(--notice-card-color-bg, var(--color-surface));
+
+	/* Typography */
+	font-size: var(--notice-card-size, var(--size-normal));
+	font-weight: var(--notice-card-weight, var(--weight-strong));
+	text-align: center;
+
+	/* Pseudo-classes */
+	&:first-child {
+		margin-block-start: 0;
+	}
+	&:last-child {
+		margin-block-end: 0;
+	}
+
+	/* No margins on children — the column gap owns the spacing. */
+	:where(& > *) {
+		margin: 0;
+	}
+}

--- a/modules/ui/notice/NoticeCard.test.tsx
+++ b/modules/ui/notice/NoticeCard.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NoticeCard } from "./NoticeCard.js";
+
+describe("NoticeCard", () => {
+	test("renders an aside with the status role and its content", () => {
+		const html = renderToStaticMarkup(<NoticeCard status="success">All done</NoticeCard>);
+		expect(html).toContain("<aside");
+		expect(html).toContain('role="status"');
+		expect(html).toContain("All done");
+	});
+
+	test("uses the alert role for error and danger statuses", () => {
+		expect(renderToStaticMarkup(<NoticeCard status="error">Broke</NoticeCard>)).toContain('role="alert"');
+		expect(renderToStaticMarkup(<NoticeCard status="danger">Careful</NoticeCard>)).toContain('role="alert"');
+	});
+
+	test("hides the icon when icon is false", () => {
+		const html = renderToStaticMarkup(
+			<NoticeCard status="info" icon={false}>
+				No icon
+			</NoticeCard>,
+		);
+		expect(html).not.toContain("<svg");
+	});
+});

--- a/modules/ui/notice/NoticeCard.tsx
+++ b/modules/ui/notice/NoticeCard.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement, ReactNode } from "react";
+import { type ColorVariants, getColorClass } from "../misc/Color.js";
+import { getStatusClass, type Status } from "../misc/Status.js";
+import { StatusIcon } from "../misc/StatusIcon.js";
+import { getClass, getModuleClass } from "../util/css.js";
+import NOTICE_CARD_CSS from "./NoticeCard.module.css";
+
+export interface NoticeCardProps extends ColorVariants {
+	/** Status for the notice card — drives the colour, the default icon, and the ARIA role. */
+	status?: Status | undefined;
+	/** Content for the notice card — laid out in a centered column. */
+	children?: ReactNode;
+	/** Icon for the notice card (or `false` to hide it; defaults to a large `<StatusIcon>` for the status). */
+	icon?: ReactElement | false | undefined;
+}
+
+/**
+ * Chunky, card-like status panel — the box treatment of a `Card` with the status styling of a `Notice`.
+ * - Use for a prominent standalone message (e.g. a full-page "not found" or error state) where an inline `<Notice>` reads too quietly.
+ * - Lays its icon and content out in a centered column; the icon defaults to a large `<StatusIcon>`, and a regular-size `<Button>` sits comfortably inside.
+ *
+ * @example <NoticeCard status="success">All done!<Button onClick={next}>Continue</Button></NoticeCard>
+ */
+export function NoticeCard({
+	children,
+	status = children ? "info" : "loading",
+	icon = <StatusIcon status={status} xxlarge />,
+	...variants
+}: NoticeCardProps): ReactElement {
+	return (
+		<aside
+			role={status === "danger" || status === "error" ? "alert" : "status"}
+			className={getClass(
+				getModuleClass(NOTICE_CARD_CSS, "card", variants), //
+				getStatusClass(status), // Notice cards have status colours.
+				getColorClass(variants), // Notice cards can also have raw colour overrides.
+			)}
+		>
+			{icon}
+			{children}
+		</aside>
+	);
+}
+
+export { NOTICE_CARD_CSS };

--- a/modules/ui/notice/README.md
+++ b/modules/ui/notice/README.md
@@ -6,6 +6,8 @@ Inline and global toast-style notices for user feedback. `<Notice>` is a standal
 
 **`<Notice>`** renders an `<aside>` with a status icon and a message. It accepts a `status` prop (`"info"`, `"success"`, `"error"`, `"danger"`, `"loading"`, etc.) and maps it to the appropriate colour and ARIA role. The icon defaults to `<StatusIcon>` but can be replaced or hidden.
 
+**`<NoticeCard>`** is the chunky variant — the box treatment of a `Card` combined with the status styling of a `Notice`. It lays its icon and content out in a centered column, with a large status icon by default, and a regular-size `<Button>` sits comfortably inside. Use it for a prominent standalone message (e.g. a full-page "not found" or error state) where an inline `<Notice>` reads too quietly.
+
 **`<Message>`** is a lighter variant — a `<p>` tag with the same status colours, for short inline feedback inside a form or card rather than a banner.
 
 **`<Notices>`** renders the global list of active notices. It subscribes to `"notice"` events on `window` (dispatched by the `notify` helpers in [ui/util](/ui/util)) and shows each one as a `<Notice>`. Notices auto-dismiss after 5 seconds unless they carry a `"loading"` status.
@@ -25,6 +27,17 @@ import { Notice } from "shelving/ui";
 ```
 
 When `status` is omitted, `<Notice>` defaults to `"info"` if `children` is present, or `"loading"` if not.
+
+Use `<NoticeCard>` for a prominent, full-attention message — it centers its content and carries a regular-size button.
+
+```tsx
+import { NoticeCard } from "shelving/ui";
+
+<NoticeCard status="error">
+  Page not found.
+  <Button onClick={retry}>Retry</Button>
+</NoticeCard>
+```
 
 Use `<Message>` for shorter inline feedback inside paragraphs or forms.
 

--- a/modules/ui/notice/index.ts
+++ b/modules/ui/notice/index.ts
@@ -1,5 +1,6 @@
 export * from "./Message.js";
 export * from "./Notice.js";
+export * from "./NoticeCard.js";
 export * from "./NoticeStore.js";
 export * from "./Notices.js";
 export * from "./NoticesStore.js";


### PR DESCRIPTION
## Summary

A fresh take on #82, replacing the rejected #101 approach (the `actions` prop / two-zone `Notice` rework).

The awkward case in #82 isn't really a `Notice` that needs a smarter `column` variant — it's a *different component*: a prominent, chunky, centered status panel. So this adds **`<NoticeCard>`** — the box treatment of a `Card` combined with the status styling of a `Notice`:

- Renders an `<aside>` (status / alert role) with `Card`-style chunk: padding, border, radius, shadow.
- Status colour comes from `Status` (`getStatusClass`), exactly like `Notice`.
- Content is laid out in a **centered column** — large `<StatusIcon>` by default (`xxlarge`), then children.
- A **regular-size `<Button>`** sits comfortably inside; no `small` / `fit` juggling.

Composing the prominent case is now trivial — just children:

```tsx
<NoticeCard status="error">
  Page not found.
  <Button onClick={retry}>Retry</Button>
</NoticeCard>
```

`Notice` and the inline `ErrorNotice` are **left completely untouched** — `Notice` stays the quiet inline banner.

## Decisions for review

- **`ErrorPage` now uses `<NoticeCard>`** instead of an inline `<Notice>` — that full-page error / "not found" layout is #82's original motivating problem, so this both resolves #82 and exercises the new component. Easy to revert that one function if you'd rather wire it yourself.
- Default icon size is `StatusIcon`'s `xxlarge` — the largest variant it offers. Tweakable; say if you want it bigger (would need a new `StatusIcon` size).
- `NoticeCard` has its own `.module.css` (like `Card` and `Notice` do) — it's a genuine new library primitive, not a restyle.

## Changes

- new `ui/notice/NoticeCard.tsx` + `.module.css` + `.test.tsx`
- `ui/notice/index.ts`, `notice/README.md`
- `ui/misc/Catcher.tsx` — `ErrorPage` uses `NoticeCard`

Closes #82

## Supersedes #101

#101 (the `Notice` two-zone rework) should be closed — this replaces that approach.

## Test plan

- [x] `bun run fix`, `test:type`, `test:unit` (1038 pass) clean
- [x] `bun run docs:build` succeeds
- [ ] Visually confirm a not-found page (centered card, large icon, regular Retry button) in a browser

https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV

---
_Generated by [Claude Code](https://claude.ai/code/session_011rzT1NuFwTE3SaSSGYhZfV)_