### PR TITLE
Fix bugs in equal and number utilities

### DIFF
--- a/modules/util/equal.test.ts
+++ b/modules/util/equal.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isArrayEqual, isDeepEqual, isEqual, isObjectEqual, isObjectMatch } from "../index.js";
+import { isArrayEqual, isArrayWith, isDeepEqual, isEqual, isObjectEqual, isObjectMatch, notArrayWith } from "../index.js";
 
 const arrFlat = [1, "b", true, false, null];
 const arrFlatSame = [1, "b", true, false, null];
@@ -220,4 +220,14 @@ test("isObjectMatch(): Matching values", () => {
 });
 test("isObjectMatch(): Non-matching values", () => {
 	expect(isObjectMatch(objFlatMissing, objFlat)).toBe(false);
+});
+test("isArrayWith(): Array including the value", () => {
+	expect(isArrayWith([1, 2, 3], 2)).toBe(true);
+	expect(isArrayWith([1, 2, 3], 9)).toBe(false);
+	expect(isArrayWith("not an array", 2)).toBe(false);
+});
+test("notArrayWith(): Not an array or array not including the value", () => {
+	expect(notArrayWith([1, 2, 3], 9)).toBe(true);
+	expect(notArrayWith("not an array", 2)).toBe(true);
+	expect(notArrayWith([1, 2, 3], 2)).toBe(false);
 });

--- a/modules/util/equal.ts
+++ b/modules/util/equal.ts
@@ -132,7 +132,7 @@ export function isArrayWith<T>(left: unknown, right: T): left is ImmutableArray<
 
 /** Is unknown value `left` not an array or does not include `right`? */
 export function notArrayWith(left: unknown, right: unknown): boolean {
-	return !notArrayWith(left, right);
+	return !isArrayWith(left, right);
 }
 
 /**

--- a/modules/util/number.test.ts
+++ b/modules/util/number.test.ts
@@ -106,6 +106,11 @@ describe("getNumber()", () => {
 		expect<number | undefined>(getNumber("a")).toBe(undefined);
 		expect<number | undefined>(getNumber("Willow perceptiveness purely sportsmanship namaste victoriously?")).toBe(undefined);
 	});
+	test("Dates are converted to their millisecond timestamp", () => {
+		const date = new Date("2026-05-21T00:00:00.000Z");
+		expect(getNumber(date)).toBe(date.getTime());
+		expect(getNumber(new Date(0))).toBe(0);
+	});
 });
 describe("getPercent()", () => {
 	test("Works correctly", () => {

--- a/modules/util/number.ts
+++ b/modules/util/number.ts
@@ -33,7 +33,7 @@ export function assertNumber(value: unknown, min?: number, max?: number, caller:
 export function getNumber(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isFinite(value)) return value === 0 ? 0 : value;
 	if (typeof value === "string") return getNumber(Number.parseFloat(value.replace(NOT_NUMERIC_REGEXP, "")));
-	if (value instanceof Date) getNumber(value.getTime());
+	if (value instanceof Date) return getNumber(value.getTime());
 }
 const NOT_NUMERIC_REGEXP = /[^0-9-.]/g;
 


### PR DESCRIPTION
This PR fixes three bugs in the utility modules and adds test coverage for new functionality.

**Key changes:**

- **equal.ts**: Fixed `notArrayWith()` function which was recursively calling itself instead of calling `isArrayWith()`, causing infinite recursion
- **number.ts**: Added missing `return` statement in `getNumber()` when handling Date objects, preventing the function from returning `undefined` for valid dates
- **equal.test.ts**: Added comprehensive test cases for `isArrayWith()` and `notArrayWith()` functions to verify correct behavior with arrays, non-arrays, and various values
- **number.test.ts**: Added test cases for `getNumber()` to verify Date objects are correctly converted to their millisecond timestamps

**Notable details:**

The `notArrayWith()` bug was a critical logic error where the function would infinitely recurse. The fix ensures it properly negates the result of `isArrayWith()`.

The `getNumber()` bug prevented Date handling from working entirely, as the recursive call result was not being returned. This is now fixed to properly handle Date objects.

https://claude.ai/code/session_01SL59KFrFDco3NYMbruvCR4