### PR TITLE
Reorganize documentation into per-symbol pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,5 +345,6 @@ Conventions for the upcoming reusable component layer.
 - Classes: one-sentence summary, bullet points for notable behaviour and caveats, `@example` for short inline usage
 - Functions: one-sentence summary, 0–2 behaviour bullets for anything surprising, `@param` / `@returns` / `@throws`, one `@example`
 - When you add, remove, or meaningfully change a class or function, check and update its docblock in the same commit
-- Each module has a `README.md` that acts as a guide page (concepts first, then examples). When module behaviour changes, check whether the README needs updating
+- Each module has a `README.md` that acts as the module's guide page. It covers **purpose, key concepts, and integration examples** — how to combine the module's classes and functions to accomplish real tasks (and, for families like `error`, shared traits). When module behaviour changes, check whether the README needs updating
+- **Per-class / per-function usage examples** live in a sibling `MyClass.md` / `myFunction.md` next to the source file. `DirectoryExtractor` merges that markdown onto the symbol's own page (`MarkdownExtractor` outranks `TypescriptExtractor`), so detailed usage belongs there rather than in the module README. `modules/util/template.md` is the precedent
 - Trust source and tests over README if they conflict — but fix the README rather than leaving it wrong

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -105,14 +105,14 @@ const user = await api.call(getUser, { id: "u_123" })
 
 ## React integration
 
-The [`react`](/react) module's `createAPIContext()` is the primary way to use a provider in a React app. It creates a context backed by an `APICache` and exposes typed hooks — `useEndpoint()`, `useProvider()` — that return reactive `EndpointStore` instances and suspend automatically while loading.
+The [`react`](/react) module's `createAPIContext()` is the primary way to use a provider in a React app. It creates a context backed by an `APICache` and exposes a typed `useAPI()` hook that returns reactive `EndpointStore` instances and suspends automatically while loading.
 
 ```ts
 import { createAPIContext } from "shelving/react"
 import { ClientAPIProvider, ValidationAPIProvider } from "shelving/api"
 
 const provider = new ValidationAPIProvider(new ClientAPIProvider({ url: "https://api.example.com" }))
-export const { APIContext, useEndpoint } = createAPIContext(provider)
+export const { APIContext, useAPI } = createAPIContext(provider)
 ```
 
 See the [`react`](/react) module for full usage.

--- a/modules/api/provider/APIProvider.md
+++ b/modules/api/provider/APIProvider.md
@@ -1,0 +1,23 @@
+# APIProvider
+
+The abstract base class every API provider implements. `APIProvider<P, R>` defines the surface that endpoint calls go through: `call(endpoint, payload)` to execute a typed endpoint, and `fetch(request)` as the lower-level transport step that wrapper providers intercept.
+
+You never instantiate `APIProvider` directly — use the concrete `ClientAPIProvider` (or a mock), optionally wrapped in `ThroughAPIProvider` subclasses. `APIProvider` implements `AsyncDisposable`.
+
+## Usage
+
+Code that accepts "any provider" should type against `APIProvider` so a bare client, a validated chain, or a mock are all interchangeable:
+
+```ts
+import type { APIProvider } from "shelving/api"
+
+async function loadUser(provider: APIProvider, id: string) {
+  return provider.call(getUser, { id }); // works with any provider in the chain
+}
+```
+
+## See also
+
+- [ClientAPIProvider](/api/provider/ClientAPIProvider) — the concrete network implementation.
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — base for wrapping providers.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/CachedAPIProvider.md
+++ b/modules/api/provider/CachedAPIProvider.md
@@ -1,0 +1,29 @@
+# CachedAPIProvider
+
+A wrapping provider that serves calls through an [`APICache`](/api/cache). Repeated calls for the same endpoint and payload skip the network and return the cached value, and it exposes `invalidate` / `refresh` helpers for cache control.
+
+The constructor takes the `source` provider and an optional default `maxAge` (defaults to `AVOID_REFRESH` — only refetch when a value is missing or invalidated).
+
+## Usage
+
+```ts
+import { CachedAPIProvider, ValidationAPIProvider, ClientAPIProvider } from "shelving/api"
+
+const provider = new CachedAPIProvider(
+  new ValidationAPIProvider(new ClientAPIProvider({ url: "https://api.example.com" }))
+)
+
+await provider.call(getUser, { id: "u_1" }) // fetches
+await provider.call(getUser, { id: "u_1" }) // returns cached
+
+provider.invalidate(getUser, { id: "u_1" }) // mark stale
+provider.refresh(getUser, { id: "u_1" })    // re-fetch eagerly
+```
+
+`invalidateAll(endpoint)` and `refreshAll(endpoint)` act on every cached payload for an endpoint at once.
+
+## See also
+
+- [api/cache](/api/cache) — the `APICache` this provider wraps.
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — the pass-through base.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/ClientAPIProvider.md
+++ b/modules/api/provider/ClientAPIProvider.md
@@ -1,0 +1,26 @@
+# ClientAPIProvider
+
+The concrete network provider. `ClientAPIProvider` sends requests over the network with the global `fetch()` API and is the innermost provider in almost every chain.
+
+The constructor takes `{ url, options?, timeout? }` — a base URL that endpoint paths are resolved against, optional default `RequestInit` options, and a request timeout in milliseconds (default `20000`).
+
+## Usage
+
+```ts
+import { ClientAPIProvider } from "shelving/api"
+
+const provider = new ClientAPIProvider({
+  url: "https://api.example.com",
+  timeout: 10_000,
+})
+
+const user = await provider.call(getUser, { id: "u_123" })
+```
+
+In practice you wrap it — e.g. `new ValidationAPIProvider(new ClientAPIProvider({ url }))` — so payloads and results are validated. See [building a provider chain](/api/provider).
+
+## See also
+
+- [APIProvider](/api/provider/APIProvider) — the abstract base.
+- [JSONAPIProvider](/api/provider/JSONAPIProvider) / [XMLAPIProvider](/api/provider/XMLAPIProvider) — client variants for specific content types.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/DebugAPIProvider.md
+++ b/modules/api/provider/DebugAPIProvider.md
@@ -1,0 +1,24 @@
+# DebugAPIProvider
+
+A wrapping provider for development. `DebugAPIProvider` writes verbose console output for every call — including full request and response bodies — so you can see exactly what is going over the wire.
+
+It is the noisy counterpart to [`LoggingAPIProvider`](/api/provider/LoggingAPIProvider): use `DebugAPIProvider` while developing, and `LoggingAPIProvider` (or nothing) in production.
+
+## Usage
+
+```ts
+import { ClientAPIProvider, DebugAPIProvider } from "shelving/api"
+
+const provider = new DebugAPIProvider(
+  new ClientAPIProvider({ url: "https://api.example.com" })
+)
+
+await provider.call(getUser, { id: "u_123" })
+// Console shows the full request and response, including bodies.
+```
+
+## See also
+
+- [LoggingAPIProvider](/api/provider/LoggingAPIProvider) — concise, production-safe logging.
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — the pass-through base.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/JSONAPIProvider.md
+++ b/modules/api/provider/JSONAPIProvider.md
@@ -1,0 +1,23 @@
+# JSONAPIProvider
+
+A [`ClientAPIProvider`](/api/provider/ClientAPIProvider) that forces JSON. It sends request bodies as JSON and always parses responses as JSON, regardless of content-type headers — useful against APIs that are inconsistent about declaring `application/json`.
+
+Because it extends `ClientAPIProvider`, it is a concrete network provider: construct it with the same `{ url, options?, timeout? }` options.
+
+## Usage
+
+```ts
+import { JSONAPIProvider, ValidationAPIProvider } from "shelving/api"
+
+const provider = new ValidationAPIProvider(
+  new JSONAPIProvider({ url: "https://api.example.com" })
+)
+
+const user = await provider.call(getUser, { id: "u_123" })
+```
+
+## See also
+
+- [ClientAPIProvider](/api/provider/ClientAPIProvider) — the base network provider.
+- [XMLAPIProvider](/api/provider/XMLAPIProvider) — the XML equivalent.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/LoggingAPIProvider.md
+++ b/modules/api/provider/LoggingAPIProvider.md
@@ -1,0 +1,30 @@
+# LoggingAPIProvider
+
+A wrapping provider that logs requests, responses, and errors. `LoggingAPIProvider` is production-safe — it logs concise lines rather than full bodies (use [`DebugAPIProvider`](/api/provider/DebugAPIProvider) for verbose development output).
+
+The constructor takes the `source` provider plus three optional callbacks — `onRequest`, `onResponse`, `onError` — each defaulting to a `console`-based logger.
+
+## Usage
+
+```ts
+import { ClientAPIProvider, LoggingAPIProvider } from "shelving/api"
+
+// Default console logging.
+const provider = new LoggingAPIProvider(
+  new ClientAPIProvider({ url: "https://api.example.com" })
+)
+
+// Or route logs into your own logger.
+const custom = new LoggingAPIProvider(
+  new ClientAPIProvider({ url: "https://api.example.com" }),
+  (request) => logger.info("api request", request.url),
+  (response, request) => logger.info("api response", request.url, response.status),
+  (reason, request) => logger.error("api error", request.url, reason),
+)
+```
+
+## See also
+
+- [DebugAPIProvider](/api/provider/DebugAPIProvider) — verbose console output for development.
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — the pass-through base.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/MockAPIProvider.md
+++ b/modules/api/provider/MockAPIProvider.md
@@ -1,0 +1,25 @@
+# MockAPIProvider
+
+A wrapping provider for tests. `MockAPIProvider` intercepts fetches through a `RequestHandler` instead of hitting the network, and records every call it makes so a test can assert on them.
+
+The constructor takes an optional `RequestHandler` and an optional `source` provider — both have defaults, so `new MockAPIProvider()` is enough for a provider that records calls and returns canned responses.
+
+## Usage
+
+```ts
+import { MockAPIProvider } from "shelving/api"
+
+const api = new MockAPIProvider((request) => new Response(JSON.stringify({ id: "u_1", name: "Alice" })))
+
+const user = await api.call(getUser, { id: "u_1" })
+
+console.log(api.requestCalls) // inspect every recorded request
+```
+
+For tests that exercise client and server logic together, use [`MockEndpointAPIProvider`](/api/provider/MockEndpointAPIProvider), which routes the mock transport through a real handler array.
+
+## See also
+
+- [MockEndpointAPIProvider](/api/provider/MockEndpointAPIProvider) — mock transport wired to real endpoint handlers.
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — the pass-through base.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/MockEndpointAPIProvider.md
+++ b/modules/api/provider/MockEndpointAPIProvider.md
@@ -1,0 +1,28 @@
+# MockEndpointAPIProvider
+
+A [`MockAPIProvider`](/api/provider/MockAPIProvider) that wires the mock transport directly to a real `EndpointHandler` array. Client code calls endpoints exactly as in production, but each call is dispatched to its handler in the same process — so you can test client and server logic together without a network.
+
+The constructor takes the `handlers` array, a `context` value passed to every handler, and an optional `source` provider.
+
+## Usage
+
+```ts
+import { MockEndpointAPIProvider } from "shelving/api"
+
+const handlers = [
+  getUser.handler(async ({ id }) => ({ id, name: "Alice", email: "alice@example.com" })),
+]
+
+const api = new MockEndpointAPIProvider(handlers, undefined)
+
+const user = await api.call(getUser, { id: "u_1" })
+// user == { id: "u_1", name: "Alice", email: "alice@example.com" }
+
+console.log(api.requestCalls) // inspect recorded calls
+```
+
+## See also
+
+- [MockAPIProvider](/api/provider/MockAPIProvider) — the base mock provider.
+- [api/endpoint](/api/endpoint) — `endpoint.handler()` and `handleEndpoints()`.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/README.md
+++ b/modules/api/provider/README.md
@@ -15,13 +15,17 @@ The transport layer for API calls. A provider builds requests, sends them, and p
 | `ValidationAPIProvider` | Validates payload before request creation and result after response parsing. |
 | `LoggingAPIProvider` | Logs requests, responses, and errors using configurable callbacks (production-safe). |
 | `DebugAPIProvider` | Verbose console output including full request/response bodies — development only. |
-| `JSONAPIProvider` | Forces JSON request bodies and always parses responses as JSON. |
-| `XMLAPIProvider` | Sends XML request bodies and returns raw text responses. |
+| `JSONAPIProvider` | A `ClientAPIProvider` that forces JSON request bodies and always parses responses as JSON. |
+| `XMLAPIProvider` | A `ClientAPIProvider` that sends XML request bodies and returns raw text responses. |
 | `MockAPIProvider` | Intercepts fetches through a `RequestHandler`; records all calls. No network requests. |
 | `MockEndpointAPIProvider` | Routes mock fetches through a real `EndpointHandler` array — test client and server together. |
-| `CachedAPIProvider` | Serves calls through an `APICache` and exposes `invalidate`/`refresh` helpers. |
+| `CachedAPIProvider` | Serves calls through an `APICache` and exposes `invalidate` / `refresh` helpers. |
+
+Each provider has its own page with focused usage examples.
 
 ### Building a provider chain
+
+Wrap outermost to innermost — the outer provider sees every call first:
 
 ```ts
 import { ClientAPIProvider, ValidationAPIProvider, LoggingAPIProvider } from "shelving/api"
@@ -35,62 +39,7 @@ const provider = new LoggingAPIProvider(
 const user = await provider.call(getUser, { id: "u_123" })
 ```
 
-Wrap outermost to innermost: `LoggingAPIProvider` sees every call first, `ValidationAPIProvider` validates next, `ClientAPIProvider` sends last.
-
-### Custom provider
-
-Extend `ThroughAPIProvider` to inject auth headers or any other per-request behaviour:
-
-```ts
-import { ThroughAPIProvider } from "shelving/api"
-
-class AuthAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
-  constructor(source: APIProvider<P, R>, readonly token: string) { super(source) }
-
-  override fetch(request: Request): Promise<Response> {
-    const authed = new Request(request, {
-      headers: { ...Object.fromEntries(request.headers), Authorization: `Bearer ${this.token}` },
-    })
-    return super.fetch(authed)
-  }
-}
-```
-
-### Testing with MockAPIProvider and MockEndpointAPIProvider
-
-`MockAPIProvider` captures all calls and routes fetches through a `RequestHandler` instead of the network. `MockEndpointAPIProvider` goes further — it wires the mock transport directly to a real handler array, so client and server code run together in a single process:
-
-```ts
-import { MockEndpointAPIProvider } from "shelving/api"
-
-const handlers = [
-  getUser.handler(async ({ id }) => ({ id, name: "Alice", email: "alice@example.com" })),
-]
-
-const api = new MockEndpointAPIProvider(handlers, undefined)
-const user = await api.call(getUser, { id: "u_1" })
-// user == { id: "u_1", name: "Alice", email: "alice@example.com" }
-
-console.log(api.requestCalls) // inspect recorded calls
-```
-
-### `CachedAPIProvider`
-
-Wraps any provider with an `APICache` so repeated calls for the same endpoint+payload skip the network. Exposes `invalidate`, `invalidateAll`, `refresh`, and `refreshAll` for cache control:
-
-```ts
-import { CachedAPIProvider, ValidationAPIProvider, ClientAPIProvider } from "shelving/api"
-
-const provider = new CachedAPIProvider(
-  new ValidationAPIProvider(new ClientAPIProvider({ url: "https://api.example.com" }))
-)
-
-await provider.call(getUser, { id: "u_1" }) // fetches
-await provider.call(getUser, { id: "u_1" }) // returns cached
-
-provider.invalidate(getUser, { id: "u_1" }) // mark stale
-provider.refresh(getUser, { id: "u_1" })    // re-fetch eagerly
-```
+`LoggingAPIProvider` sees every call first, `ValidationAPIProvider` validates next, `ClientAPIProvider` sends last.
 
 ## See also
 

--- a/modules/api/provider/ThroughAPIProvider.md
+++ b/modules/api/provider/ThroughAPIProvider.md
@@ -1,0 +1,30 @@
+# ThroughAPIProvider
+
+The pass-through base class for wrapping providers. `ThroughAPIProvider` takes a `source` provider and delegates every method to it. Extend it to intercept only the methods you care about — adding auth headers, retries, metrics — without reimplementing transport logic.
+
+`ValidationAPIProvider`, `LoggingAPIProvider`, `DebugAPIProvider`, `MockAPIProvider`, and `CachedAPIProvider` are all `ThroughAPIProvider` subclasses.
+
+## Usage
+
+Override `fetch()` (or `call()`) and call `super` to delegate the rest. For example, a provider that injects an `Authorization` header:
+
+```ts
+import { ThroughAPIProvider } from "shelving/api"
+import type { APIProvider } from "shelving/api"
+
+class AuthAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
+  constructor(source: APIProvider<P, R>, readonly token: string) { super(source) }
+
+  override fetch(request: Request): Promise<Response> {
+    const authed = new Request(request, {
+      headers: { ...Object.fromEntries(request.headers), Authorization: `Bearer ${this.token}` },
+    })
+    return super.fetch(authed)
+  }
+}
+```
+
+## See also
+
+- [APIProvider](/api/provider/APIProvider) — the abstract base.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/ValidationAPIProvider.md
+++ b/modules/api/provider/ValidationAPIProvider.md
@@ -1,0 +1,25 @@
+# ValidationAPIProvider
+
+A wrapping provider that validates data against the endpoint's [schemas](/schema). `ValidationAPIProvider` validates the payload before the request is built and validates the result after the response is parsed — so a malformed payload is caught before it leaves, and a bad response surfaces as a clear error.
+
+Place it just inside the network provider so everything above it works with validated, typed data.
+
+## Usage
+
+```ts
+import { ClientAPIProvider, ValidationAPIProvider } from "shelving/api"
+
+const provider = new ValidationAPIProvider(
+  new ClientAPIProvider({ url: "https://api.example.com" })
+)
+
+// Payload validated against the endpoint's payload schema before sending;
+// result validated against its result schema before returning.
+const user = await provider.call(getUser, { id: "u_123" })
+```
+
+## See also
+
+- [ThroughAPIProvider](/api/provider/ThroughAPIProvider) — the pass-through base.
+- [schema](/schema) — the `Schema<T>` validators used here.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/api/provider/XMLAPIProvider.md
+++ b/modules/api/provider/XMLAPIProvider.md
@@ -1,0 +1,22 @@
+# XMLAPIProvider
+
+A [`ClientAPIProvider`](/api/provider/ClientAPIProvider) for XML APIs. It sends request bodies as XML and returns the raw text of the response rather than parsing it as JSON.
+
+Because it extends `ClientAPIProvider`, it is a concrete network provider: construct it with the same `{ url, options?, timeout? }` options.
+
+## Usage
+
+```ts
+import { XMLAPIProvider } from "shelving/api"
+
+const provider = new XMLAPIProvider({ url: "https://legacy.example.com" })
+
+// The result is the raw response text.
+const xml = await provider.call(getFeed, { channel: "news" })
+```
+
+## See also
+
+- [ClientAPIProvider](/api/provider/ClientAPIProvider) — the base network provider.
+- [JSONAPIProvider](/api/provider/JSONAPIProvider) — the JSON equivalent.
+- [api/provider](/api/provider) — overview of the provider hierarchy.

--- a/modules/db/README.md
+++ b/modules/db/README.md
@@ -117,7 +117,7 @@ for await (const post of provider.getItemSequence(POSTS, id)) {
 
 ## React integration
 
-The [`react`](/react) module's `createDBContext()` is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — `useItem()`, `useQuery()`, `useProvider()` — that return reactive `Store` instances and suspend automatically while loading.
+The [`react`](/react) module's `createDBContext()` is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — `useItem()` and `useQuery()` — that return reactive `Store` instances and suspend automatically while loading.
 
 ```ts
 import { createDBContext } from "shelving/react"

--- a/modules/db/provider/CacheDBProvider.md
+++ b/modules/db/provider/CacheDBProvider.md
@@ -1,0 +1,26 @@
+# CacheDBProvider
+
+A wrapping provider that keeps an in-memory mirror in sync with a remote source. `CacheDBProvider` holds a `MemoryDBProvider` and populates it as data is read, so subsequent reads are synchronous — the basis of synchronous first renders in the React integration.
+
+The constructor takes the `source` provider and an optional `MemoryDBProvider` to use as the mirror (one is created by default).
+
+## Usage
+
+```ts
+import { CacheDBProvider, ValidationDBProvider, MemoryDBProvider } from "shelving/db";
+
+const provider = new CacheDBProvider(
+  new ValidationDBProvider(new MemoryDBProvider())
+);
+
+await provider.getItem(POSTS, "abc"); // fetches from source, populates the mirror
+await provider.getItem(POSTS, "abc"); // served synchronously from the mirror
+```
+
+[`DBCache`](/db/cache) finds the `CacheDBProvider` in a chain automatically and reuses its mirror to seed reactive stores.
+
+## See also
+
+- [MemoryDBProvider](/db/provider/MemoryDBProvider) — the mirror layer.
+- [db/cache](/db/cache) — `DBCache` reuses this provider's mirror.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/ChangesDBProvider.md
+++ b/modules/db/provider/ChangesDBProvider.md
@@ -1,0 +1,22 @@
+# ChangesDBProvider
+
+A wrapping provider that records every write. `ChangesDBProvider` extends [`ThroughDBProvider`](/db/provider/ThroughDBProvider) and accumulates a `.changes` log of each set, update, and delete that passes through it — useful for audit trails, change feeds, and assertions in tests.
+
+## Usage
+
+```ts
+import { ChangesDBProvider, MemoryDBProvider } from "shelving/db";
+
+const db = new ChangesDBProvider(new MemoryDBProvider());
+
+await db.setItem(POSTS, "abc", { title: "Hi", body: "", published: true });
+
+console.log(db.changes);
+// [{ action: "set", collection: "posts", id: "abc", data: { … } }]
+```
+
+## See also
+
+- [ThroughDBProvider](/db/provider/ThroughDBProvider) — the pass-through base.
+- [MockDBProvider](/db/provider/MockDBProvider) — records all calls, not just writes.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/DBProvider.md
+++ b/modules/db/provider/DBProvider.md
@@ -1,0 +1,25 @@
+# DBProvider
+
+The abstract base class every database backend implements. `DBProvider<I, T>` defines the typed surface that all call sites use — item reads and writes, queries, and realtime sequences — generic over a [`Collection`](/db/collection) so the compiler tracks `id` and `data` types automatically.
+
+Concrete backends implement the abstract methods; the base class derives `requireItem`, `countQuery`, `getFirst`, and `requireFirst` from them. `DBProvider` implements `AsyncDisposable`.
+
+## Usage
+
+Type code that accepts "any database" against `DBProvider` so an in-memory store, a validated chain, or a SQL backend are all interchangeable:
+
+```ts
+import type { DBProvider } from "shelving/db"
+
+async function publishPost(provider: DBProvider, id: string) {
+  await provider.updateItem(POSTS, id, { published: true });
+}
+```
+
+The method surface covers single items (`getItem`, `requireItem`, `addItem`, `setItem`, `updateItem`, `deleteItem`), queries (`getQuery`, `countQuery`, `setQuery`, `updateQuery`, `deleteQuery`, `getFirst`, `requireFirst`), and realtime (`getItemSequence`, `getQuerySequence` — iterate with `for await...of`).
+
+## See also
+
+- [MemoryDBProvider](/db/provider/MemoryDBProvider) — the concrete in-memory implementation.
+- [ThroughDBProvider](/db/provider/ThroughDBProvider) — base for wrapping providers.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/DebugDBProvider.md
+++ b/modules/db/provider/DebugDBProvider.md
@@ -1,0 +1,19 @@
+# DebugDBProvider
+
+A wrapping provider that logs every database operation to the console with ANSI formatting. `DebugDBProvider` extends [`ThroughDBProvider`](/db/provider/ThroughDBProvider) and is a development aid — drop it into a chain to see each read and write as it happens.
+
+## Usage
+
+```ts
+import { DebugDBProvider, MemoryDBProvider } from "shelving/db";
+
+const provider = new DebugDBProvider(new MemoryDBProvider());
+
+await provider.addItem(POSTS, { title: "Hello", body: "…", published: false });
+// Console shows the addItem operation and its result.
+```
+
+## See also
+
+- [ThroughDBProvider](/db/provider/ThroughDBProvider) — the pass-through base.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/MemoryDBProvider.md
+++ b/modules/db/provider/MemoryDBProvider.md
@@ -1,0 +1,27 @@
+# MemoryDBProvider
+
+A fully in-memory `DBProvider`. `MemoryDBProvider` stores every collection in plain memory — fast, with no persistence. It is ideal for tests and prototypes, and it is also the mirror layer that `CacheDBProvider` keeps in sync.
+
+Unlike the SQL providers, `MemoryDBProvider` supports realtime sequences (`getItemSequence`, `getQuerySequence`).
+
+## Usage
+
+```ts
+import { MemoryDBProvider } from "shelving/db";
+
+const provider = new MemoryDBProvider();
+
+const id = await provider.addItem(POSTS, { title: "Hello", body: "First post.", published: false });
+const post = await provider.getItem(POSTS, id);
+
+// Realtime — emits whenever the item changes.
+for await (const next of provider.getItemSequence(POSTS, id)) {
+  console.log(next);
+}
+```
+
+## See also
+
+- [DBProvider](/db/provider/DBProvider) — the abstract base.
+- [CacheDBProvider](/db/provider/CacheDBProvider) — uses a `MemoryDBProvider` as its mirror.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/MockDBProvider.md
+++ b/modules/db/provider/MockDBProvider.md
@@ -1,0 +1,21 @@
+# MockDBProvider
+
+A test provider that records every call. `MockDBProvider` extends [`MemoryDBProvider`](/db/provider/MemoryDBProvider) — so it behaves like a real in-memory database — and additionally captures every operation in a `.calls` array so tests can assert exactly what happened.
+
+## Usage
+
+```ts
+import { MockDBProvider } from "shelving/db";
+
+const mock = new MockDBProvider();
+await mock.addItem(POSTS, { title: "Hello", body: "", published: false });
+
+console.log(mock.calls[0]);
+// { type: "addItem", collection: "posts", data: { … }, result: <id> }
+```
+
+## See also
+
+- [MemoryDBProvider](/db/provider/MemoryDBProvider) — the in-memory base.
+- [ChangesDBProvider](/db/provider/ChangesDBProvider) — records writes only, as a change log.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/PostgreSQLProvider.md
+++ b/modules/db/provider/PostgreSQLProvider.md
@@ -1,0 +1,27 @@
+# PostgreSQLProvider
+
+The abstract SQL provider for PostgreSQL. `PostgreSQLProvider` extends [`SQLProvider`](/db/provider/SQLProvider) with PostgreSQL-specific behaviour: the `data` column is `jsonb NOT NULL`, generated columns use the `#>>` operator with a cast, and compatible numeric/string column type changes are applied in place with `ALTER COLUMN TYPE`.
+
+It is abstract — a concrete subclass implements `exec()` against a specific PostgreSQL driver.
+
+## Usage
+
+```ts
+import { PostgreSQLProvider } from "shelving/db";
+
+class BunPostgreSQLProvider extends PostgreSQLProvider {
+  constructor(private sql: Bun.SQL) { super(); }
+  async exec(strings, ...values) {
+    return this.sql(strings, ...values);
+  }
+}
+```
+
+Pair it with [`PostgreSQLMigrator`](/db/migrate) to create and alter tables to match your collection schemas. A ready-made provider is available in the [`bun`](/bun) module.
+
+## See also
+
+- [SQLProvider](/db/provider/SQLProvider) — the abstract SQL base.
+- [SQLiteProvider](/db/provider/SQLiteProvider) — the SQLite / D1 equivalent.
+- [db/migrate](/db/migrate) — `PostgreSQLMigrator` for schema migration.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/README.md
+++ b/modules/db/provider/README.md
@@ -14,7 +14,7 @@ SQLite realtime sequences (`getItemSequence`, `getQuerySequence`) are not suppor
 
 ### Provider chain
 
-Stack providers to compose behaviour. Each wrapping provider delegates to its `source` and intercepts only what it needs.
+Stack providers to compose behaviour. Each wrapping provider delegates to its `source` and intercepts only what it needs. Each provider has its own page with focused usage examples.
 
 | Provider | Role |
 |---|---|
@@ -25,29 +25,9 @@ Stack providers to compose behaviour. Each wrapping provider delegates to its `s
 | `DebugDBProvider` | Logs all operations to the console (ANSI-formatted). Extends `ThroughDBProvider`. |
 | `ChangesDBProvider` | Accumulates a `.changes` log of every write. Useful for audit trails and testing. Extends `ThroughDBProvider`. |
 | `MockDBProvider` | Extends `MemoryDBProvider` and records every call in `.calls`. Use in tests to assert operations. |
-| `SQLiteProvider` | Abstract SQL backend targeting SQLite/D1 with JSON1 support for nested keys and array operations. |
+| `SQLProvider` | Abstract SQL base — concrete subclasses bind it to a driver. |
+| `SQLiteProvider` | Abstract SQL backend targeting SQLite / D1 with JSON1 support for nested keys and array operations. |
 | `PostgreSQLProvider` | Abstract SQL backend targeting PostgreSQL with JSONB support. |
-
-### Extending ThroughDBProvider
-
-`ThroughDBProvider` is the right base for any intercepting layer. Override only the methods you care about and call `super` to delegate the rest:
-
-```ts
-import { ThroughDBProvider } from "shelving/db";
-
-class TimingDBProvider extends ThroughDBProvider {
-  override async getItem(collection, id) {
-    const t = performance.now();
-    const result = await super.getItem(collection, id);
-    console.log(`getItem took ${performance.now() - t}ms`);
-    return result;
-  }
-}
-```
-
-### SQL providers
-
-`SQLProvider` is the abstract SQL base. Concrete subclasses must implement `exec<X>(strings, ...values)` to run a parameterised query and return rows as plain objects. `SQLiteProvider` and `PostgreSQLProvider` extend `SQLProvider` with dialect-specific JSON path syntax, array operations (`with` / `omit`), and generated column support.
 
 ## Usage
 
@@ -66,30 +46,6 @@ const provider = new CacheDBProvider(
 ```
 
 `ValidationDBProvider` sits between the cache and the backend so bad data from the database surfaces as a `ValueError` before it reaches the cache.
-
-### Testing with MockDBProvider
-
-```ts
-import { MockDBProvider } from "shelving/db";
-
-const mock = new MockDBProvider();
-await mock.addItem(POSTS, { title: "Hello", body: "", published: false });
-
-console.log(mock.calls[0]);
-// { type: "addItem", collection: "posts", data: { ... }, result: <id> }
-```
-
-### Tracking writes with ChangesDBProvider
-
-```ts
-import { ChangesDBProvider, MemoryDBProvider } from "shelving/db";
-
-const db = new ChangesDBProvider(new MemoryDBProvider());
-await db.setItem(POSTS, "abc", { title: "Hi", body: "", published: true });
-
-console.log(db.changes);
-// [{ action: "set", collection: "posts", id: "abc", data: { ... } }]
-```
 
 ## See also
 

--- a/modules/db/provider/SQLProvider.md
+++ b/modules/db/provider/SQLProvider.md
@@ -1,0 +1,27 @@
+# SQLProvider
+
+The abstract SQL base provider. `SQLProvider` implements the `DBProvider` surface in terms of SQL, leaving one method for concrete subclasses to provide: `exec<X>(strings, ...values)`, which runs a parameterised query and returns rows as plain objects.
+
+Each scalar field in a collection schema maps to a **generated column** extracted from the `data` JSON blob, so queries use indexed column comparisons. `SQLProvider` supports integer (`number` with `step: 1`) and string identifiers. Realtime sequences are not supported — `getItemSequence` / `getQuerySequence` throw `UnimplementedError`.
+
+## Usage
+
+`SQLProvider` is abstract — bind it to a driver by implementing `exec()`. The built-in [`SQLiteProvider`](/db/provider/SQLiteProvider) and [`PostgreSQLProvider`](/db/provider/PostgreSQLProvider) extend it with dialect-specific JSON path syntax; concrete drivers live in the [`cloudflare`](/cloudflare) and [`bun`](/bun) modules.
+
+```ts
+import { SQLiteProvider } from "shelving/db";
+
+// A concrete subclass implements exec() against a specific driver.
+class D1Provider extends SQLiteProvider {
+  async exec(strings, ...values) {
+    return this.db.prepare(strings.join("?")).bind(...values).all();
+  }
+}
+```
+
+## See also
+
+- [SQLiteProvider](/db/provider/SQLiteProvider) — SQLite / D1 dialect.
+- [PostgreSQLProvider](/db/provider/PostgreSQLProvider) — PostgreSQL dialect.
+- [db/migrate](/db/migrate) — migrators that create the generated-column tables.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/SQLiteProvider.md
+++ b/modules/db/provider/SQLiteProvider.md
@@ -1,0 +1,27 @@
+# SQLiteProvider
+
+The abstract SQL provider for SQLite and Cloudflare D1. `SQLiteProvider` extends [`SQLProvider`](/db/provider/SQLProvider) with SQLite-specific behaviour: tables are created in `STRICT` mode, the `data` column is `TEXT NOT NULL CHECK (json_valid(data))`, and generated columns use `json_extract`.
+
+It is abstract — a concrete subclass implements `exec()` against a specific SQLite driver.
+
+## Usage
+
+```ts
+import { SQLiteProvider } from "shelving/db";
+
+class D1Provider extends SQLiteProvider {
+  constructor(private d1: D1Database) { super(); }
+  async exec(strings, ...values) {
+    return this.d1.prepare(strings.join("?")).bind(...values).all();
+  }
+}
+```
+
+Pair it with [`SQLiteMigrator`](/db/migrate) to create and alter tables to match your collection schemas. A ready-made D1 provider is available in the [`cloudflare`](/cloudflare) module.
+
+## See also
+
+- [SQLProvider](/db/provider/SQLProvider) — the abstract SQL base.
+- [PostgreSQLProvider](/db/provider/PostgreSQLProvider) — the PostgreSQL equivalent.
+- [db/migrate](/db/migrate) — `SQLiteMigrator` for schema migration.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/ThroughDBProvider.md
+++ b/modules/db/provider/ThroughDBProvider.md
@@ -1,0 +1,27 @@
+# ThroughDBProvider
+
+The identity pass-through base for wrapping providers. `ThroughDBProvider` takes a `source` provider and delegates every method to it. Extend it to intercept only the methods you care about — timing, metrics, access control — without reimplementing the rest.
+
+`ValidationDBProvider`, `DebugDBProvider`, and `ChangesDBProvider` are all `ThroughDBProvider` subclasses.
+
+## Usage
+
+Override only the methods you need and call `super` to delegate the rest:
+
+```ts
+import { ThroughDBProvider } from "shelving/db";
+
+class TimingDBProvider extends ThroughDBProvider {
+  override async getItem(collection, id) {
+    const t = performance.now();
+    const result = await super.getItem(collection, id);
+    console.log(`getItem took ${performance.now() - t}ms`);
+    return result;
+  }
+}
+```
+
+## See also
+
+- [DBProvider](/db/provider/DBProvider) — the abstract base.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/db/provider/ValidationDBProvider.md
+++ b/modules/db/provider/ValidationDBProvider.md
@@ -1,0 +1,25 @@
+# ValidationDBProvider
+
+A wrapping provider that validates data against the collection schema. `ValidationDBProvider` validates data on the way **in** (writes) and on the way **out** (reads) — so bad data never reaches the backend, and corrupt data from the backend surfaces as a `ValueError` rather than propagating silently.
+
+Place it between the cache and the backend so cached data is always known-good.
+
+## Usage
+
+```ts
+import { ValidationDBProvider, MemoryDBProvider } from "shelving/db";
+
+const provider = new ValidationDBProvider(new MemoryDBProvider());
+
+// Validated against the POSTS schema before writing.
+await provider.addItem(POSTS, { title: "Hello", body: "…", published: false });
+
+// If the backend ever returns data that fails the schema, this throws ValueError.
+const post = await provider.getItem(POSTS, "abc");
+```
+
+## See also
+
+- [ThroughDBProvider](/db/provider/ThroughDBProvider) — the pass-through base.
+- [db/collection](/db/collection) — the `Collection` schema validated against.
+- [db/provider](/db/provider) — overview of the provider hierarchy.

--- a/modules/error/NetworkError.md
+++ b/modules/error/NetworkError.md
@@ -1,0 +1,24 @@
+# NetworkError
+
+Thrown on a network-level failure — a connection refused, a server unreachable, a request that never completed. Use it for transport problems, as distinct from a response that arrived but indicated an error (`ResponseError`).
+
+## Usage
+
+```ts
+import { NetworkError } from "shelving/error";
+
+async function fetchData(url: string): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch {
+    throw new NetworkError("Could not reach server");
+  }
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [ResponseError](/error/ResponseError) — for a response that arrived but indicated an error.
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/error/README.md
+++ b/modules/error/README.md
@@ -24,9 +24,7 @@ function requirePositive(n: number): number {
 }
 ```
 
-## Usage
-
-### Choosing the right class
+## Choosing the right class
 
 | Class | When to throw |
 |---|---|
@@ -40,61 +38,13 @@ function requirePositive(n: number): number {
 
 `RequestError` has named subclasses for common HTTP status codes: `UnauthorizedError` (401), `ForbiddenError` (403), `NotFoundError` (404), `MethodNotAllowedError` (405), and `UnprocessableError` (422).
 
-### Basic usage
+See each class's own page for focused usage examples.
 
-```ts
-import {
-  RequiredError,
-  ValueError,
-  NetworkError,
-  NotFoundError,
-  ResponseError,
-  UnexpectedError,
-  UnimplementedError,
-} from "shelving/error";
-
-// Something required is missing.
-function getUser(id: string | undefined): User {
-  if (!id) throw new RequiredError("User ID is required");
-  // ...
-}
-
-// A value from an external source failed validation.
-function parseConfig(raw: unknown): Config {
-  if (!isConfig(raw)) throw new ValueError("Invalid config from server", { received: raw });
-  return raw;
-}
-
-// Network or transport failure.
-async function fetchData(url: string): Promise<Response> {
-  try {
-    return await fetch(url);
-  } catch {
-    throw new NetworkError("Could not reach server");
-  }
-}
-
-// HTTP error response.
-function checkResponse(res: Response): void {
-  if (!res.ok) throw new ResponseError(res.statusText, { code: res.status });
-}
-
-// Guard against code paths that should be unreachable.
-function assertNever(x: never): never {
-  throw new UnexpectedError("Unhandled case", { received: x });
-}
-
-// Stub out a method that must be overridden.
-class BaseProvider {
-  save(): Promise<void> {
-    throw new UnimplementedError("save() is not implemented");
-  }
-}
-```
+## Usage
 
 ### Attaching context
 
-Any extra fields in the options bag land on the error instance and will appear in structured logs:
+Any extra fields in the options bag land on the error instance and will appear in structured logs — this works the same way for every class in the module:
 
 ```ts
 throw new ValueError("Unexpected status", {
@@ -106,6 +56,8 @@ throw new ValueError("Unexpected status", {
 ```
 
 ### Catching by type
+
+Every class participates in `instanceof` checks, and subclasses match their base class — so a `catch` block can branch from specific to general:
 
 ```ts
 import { NotFoundError, ResponseError } from "shelving/error";

--- a/modules/error/RequestError.md
+++ b/modules/error/RequestError.md
@@ -1,0 +1,25 @@
+# RequestError
+
+Thrown when an incoming request is malformed or unacceptable — the HTTP 4xx range. Its `.code` property defaults to `400`.
+
+`RequestError` has named subclasses for common HTTP status codes, each setting its own `.code`: `UnauthorizedError` (401), `ForbiddenError` (403), `NotFoundError` (404), `MethodNotAllowedError` (405), and `UnprocessableError` (422). Throw the most specific class that fits.
+
+## Usage
+
+```ts
+import { RequestError, NotFoundError } from "shelving/error";
+
+function loadDocument(id: string): Document {
+  if (!isValidId(id)) throw new RequestError("Malformed document ID", { received: id });
+  const doc = documents.get(id);
+  if (!doc) throw new NotFoundError("Document not found", { received: id }); // .code === 404
+  return doc;
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [ResponseError](/error/ResponseError) — for an error indicated by a received response.
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/error/RequiredError.md
+++ b/modules/error/RequiredError.md
@@ -1,0 +1,21 @@
+# RequiredError
+
+Thrown when something required was absent — a missing argument, an empty lookup result, or an unset value. The `require*()` helpers in [util](/util) throw this class.
+
+## Usage
+
+```ts
+import { RequiredError } from "shelving/error";
+
+function getUser(id: string | undefined): User {
+  if (!id) throw new RequiredError("User ID is required");
+  // ...
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [error](/error) — module overview and shared error behaviour.
+- [util](/util) — `require*()` functions that throw `RequiredError`.

--- a/modules/error/ResponseError.md
+++ b/modules/error/ResponseError.md
@@ -1,0 +1,21 @@
+# ResponseError
+
+Thrown when a received response indicates an error — the HTTP 4xx/5xx range. Its `.code` property defaults to `400`. Use it for a response that arrived but was unsuccessful, as distinct from a transport failure (`NetworkError`).
+
+## Usage
+
+```ts
+import { ResponseError } from "shelving/error";
+
+function checkResponse(res: Response): void {
+  if (!res.ok) throw new ResponseError(res.statusText, { code: res.status });
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [NetworkError](/error/NetworkError) — for a transport-level failure where no response arrived.
+- [RequestError](/error/RequestError) — for a malformed or unacceptable incoming request.
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/error/UnexpectedError.md
+++ b/modules/error/UnexpectedError.md
@@ -1,0 +1,19 @@
+# UnexpectedError
+
+Thrown when something that should never happen did — an invariant was violated or an unreachable code path was reached. Reaching an `UnexpectedError` means there is a bug, not a bad input.
+
+## Usage
+
+```ts
+import { UnexpectedError } from "shelving/error";
+
+function assertNever(x: never): never {
+  throw new UnexpectedError("Unhandled case", { received: x });
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/error/UnimplementedError.md
+++ b/modules/error/UnimplementedError.md
@@ -1,0 +1,21 @@
+# UnimplementedError
+
+Thrown when a method or feature is not implemented — for example an abstract method left for a subclass to override, or a provider stub that has not been filled in yet.
+
+## Usage
+
+```ts
+import { UnimplementedError } from "shelving/error";
+
+class BaseProvider {
+  save(): Promise<void> {
+    throw new UnimplementedError("save() is not implemented");
+  }
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/error/ValueError.md
+++ b/modules/error/ValueError.md
@@ -1,0 +1,20 @@
+# ValueError
+
+Thrown when a value was present but invalid in its context — for example data read from a database or an external source that failed validation. Pass the offending value as `received` so it appears in structured logs.
+
+## Usage
+
+```ts
+import { ValueError } from "shelving/error";
+
+function parseConfig(raw: unknown): Config {
+  if (!isConfig(raw)) throw new ValueError("Invalid config from server", { received: raw });
+  return raw;
+}
+```
+
+See [error](/error) for shared behaviour — attaching context fields, `caller` trimming, and catching by type.
+
+## See also
+
+- [error](/error) — module overview and shared error behaviour.

--- a/modules/react/README.md
+++ b/modules/react/README.md
@@ -14,135 +14,58 @@ React hooks and context helpers for integrating Shelving [stores](/store), async
 
 ### Stable references
 
-A recurring React problem is stale closures and unnecessary re-renders caused by objects being recreated on every render. `useProps`, `useInstance`, `useLazy`, and `useReduce` each solve a specific variant of this: `useProps` gives you a single mutable object that lives for the lifetime of the component; `useInstance` memoises a class constructor call; `useLazy` memoises an arbitrary factory call; `useReduce` lets you fold render state with custom equality logic.
+A recurring React problem is stale closures and unnecessary re-renders caused by objects being recreated on every render. `useInstance`, `useLazy`, `useReduce`, and `useMap` each solve a specific variant of this: `useInstance` memoises a class constructor call; `useLazy` memoises an arbitrary factory call; `useReduce` lets you fold render state with custom equality logic; `useMap` gives you a single mutable `Map` that lives for the lifetime of the component.
 
 ## Usage
 
-### `useStore` with Suspense
+The per-symbol pages below carry the detailed usage for each hook and context factory. This section shows how the pieces fit together for real tasks — start here, then follow the links for specifics.
 
-`useStore` subscribes to a store and returns it. The component suspends while the store is loading and surfaces errors to the nearest error boundary.
+### Rendering data with a DB context
+
+Create a context once at module scope, wrap the tree in it, and let child components suspend while data loads. The same shape works for `createAPIContext` — swap `useItem` / `useQuery` for `useAPI`.
 
 ```tsx
 import { Suspense } from "react";
-import { useStore } from "shelving/react";
-
-function UserCard({ store }: { store: Store<User> }) {
-  useStore(store); // Subscribe — re-renders when the store updates.
-  const user = store.value; // Throws Promise (loading) or reason (error).
-  return <div>{user.name}</div>;
-}
-
-function App() {
-  return (
-    <ErrorBoundary fallback={<p>Something went wrong.</p>}>
-      <Suspense fallback={<p>Loading...</p>}>
-        <UserCard store={userStore} />
-      </Suspense>
-    </ErrorBoundary>
-  );
-}
-```
-
-### `createAPIContext`
-
-Call `createAPIContext(provider)` once (outside any component) to produce a context component and a `useAPI` hook. Wrap your tree in the context component and call `useAPI` wherever you need data.
-
-```tsx
-import { ClientAPIProvider, ValidationAPIProvider, GET } from "shelving/api";
-import { createAPIContext } from "shelving/react";
-import { STRING, DATA } from "shelving/schema";
-
-const UserSchema = DATA({ id: STRING, name: STRING });
-const getUser = GET("/users/{id}", { id: STRING }, UserSchema);
-
-const provider = new ValidationAPIProvider(new ClientAPIProvider({ url: "https://api.example.com" }));
-const { APIContext, useAPI } = createAPIContext(provider);
-
-function UserCard({ id }: { id: string }) {
-  const store = useAPI(getUser, { id }); // Returns an EndpointStore; component suspends while loading.
-  const user = store.value;
-  return <div>{user.name}</div>;
-}
-
-function App() {
-  return (
-    <APIContext>
-      <ErrorBoundary fallback={<p>Error</p>}>
-        <Suspense fallback={<p>Loading...</p>}>
-          <UserCard id="u_123" />
-        </Suspense>
-      </ErrorBoundary>
-    </APIContext>
-  );
-}
-```
-
-`useAPI` accepts an optional `maxAge` (milliseconds, default 5 minutes). If the cached response is older than `maxAge`, a background re-fetch is triggered automatically.
-
-### `createDBContext`
-
-The DB equivalent works the same way but exposes `useItem` and `useQuery` hooks:
-
-```tsx
 import { createDBContext } from "shelving/react";
 
 const { DBContext, useItem, useQuery } = createDBContext(dbProvider);
 
 function UserCard({ id }: { id: string }) {
-  const store = useItem(Users, id); // ItemStore — suspends while loading.
-  const user = store.value;
-  return <div>{user.name}</div>;
+  const user = useItem(Users, id).value; // Suspends while loading.
+  return <li>{user.name}</li>;
 }
 
 function UserList() {
-  const store = useQuery(Users, { $order: "name" }); // QueryStore.
-  const users = store.value;
-  return <ul>{users.map(u => <li key={u.id}>{u.name}</li>)}</ul>;
+  const users = useQuery(Users, { $order: "name" }).value;
+  return <ul>{users.map(u => <UserCard key={u.id} id={u.id} />)}</ul>;
+}
+
+function App() {
+  return (
+    <DBContext>
+      <ErrorBoundary fallback={<p>Something went wrong.</p>}>
+        <Suspense fallback={<p>Loading…</p>}>
+          <UserList />
+        </Suspense>
+      </ErrorBoundary>
+    </DBContext>
+  );
 }
 ```
 
-### `useInstance`
+### Building a store inside a component
 
-Creates a stable class instance. A new instance is only constructed when the arguments change (by deep equality). Useful for creating stores or caches inside a component without moving them to module scope.
+A store that depends on props can't live at module scope. `useInstance` constructs it once and keeps it stable across renders, while `useStore` subscribes the component to its updates.
 
 ```tsx
-import { useInstance } from "shelving/react";
-import { APICache } from "shelving/api";
+import { useInstance, useStore } from "shelving/react";
+import { BooleanStore } from "shelving/store";
 
-function MyComponent({ provider }: { provider: APIProvider }) {
-  const cache = useInstance(APICache, provider); // Stable across renders.
-  // ...
+function Toggle() {
+  const open = useInstance(BooleanStore); // Created once, stable across renders.
+  useStore(open); // Re-render whenever the store changes.
+  return <button onClick={() => open.toggle()}>{open.value ? "Open" : "Closed"}</button>;
 }
-```
-
-### `useSequence`
-
-Subscribes to an `AsyncIterable` for the lifetime of the component and returns the most recent value. The subscription is recreated whenever the iterable reference changes, so memoising the iterable keeps it stable.
-
-```tsx
-import { useSequence } from "shelving/react";
-
-function LiveCounter({ counter }: { counter: AsyncIterable<number> }) {
-  const count = useSequence(counter); // undefined until first emission.
-  return <span>{count ?? "—"}</span>;
-}
-```
-
-### `useLazy` and `useReduce`
-
-`useLazy` computes a value once and recomputes only when its arguments change:
-
-```tsx
-const sorted = useLazy((items) => [...items].sort(), items);
-```
-
-`useReduce` runs a reducer on every render, receiving the previous return value so you can implement custom memoisation:
-
-```tsx
-const stable = useReduce((prev, next) => {
-  if (prev && isDeepEqual(prev, next)) return prev; // Preserve reference if equal.
-  return next;
-}, incoming);
 ```
 
 ## See also

--- a/modules/react/createAPIContext.md
+++ b/modules/react/createAPIContext.md
@@ -1,0 +1,46 @@
+# createAPIContext
+
+Create a React context for a Shelving [API](/api) provider. Call `createAPIContext(provider)` once, outside any component, to produce an `<APIContext>` wrapper component and a `useAPI` hook. Each mounted `<APIContext>` gets its own in-memory `APICache`, so independent subtrees can use independent providers.
+
+## Usage
+
+Wrap your tree in the context component and call `useAPI(endpoint, payload)` wherever you need data. `useAPI` returns an `EndpointStore`; read `.value` to get the response — the component suspends while loading and surfaces errors to the nearest error boundary.
+
+```tsx
+import { Suspense } from "react";
+import { ClientAPIProvider, ValidationAPIProvider, GET } from "shelving/api";
+import { createAPIContext } from "shelving/react";
+import { STRING, DATA } from "shelving/schema";
+
+const UserSchema = DATA({ id: STRING, name: STRING });
+const getUser = GET("/users/{id}", { id: STRING }, UserSchema);
+
+const provider = new ValidationAPIProvider(new ClientAPIProvider({ url: "https://api.example.com" }));
+const { APIContext, useAPI } = createAPIContext(provider);
+
+function UserCard({ id }: { id: string }) {
+  const store = useAPI(getUser, { id }); // Returns an EndpointStore; component suspends while loading.
+  const user = store.value;
+  return <div>{user.name}</div>;
+}
+
+function App() {
+  return (
+    <APIContext>
+      <ErrorBoundary fallback={<p>Error</p>}>
+        <Suspense fallback={<p>Loading...</p>}>
+          <UserCard id="u_123" />
+        </Suspense>
+      </ErrorBoundary>
+    </APIContext>
+  );
+}
+```
+
+`useAPI` accepts a nullish endpoint — passing `undefined` returns `undefined` instead of a store, which keeps the hook call unconditional. Calling `useAPI` outside an `<APIContext>` throws a `RequiredError`.
+
+## See also
+
+- [createDBContext](/react/createDBContext) — the same pattern for a database provider.
+- [api](/api) — `APIProvider`, `APICache`, `Endpoint`, and `EndpointStore`.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/createDBContext.md
+++ b/modules/react/createDBContext.md
@@ -1,0 +1,46 @@
+# createDBContext
+
+Create a React context for a Shelving [database](/db) provider. Call `createDBContext(provider)` once, outside any component, to produce a `<DBContext>` wrapper component plus `useItem` and `useQuery` hooks. Each mounted `<DBContext>` gets its own in-memory `DBCache`; if the provider chain includes a `CacheDBProvider`, the returned stores reuse that cached data.
+
+## Usage
+
+Wrap your tree in the context component, then call `useItem` for a single document or `useQuery` for a collection query. Both return a store (`ItemStore` / `QueryStore`); read `.value` to get the data — the component suspends while loading.
+
+```tsx
+import { Suspense } from "react";
+import { createDBContext } from "shelving/react";
+
+const { DBContext, useItem, useQuery } = createDBContext(dbProvider);
+
+function UserCard({ id }: { id: string }) {
+  const store = useItem(Users, id); // ItemStore — suspends while loading.
+  const user = store.value;
+  return <div>{user.name}</div>;
+}
+
+function UserList() {
+  const store = useQuery(Users, { $order: "name" }); // QueryStore.
+  const users = store.value;
+  return <ul>{users.map(u => <li key={u.id}>{u.name}</li>)}</ul>;
+}
+
+function App() {
+  return (
+    <DBContext>
+      <ErrorBoundary fallback={<p>Error</p>}>
+        <Suspense fallback={<p>Loading...</p>}>
+          <UserList />
+        </Suspense>
+      </ErrorBoundary>
+    </DBContext>
+  );
+}
+```
+
+Both hooks accept nullish arguments — passing `undefined` for the collection, id, or query returns `undefined` instead of a store, keeping the hook call unconditional. Calling either hook outside a `<DBContext>` throws a `RequiredError`.
+
+## See also
+
+- [createAPIContext](/react/createAPIContext) — the same pattern for an API provider.
+- [db](/db) — `DBProvider`, `DBCache`, `Collection`, `ItemStore`, and `QueryStore`.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useInstance.md
+++ b/modules/react/useInstance.md
@@ -1,0 +1,24 @@
+# useInstance
+
+Create a stable class instance inside a component. A new instance is constructed only when the constructor arguments change (by deep equality of the argument list), so the instance is safe to depend on across renders.
+
+This is useful for creating stores, caches, or other objects that should live for the lifetime of a component without being hoisted to module scope — for example when the object depends on props.
+
+## Usage
+
+```tsx
+import { useInstance } from "shelving/react";
+import { APICache } from "shelving/api";
+
+function MyComponent({ provider }: { provider: APIProvider }) {
+  const cache = useInstance(APICache, provider); // Stable across renders.
+  // ...rebuilt only when `provider` changes.
+}
+```
+
+Arguments are compared by deep equality, so passing equal-but-not-identical values (a fresh object literal each render) does not trigger reconstruction.
+
+## See also
+
+- [useLazy](/react/useLazy) — the same memoisation for an arbitrary factory call rather than a constructor.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useLazy.md
+++ b/modules/react/useLazy.md
@@ -1,0 +1,21 @@
+# useLazy
+
+Compute a value once and recompute it only when its arguments change (by deep equality of the argument list). If the first argument is a function it is called with the remaining arguments; otherwise the value is returned as-is.
+
+`useLazy` is the factory-call counterpart to [`useInstance`](/react/useInstance) — use it when you have a plain function rather than a class constructor.
+
+## Usage
+
+```tsx
+import { useLazy } from "shelving/react";
+
+const sorted = useLazy((items) => [...items].sort(), items);
+```
+
+The result is recomputed only when `items` changes. Because arguments are compared by deep equality, a value that is equal-but-not-identical across renders does not trigger recomputation.
+
+## See also
+
+- [useInstance](/react/useInstance) — the same memoisation for a class constructor call.
+- [useReduce](/react/useReduce) — fold render state with custom equality logic.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useMap.md
+++ b/modules/react/useMap.md
@@ -1,0 +1,25 @@
+# useMap
+
+Create a mutable `Map` that persists for the lifetime of the component. The same `Map` instance is returned on every render, so it is safe to read from and write to across renders without triggering reconstruction.
+
+`useMap` does **not** re-render the component when the map is mutated — it is a stable scratch container, not reactive state. Use it for caches, lookup tables, or per-key bookkeeping that lives alongside a component.
+
+## Usage
+
+```tsx
+import { useMap } from "shelving/react";
+
+function Gallery({ ids }: { ids: string[] }) {
+  const seen = useMap<string, boolean>(); // Same Map on every render.
+  return <>{ids.map(id => {
+    const isNew = !seen.has(id);
+    seen.set(id, true);
+    return <Thumbnail key={id} id={id} highlight={isNew} />;
+  })}</>;
+}
+```
+
+## See also
+
+- [useInstance](/react/useInstance) — a stable instance of any class, rebuilt when its arguments change.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useReduce.md
+++ b/modules/react/useReduce.md
@@ -1,0 +1,26 @@
+# useReduce
+
+Run a reducer on every render, passing it the value returned on the previous render. This lets you implement custom memoisation — deciding render by render whether to keep the previous reference or adopt a new one.
+
+On the first render the reducer's `previous` argument is `undefined`; on every later render it is whatever the reducer returned last time.
+
+## Usage
+
+`useReduce` runs a reducer on every render, receiving the previous return value so you can implement custom equality logic:
+
+```tsx
+import { useReduce } from "shelving/react";
+import { isDeepEqual } from "shelving/util";
+
+const stable = useReduce((prev, next) => {
+  if (prev && isDeepEqual(prev, next)) return prev; // Preserve reference if equal.
+  return next;
+}, incoming);
+```
+
+Here `stable` keeps the same reference for as long as the incoming value is deeply equal, even though `incoming` is a fresh object each render.
+
+## See also
+
+- [useLazy](/react/useLazy) — memoise a factory call by deep-equality of its arguments.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useSequence.md
+++ b/modules/react/useSequence.md
@@ -1,0 +1,23 @@
+# useSequence
+
+Subscribe to an `AsyncIterable` for the lifetime of the component and return its most recent value. The subscription is recreated whenever the iterable reference changes, so memoise the iterable to keep the subscription stable.
+
+The return value is `undefined` until the first emission. If the sequence throws, the error is re-thrown during render so the nearest error boundary catches it.
+
+## Usage
+
+```tsx
+import { useSequence } from "shelving/react";
+
+function LiveCounter({ counter }: { counter: AsyncIterable<number> }) {
+  const count = useSequence(counter); // undefined until first emission.
+  return <span>{count ?? "—"}</span>;
+}
+```
+
+Because the subscription resets when the iterable reference changes, pass a stable reference — hoist it, or memoise it with [`useLazy`](/react/useLazy) / [`useInstance`](/react/useInstance) — to avoid resubscribing on every render.
+
+## See also
+
+- [useStore](/react/useStore) — subscribe to a Shelving `Store` with Suspense support.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/react/useStore.md
+++ b/modules/react/useStore.md
@@ -1,0 +1,37 @@
+# useStore
+
+Subscribe a component to a Shelving [`Store`](/store) so it re-renders whenever the store emits a new value. The store is wired into React's `useSyncExternalStore`, and `useStore` returns the same store it was given.
+
+`useStore` only handles the subscription. To read the value, use `store.value` — which throws a `Promise` while the store is loading (caught by `<Suspense>`) and throws the error reason if the store has failed (caught by an error boundary).
+
+## Usage
+
+`useStore` subscribes to a store and returns it. The component suspends while the store is loading and surfaces errors to the nearest error boundary.
+
+```tsx
+import { Suspense } from "react";
+import { useStore } from "shelving/react";
+
+function UserCard({ store }: { store: Store<User> }) {
+  useStore(store); // Subscribe — re-renders when the store updates.
+  const user = store.value; // Throws Promise (loading) or reason (error).
+  return <div>{user.name}</div>;
+}
+
+function App() {
+  return (
+    <ErrorBoundary fallback={<p>Something went wrong.</p>}>
+      <Suspense fallback={<p>Loading...</p>}>
+        <UserCard store={userStore} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+```
+
+The argument is optional — passing `undefined` is allowed (the hook is still called unconditionally, satisfying the rules of hooks) and returns `undefined`.
+
+## See also
+
+- [store](/store) — the `Store` class this hook subscribes to.
+- [react](/react) — overview of all React hooks and context helpers.

--- a/modules/schema/ArraySchema.md
+++ b/modules/schema/ArraySchema.md
@@ -1,0 +1,25 @@
+# ArraySchema
+
+Validates a value into a `readonly` array, validating each element against an `items` schema. Following the robustness principle, a comma-separated string is split into an array, and a missing value falls back to an empty array.
+
+`ARRAY(itemSchema)` is the factory that builds an `ArraySchema` for a given element schema.
+
+## Usage
+
+```ts
+import { ARRAY, STRING, NUMBER } from "shelving/schema";
+
+const TAGS = ARRAY(STRING);
+TAGS.validate(["a", "b"]);     // ["a", "b"]
+TAGS.validate("a,b,c");        // ["a", "b", "c"]  (split on comma)
+TAGS.validate(undefined);      // []
+
+const NUMBERS = ARRAY(NUMBER);
+NUMBERS.validate([1, 2]);      // [1, 2]
+NUMBERS.validate("1,2,3");     // [1, 2, 3]  (split on comma, each coerced)
+NUMBERS.validate(undefined);   // []
+```
+
+## See also
+
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/BooleanSchema.md
+++ b/modules/schema/BooleanSchema.md
@@ -1,0 +1,21 @@
+# BooleanSchema
+
+Validates a value into a `boolean`. Following the robustness principle, the strings `"no"` and `"false"` coerce to `false`, and any other value is tested for truthiness. A missing value falls back to the schema's `value` default (`false`).
+
+`BOOLEAN` is the ready-made constant for a boolean field.
+
+## Usage
+
+```ts
+import { BOOLEAN } from "shelving/schema";
+
+BOOLEAN.validate(true);          // true
+BOOLEAN.validate("false");       // false  (coerced)
+BOOLEAN.validate("no");          // false  (coerced)
+BOOLEAN.validate(1);             // true   (truthiness)
+BOOLEAN.validate(undefined);     // false  (default)
+```
+
+## See also
+
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/ChoiceSchema.md
+++ b/modules/schema/ChoiceSchema.md
@@ -1,0 +1,25 @@
+# ChoiceSchema
+
+Validates that a value is one of a known set of options — designed to power a `<select>` field in HTML. The validated type is the union of the option keys.
+
+`CHOICE` builds a `ChoiceSchema` from either an array of strings (keys and labels are the same) or an object (keys are the validated values, object values are display labels).
+
+## Usage
+
+```ts
+import { CHOICE } from "shelving/schema";
+
+// Array form — keys and labels are the same.
+const STATUS = CHOICE(["draft", "published", "archived"] as const);
+STATUS.validate("published"); // "published"
+STATUS.validate("deleted");   // throws "Unknown value"
+
+// Object form — keys are validated values, object values are display labels.
+const Priority = CHOICE({ low: "Low priority", high: "High priority" });
+```
+
+`ChoiceSchema` is iterable and exposes `.keys()` and `.entries()` for building select menus. It does not implicitly default to the first option; pass `value` if you want a preselected choice.
+
+## See also
+
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/CurrencyAmountSchema.md
+++ b/modules/schema/CurrencyAmountSchema.md
@@ -1,0 +1,20 @@
+# CurrencyAmountSchema
+
+A `NumberSchema` subclass for monetary amounts. It rounds to the currency's minor units (e.g. two decimal places for `GBP`) and exposes a `format()` method that renders the amount with the correct currency symbol.
+
+`USD_AMOUNT`, `GBP_AMOUNT`, and `EUR_AMOUNT` are ready-made constants; `CURRENCY_AMOUNT(code)` builds one for any currency code.
+
+## Usage
+
+```ts
+import { CurrencyAmountSchema } from "shelving/schema";
+
+const PRICE = new CurrencyAmountSchema({ title: "Price", currency: "GBP", min: 0 });
+PRICE.validate("12.345");        // 12.35   (rounded to minor units)
+PRICE.format(12.3);              // "£12.30"
+```
+
+## See also
+
+- [NumberSchema](/schema/NumberSchema) — the base class.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/DataSchema.md
+++ b/modules/schema/DataSchema.md
@@ -1,0 +1,62 @@
+# DataSchema
+
+Validates a plain object whose properties each have their own schema. The term `Data` in Shelving refers to a plain object with known named properties; a `DataSchema` is the validator for one.
+
+When several properties fail, the errors are joined by `\n` with each field name prepended — e.g. `"name: Required\nprice: Minimum 0"`. This file also exports the `DATA`, `ITEM`, and `PARTIAL` factories that build `DataSchema` instances.
+
+## Usage
+
+### `DATA` — validate an object
+
+```ts
+import { DATA, BOOLEAN, StringSchema, NumberSchema } from "shelving/schema";
+
+const PRODUCT = DATA({
+  name: new StringSchema({ title: "Name", min: 1, max: 100 }),
+  price: new NumberSchema({ title: "Price", min: 0 }),
+  available: BOOLEAN,
+});
+
+PRODUCT.validate({ name: "Widget", price: 9.99, available: true });
+// { name: "Widget", price: 9.99, available: true }
+
+PRODUCT.validate({ name: "", price: -1, available: true });
+// throws "name: Required\nprice: Minimum 0"
+```
+
+Use `.pick()` and `.omit()` to derive subset schemas without redefining props:
+
+```ts
+const PatchProduct = PRODUCT.omit("available");
+const NameOnly = PRODUCT.pick("name");
+```
+
+### `ITEM` — add a typed `id` field
+
+`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the `Item` type in [util](/util).
+
+```ts
+import { ITEM, STRING, INTEGER, NUMBER } from "shelving/schema";
+
+const PRODUCT_ITEM = ITEM(INTEGER, {
+  name: STRING,
+  price: NUMBER,
+}); // Validates: { id: number, name: string, price: number }
+```
+
+### `PARTIAL` — make every field optional
+
+`PARTIAL` wraps a `DataSchema` so every field becomes optional — useful for PATCH-style update payloads.
+
+```ts
+import { PARTIAL } from "shelving/schema";
+
+const PARTIAL_PRODUCT = PARTIAL(PRODUCT);
+PARTIAL_PRODUCT.validate({ price: 4.99 }); // { price: 4.99 }
+```
+
+## See also
+
+- [util](/util) — the `Data` and `Item` types this schema validates.
+- [db](/db) — `Collection` extends `DataSchema` to validate stored documents.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/NullableSchema.md
+++ b/modules/schema/NullableSchema.md
@@ -1,0 +1,22 @@
+# NullableSchema
+
+Wraps another schema to allow `null` as a valid value. Following the robustness principle, `undefined` and the empty string `""` also coerce to `null`; any other value is delegated to the wrapped schema.
+
+`NULLABLE(schema)` is the factory that builds a `NullableSchema` around an existing schema.
+
+## Usage
+
+```ts
+import { NULLABLE, NUMBER } from "shelving/schema";
+
+const NULLABLE_NUMBER = NULLABLE(NUMBER);
+NULLABLE_NUMBER.validate(null);       // null
+NULLABLE_NUMBER.validate(undefined);  // null
+NULLABLE_NUMBER.validate("");         // null
+NULLABLE_NUMBER.validate(42);         // 42
+```
+
+## See also
+
+- [OptionalSchema](/schema/OptionalSchema) — the `undefined`-allowing equivalent.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/NumberSchema.md
+++ b/modules/schema/NumberSchema.md
@@ -1,0 +1,34 @@
+# NumberSchema
+
+Validates a value into a `number`. Strings that look like numbers are parsed, and a missing value falls back to the schema's `value` default (`0` by default). Construct a `NumberSchema` directly to add constraints like `min`, `max`, and `step`.
+
+`NUMBER` is the ready-made constant for an unconstrained number; `INTEGER` is a `NumberSchema` with `step: 1` constrained to the safe-integer range.
+
+## Usage
+
+### The `NUMBER` constant
+
+```ts
+import { NUMBER } from "shelving/schema";
+
+NUMBER.validate("3.14");         // 3.14   (strings coerced)
+NUMBER.validate(undefined);      // 0      (default)
+```
+
+### Custom number schemas
+
+Construct a `NumberSchema` to apply range and step constraints:
+
+```ts
+import { NumberSchema } from "shelving/schema";
+
+const RATING = new NumberSchema({ title: "Rating", min: 1, max: 5, step: 1 });
+RATING.validate(3);              // 3
+RATING.validate(0);              // throws "Minimum 1"
+```
+
+## See also
+
+- [CurrencyAmountSchema](/schema/CurrencyAmountSchema) — a `NumberSchema` subclass for currency amounts.
+- [StringSchema](/schema/StringSchema) — the string equivalent.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/OptionalSchema.md
+++ b/modules/schema/OptionalSchema.md
@@ -1,0 +1,20 @@
+# OptionalSchema
+
+Wraps another schema to allow `undefined` as a valid value. Any value other than `undefined` is delegated to the wrapped schema. It is mainly used for partial data props.
+
+`OPTIONAL(schema)` is the factory that builds an `OptionalSchema` around an existing schema.
+
+## Usage
+
+```ts
+import { OPTIONAL, NUMBER } from "shelving/schema";
+
+const OPTIONAL_NUMBER = OPTIONAL(NUMBER);
+OPTIONAL_NUMBER.validate(undefined); // undefined
+OPTIONAL_NUMBER.validate(42);        // 42
+```
+
+## See also
+
+- [NullableSchema](/schema/NullableSchema) — the `null`-allowing equivalent.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -44,7 +44,7 @@ Pre-built constants and factory functions cover the most common cases:
 | ----------------------- | -------------------- |
 | `STRING`                | `string`             |
 | `NUMBER`                | `number`             |
-| `CURRENCY`              | `number`             |
+| `CURRENCY_AMOUNT(code)` | `number`             |
 | `BOOLEAN`               | `boolean`            |
 | `DATA(props)`           | `T` (plain object)   |
 | `ARRAY(itemSchema)`     | `readonly T[]`       |
@@ -56,145 +56,23 @@ Pre-built constants and factory functions cover the most common cases:
 
 ## Usage
 
-### Primitive schemas
+Schemas compose: primitives, wrappers (`NULLABLE`, `OPTIONAL`, `ARRAY`), and `DATA` nest freely to describe an entire payload in a single validator. See each schema's own page for detailed usage of that class and its constants.
 
 ```ts
-import { STRING, NUMBER, BOOLEAN, REQUIRED_STRING } from "shelving/schema";
+import { ITEM, STRING, REQUIRED_STRING, NUMBER, ARRAY, OPTIONAL, INTEGER } from "shelving/schema";
 
-STRING.validate("hello");        // "hello"
-STRING.validate(42);             // "42"   (numbers coerced)
-STRING.validate(undefined);      // ""     (default)
-REQUIRED_STRING.validate("");    // throws "Required"
-
-NUMBER.validate("3.14");         // 3.14   (strings coerced)
-NUMBER.validate(undefined);      // 0      (default)
-
-BOOLEAN.validate("false");       // false
-BOOLEAN.validate(1);             // true
-```
-
-### Custom string and number schemas
-
-```ts
-import { CurrencyAmountSchema, StringSchema, NumberSchema } from "shelving/schema";
-
-const USERNAME = new StringSchema({ title: "Username", min: 3, max: 20, match: /^[a-z0-9_]+$/ });
-USERNAME.validate("alice_99");   // "alice_99"
-USERNAME.validate("al");         // throws "Minimum 3 characters"
-USERNAME.validate("ALICE");      // throws "Invalid format"
-
-const RATING = new NumberSchema({ title: "Rating", min: 1, max: 5, step: 1 });
-RATING.validate(3);              // 3
-RATING.validate(0);              // throws "Minimum 1"
-
-const PRICE = new CurrencyAmountSchema({ title: "Price", currency: "GBP", min: 0 });
-PRICE.validate("12.345");        // 12.35
-PRICE.format(12.3);              // "£12.30"
-```
-
-### Choice schemas
-
-Define a schema where a user must choose from a list of known valid values. Designed to power a `<select>` field in HTML.
-
-```ts
-import { CHOICE } from "shelving/schema";
-
-// Array form — keys and labels are the same.
-const STATUS = CHOICE(["draft", "published", "archived"] as const);
-STATUS.validate("published"); // "published"
-STATUS.validate("deleted");   // throws "Unknown value"
-
-// Object form — keys are validated values, object values are display labels.
-const Priority = CHOICE({ low: "Low priority", high: "High priority" });
-```
-
-`ChoiceSchema` is iterable and exposes `.keys()` and `.entries()` for building select menus. It does not implicitly default to the first option; pass `value` if you want a preselected choice.
-
-### Data schemas
-
-The term `Data` in Shelving refers to a plain object with known named properties. A `DataSchema` validates a plain object whose properties each have their own schema.
-
-```ts
-import { DATA, STRING, NUMBER, BOOLEAN, StringSchema, NumberSchema } from "shelving/schema";
-
-const PRODUCT = DATA({
-  name: new StringSchema({ title: "Name", min: 1, max: 100 }),
-  price: new NumberSchema({ title: "Price", min: 0 }),
-  available: BOOLEAN,
+const PRODUCT = ITEM(INTEGER, {
+  name: REQUIRED_STRING,
+  price: NUMBER,
+  tags: ARRAY(STRING),
+  notes: OPTIONAL(STRING),
 });
 
-PRODUCT.validate({ name: "Widget", price: 9.99, available: true });
-// { name: "Widget", price: 9.99, available: true }
+PRODUCT.validate({ id: 1, name: "Widget", price: 9.99, tags: "a,b" });
+// { id: 1, name: "Widget", price: 9.99, tags: ["a", "b"], notes: undefined }
 
-PRODUCT.validate({ name: "", price: -1, available: true });
-// throws "name: Required\nprice: Minimum 0"
-```
-
-Use `.pick()` and `.omit()` to derive subset schemas without redefining props:
-
-```ts
-const PatchProduct = Product.omit("available");
-const NameOnly = Product.pick("name");
-```
-
-### Array schemas
-
-Arrays have a `items` property that defines the schema
-
-```ts
-import { ARRAY, STRING } from "shelving/schema";
-
-const TAGS = ARRAY(STRING);
-TAGS.validate(["a", "b"]);     // ["a", "b"]
-TAGS.validate("a,b,c");        // ["a", "b", "c"]  (split on comma)
-TAGS.validate(undefined);      // []
-
-const NUMBERS = ARRAY(STRING);
-NUMBERS.validate([1, 2]);     // [1, 2]
-NUMBERS.validate("1,2,3");        // [1, 2, 3]  (split on comma)
-NUMBERS.validate(undefined);      // []
-```
-
-### Item schemas
-
-`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the `Item` type in [util](/util).
-
-```ts
-import { ITEM, STRING, INTEGER, NUMBER } from "shelving/schema";
-
-const PRODUCT_ITEM = ITEM(INTEGER, {
-  name: STRING,
-  price: NUMBER,
-}); // Validates: { id: number, name: string, price: number }
-```
-
-### Nullable and optional
-
-`NULLABLE` allows a value to be `null` (and also coerces `undefined` and `""` to `null`). `OPTIONAL` allows `undefined` and is mainly used for partial data props.
-
-```ts
-import { NULLABLE, OPTIONAL, NUMBER } from "shelving/schema";
-
-const NULLABLE_NUMBER = NULLABLE(NUMBER);
-NULLABLE_NUMBER.validate(null);       // null
-NULLABLE_NUMBER.validate(undefined);  // null
-NULLABLE_NUMBER.validate("");         // null
-NULLABLE_NUMBER.validate(42);         // 42
-
-const OPTIONAL_NUMBER = OPTIONAL(NUMBER);
-OPTIONAL_NUMBER.validate(undefined); // undefined
-OPTIONAL_NUMBER.validate(42);        // 42
-```
-
-### Partial schemas
-
-`PARTIAL` wraps a `DataSchema` so every field becomes optional — useful for PATCH-style update payloads.
-
-```ts
-import { PARTIAL } from "shelving/schema";
-
-const PARTIAL_PRODUCT = PARTIAL(PRODUCT);
-PARTIAL_PRODUCT.validate({ price: 4.99 }); // { price: 4.99 }
+PRODUCT.validate({ id: 2, name: "", price: 9.99, tags: [] });
+// throws "name: Required"
 ```
 
 ## See also

--- a/modules/schema/StringSchema.md
+++ b/modules/schema/StringSchema.md
@@ -1,0 +1,36 @@
+# StringSchema
+
+Validates a value into a `string`. Numbers are coerced to their string form, and a missing value falls back to the schema's `value` default (an empty string by default). Construct a `StringSchema` directly to add constraints like `min`, `max`, and `match`.
+
+`STRING` is the ready-made constant for an unconstrained string; `REQUIRED_STRING` is a `StringSchema` with `min: 1`, so an empty string fails validation.
+
+## Usage
+
+### The `STRING` and `REQUIRED_STRING` constants
+
+```ts
+import { STRING, REQUIRED_STRING } from "shelving/schema";
+
+STRING.validate("hello");        // "hello"
+STRING.validate(42);             // "42"   (numbers coerced)
+STRING.validate(undefined);      // ""     (default)
+REQUIRED_STRING.validate("");    // throws "Required"
+```
+
+### Custom string schemas
+
+Construct a `StringSchema` to apply length and pattern constraints:
+
+```ts
+import { StringSchema } from "shelving/schema";
+
+const USERNAME = new StringSchema({ title: "Username", min: 3, max: 20, match: /^[a-z0-9_]+$/ });
+USERNAME.validate("alice_99");   // "alice_99"
+USERNAME.validate("al");         // throws "Minimum 3 characters"
+USERNAME.validate("ALICE");      // throws "Invalid format"
+```
+
+## See also
+
+- [NumberSchema](/schema/NumberSchema) — the numeric equivalent.
+- [schema](/schema) — overview of schema concepts and composition.

--- a/modules/sequence/DeferredSequence.md
+++ b/modules/sequence/DeferredSequence.md
@@ -1,0 +1,39 @@
+# DeferredSequence
+
+A sequence that external code drives on demand. Call `resolve(value)` to publish the next value to every active iterator, `reject(reason)` to publish an error, or `done()` to end iteration cleanly. Calling `cancel()` discards a queued resolution without advancing iterators.
+
+`DeferredSequence` is also a `Promise`, so you can `await` it directly to get just the next value without a loop. It is the primitive [`Store`](/store) uses internally to broadcast changes.
+
+## Usage
+
+### Publish and subscribe
+
+```ts
+import { DeferredSequence } from "shelving/sequence";
+
+const seq = new DeferredSequence<string>();
+
+// Produce values from anywhere:
+setInterval(() => seq.resolve("ping"), 1000);
+
+// Consume in one or more places simultaneously:
+for await (const msg of seq) {
+  console.log(msg); // "ping" every second
+}
+```
+
+Multiple concurrent iterators all advance together — a single `resolve()` delivers to every one.
+
+### Await the next value
+
+Because `DeferredSequence` implements `Promise`, you can `await` it for a single value without setting up a loop:
+
+```ts
+const next = await seq; // resolves when resolve() is next called
+```
+
+## See also
+
+- [Sequence](/sequence/Sequence) — the abstract base class.
+- [store](/store) — `Store` broadcasts changes through a `DeferredSequence`.
+- [sequence](/sequence) — overview of all sequence primitives.

--- a/modules/sequence/InspectSequence.md
+++ b/modules/sequence/InspectSequence.md
@@ -1,0 +1,32 @@
+# InspectSequence
+
+A [`ThroughSequence`](/sequence/ThroughSequence) that records what passes through it without changing the values. As it iterates a source sequence it tracks the `first` and `last` yielded values, the `count` of values, whether iteration is `done`, and the final `returned` value.
+
+Useful in tests and diagnostics when you need to assert on what a sequence produced.
+
+## Usage
+
+```ts
+import { InspectSequence } from "shelving/sequence";
+
+async function* numbers() {
+  yield 10; yield 20; yield 30;
+}
+
+const watch = new InspectSequence(numbers());
+for await (const n of watch) {
+  console.log("yielded", n);
+}
+
+console.log(watch.count);  // 3
+console.log(watch.first);  // 10
+console.log(watch.last);   // 30
+console.log(watch.done);   // true
+```
+
+`first`, `last`, and `returned` throw an `UnexpectedError` if read before the relevant values exist — e.g. `first` before iteration has yielded anything, or `returned` before iteration is `done`.
+
+## See also
+
+- [ThroughSequence](/sequence/ThroughSequence) — the base class.
+- [sequence](/sequence) — overview of all sequence primitives.

--- a/modules/sequence/LazySequence.md
+++ b/modules/sequence/LazySequence.md
@@ -1,0 +1,28 @@
+# LazySequence
+
+A [`ThroughSequence`](/sequence/ThroughSequence) paired with a start/stop callback. The `StartCallback` runs when the first iterator begins iterating; the `StopCallback` it returns runs when the last iterator finishes. This is the sequence equivalent of an observable subscription — work happens only while something is listening.
+
+## Usage
+
+Pass a source iterator and a start callback. The callback sets up the work and returns a teardown function:
+
+```ts
+import { DeferredSequence, LazySequence } from "shelving/sequence";
+
+const deferred = new DeferredSequence<number>();
+
+const seq = new LazySequence(deferred, () => {
+  const id = setInterval(() => deferred.resolve(Date.now()), 500);
+  return () => clearInterval(id); // StopCallback — runs when the last iterator finishes.
+});
+
+for await (const ts of seq) {
+  console.log(ts); // the interval runs only for the duration of this loop
+}
+```
+
+## See also
+
+- [ThroughSequence](/sequence/ThroughSequence) — the base class.
+- [DeferredSequence](/sequence/DeferredSequence) — the source commonly wrapped by a `LazySequence`.
+- [sequence](/sequence) — overview of all sequence primitives.

--- a/modules/sequence/README.md
+++ b/modules/sequence/README.md
@@ -4,60 +4,39 @@ Async-iterator primitives used throughout the shelving library. A "sequence" is 
 
 ## Concepts
 
-**AbstractSequence** is the base class for all sequence types. It implements both `AsyncIterator<T>` and `AsyncIterable<T>` so a single object can be both iterated and passed around as an iterable.
+**`Sequence`** is the abstract base class for every sequence type. It implements `AsyncIterator`, `AsyncIterable`, and `AsyncDisposable` at once, so a single object can be iterated, passed around as an iterable, and disposed. Subclasses implement `next()`.
 
-**DeferredSequence** is a sequence that is also a `Promise`. It holds an internal deferred promise that advances the iterator each time `resolve(value)` is called. Calling `reject(reason)` terminates all current consumers with an error. Calling `cancel()` discards any queued resolution without advancing iterators. Multiple concurrent iterators all advance together when the deferred resolves.
+**`DeferredSequence`** is a sequence you push values into: call `resolve(value)` to publish the next value, `reject(reason)` to publish an error, or `done()` to end iteration. It is also a `Promise`, so you can `await` it to get just the next value. Multiple concurrent iterators all advance together when it resolves.
 
-**LazyDeferredSequence** wraps a `DeferredSequence` with a `StartCallback`/`StopCallback` pair. The callback runs when the first iterator begins iterating and is torn down when the last one finishes — the sequence equivalent of an observable subscription.
+**`ThroughSequence`** wraps a source `AsyncIterator` and presents it as a full `Sequence` — useful for turning a bare iterator into a reusable iterable and guaranteeing `return()` / `throw()` are present.
 
-**ThroughSequence** and **IteratorSequence** are thin adapters for piping values between sequences.
+**`LazySequence`** is a `ThroughSequence` paired with a `StartCallback` / `StopCallback`. The start callback runs when the first iterator begins iterating and is torn down when the last one finishes — the sequence equivalent of an observable subscription.
+
+**`InspectSequence`** is a `ThroughSequence` that records what passed through it — `first`, `last`, `count`, `done`, and `returned` — without changing the values.
 
 Most application code interacts with sequences indirectly via [`Store`](/store), which uses `DeferredSequence` internally. Use the sequence primitives directly only when building new reactive data sources.
 
 ## Usage
 
-### Basic publish/subscribe
+The per-class pages carry the detailed usage. As an integration example, wrapping a `DeferredSequence` in a `LazySequence` gives a producer that only runs while something is listening:
 
 ```ts
-import { DeferredSequence } from "shelving/sequence";
+import { DeferredSequence, LazySequence } from "shelving/sequence";
 
-const seq = new DeferredSequence<string>();
+const deferred = new DeferredSequence<number>();
 
-// Produce values from anywhere:
-setInterval(() => seq.resolve("ping"), 1000);
-
-// Consume in one or more places simultaneously:
-for await (const msg of seq) {
-  console.log(msg); // "ping" every second
-}
-```
-
-### Lazy subscription
-
-`LazyDeferredSequence` starts work only when something is actually iterating, and cleans up automatically when all consumers stop.
-
-```ts
-import { LazyDeferredSequence } from "shelving/sequence";
-
-const seq = new LazyDeferredSequence<number>(deferred => {
-  const id = setInterval(() => deferred.resolve(Date.now()), 500);
-  return () => clearInterval(id); // StopCallback — runs when all iterators finish
+// The interval starts on the first `for await` and stops when the last one ends.
+const clock = new LazySequence(deferred, () => {
+  const id = setInterval(() => deferred.resolve(Date.now()), 1000);
+  return () => clearInterval(id);
 });
 
-for await (const ts of seq) {
-  console.log(ts);
+for await (const ts of clock) {
+  console.log(ts); // a timestamp every second, only while iterating
 }
-```
-
-### Awaiting the next value
-
-Because `DeferredSequence` also implements `Promise`, you can `await` it directly to get the next single value without setting up a full loop:
-
-```ts
-const next = await seq; // waits for the next resolve()
 ```
 
 ## See also
 
 - [`Store`](/store) — observable value container built on `DeferredSequence`
-- [`DB`](/db) — database providers that expose `AsyncIterable` via `getItemSequence` / `getQuerySequence`
+- [`db`](/db) — database providers that expose `AsyncIterable` via `getItemSequence` / `getQuerySequence`

--- a/modules/sequence/Sequence.md
+++ b/modules/sequence/Sequence.md
@@ -1,0 +1,27 @@
+# Sequence
+
+The abstract base class for every sequence type. `Sequence<T, R, N>` implements `AsyncIterator`, `AsyncIterable`, and `AsyncDisposable` at once, so a single object can be iterated with `for await...of`, passed around as an iterable, and disposed with `await using`.
+
+Unlike a generator, a `Sequence` places no one-shot constraint on iteration — throwing does not permanently end it. Subclasses implement the abstract `next()` method; `return()` and `throw()` have generator-like defaults that subclasses can override for cleanup.
+
+## Usage
+
+`Sequence` is not used directly — extend it, or use a built-in subclass (`DeferredSequence`, `ThroughSequence`, `LazySequence`, `InspectSequence`). A minimal subclass only needs `next()`:
+
+```ts
+import { Sequence } from "shelving/sequence";
+
+class CountdownSequence extends Sequence<number, void, void> {
+  constructor(private n: number) { super(); }
+  async next() {
+    return this.n > 0
+      ? { done: false as const, value: this.n-- }
+      : { done: true as const, value: undefined };
+  }
+}
+```
+
+## See also
+
+- [DeferredSequence](/sequence/DeferredSequence) — a sequence you publish values into.
+- [sequence](/sequence) — overview of all sequence primitives.

--- a/modules/sequence/ThroughSequence.md
+++ b/modules/sequence/ThroughSequence.md
@@ -1,0 +1,26 @@
+# ThroughSequence
+
+Wraps a source `AsyncIterator` and presents it as a full `Sequence`. Use it to turn a bare async iterator into a reusable `AsyncIterable`, and to guarantee `return()` and `throw()` are always available — delegating to the source when it provides them.
+
+`ThroughSequence` is the base class for [`LazySequence`](/sequence/LazySequence) and [`InspectSequence`](/sequence/InspectSequence), which add behaviour on top of the pass-through.
+
+## Usage
+
+```ts
+import { ThroughSequence } from "shelving/sequence";
+
+async function* numbers() {
+  yield 1; yield 2; yield 3;
+}
+
+const seq = new ThroughSequence(numbers());
+for await (const n of seq) {
+  console.log(n); // 1, 2, 3
+}
+```
+
+## See also
+
+- [LazySequence](/sequence/LazySequence) — a `ThroughSequence` with start/stop callbacks.
+- [InspectSequence](/sequence/InspectSequence) — a `ThroughSequence` that records what passed through.
+- [sequence](/sequence) — overview of all sequence primitives.

--- a/modules/store/ArrayStore.md
+++ b/modules/store/ArrayStore.md
@@ -1,0 +1,28 @@
+# ArrayStore
+
+A [`Store`](/store/Store) for an array value. `ArrayStore<T>` defaults to an empty array, accepts any iterable as input, and adds immutable array helpers — every mutation produces a new array so consumers see a genuine change.
+
+## Usage
+
+```ts
+import { ArrayStore } from "shelving/store";
+
+const tags = new ArrayStore<string>(["a", "b"]);
+
+tags.add("c");          // ["a", "b", "c"]
+tags.delete("a");       // ["b", "c"]
+tags.toggle("b");       // ["c"] — removes if present, adds if not
+
+console.log(tags.first);   // "c"   (throws if empty)
+console.log(tags.count);   // 1
+console.log(tags.exists);  // true
+
+for (const tag of tags) console.log(tag); // ArrayStore is iterable
+```
+
+Use `.optionalFirst` / `.optionalLast` instead of `.first` / `.last` to get `undefined` rather than a thrown `RequiredError` when the array is empty.
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [store](/store) — overview of all store classes.

--- a/modules/store/BooleanStore.md
+++ b/modules/store/BooleanStore.md
@@ -1,0 +1,20 @@
+# BooleanStore
+
+A [`Store`](/store/Store) for a boolean value. `BooleanStore` defaults to `false`, coerces any assigned value to a boolean, and adds a `.toggle()` helper.
+
+## Usage
+
+```ts
+import { BooleanStore } from "shelving/store";
+
+const open = new BooleanStore(); // defaults to false
+
+open.toggle();        // true
+open.value = 0;       // false — assigned values are coerced to boolean
+console.log(open.value); // false
+```
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [store](/store) — overview of all store classes.

--- a/modules/store/BusyStore.md
+++ b/modules/store/BusyStore.md
@@ -1,0 +1,27 @@
+# BusyStore
+
+A [`Store`](/store/Store) that tracks whether it is currently awaiting a new value. `BusyStore<T>` exposes a `.busy` boolean store that becomes `true` when the store starts awaiting an async value and `false` once that value (or an error) arrives.
+
+`BusyStore` is the base class for `DataStore`, `ArrayStore`, `DictionaryStore`, and `FetchStore` — anything that may resolve a value asynchronously.
+
+## Usage
+
+`.busy` is itself a [`BooleanStore`](/store/BooleanStore), so you can read it or iterate it like any store — useful for driving a loading spinner that is separate from the store's own value:
+
+```ts
+import { BusyStore, NONE } from "shelving/store";
+
+const store = new BusyStore<number>(NONE);
+
+store.value = fetchNextValue(); // assigning a promise — store.busy becomes true
+
+for await (const busy of store.busy) {
+  console.log(busy ? "loading…" : "idle");
+}
+```
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [FetchStore](/store/FetchStore) — extends `BusyStore` with callback-driven fetching.
+- [store](/store) — overview of all store classes.

--- a/modules/store/DataStore.md
+++ b/modules/store/DataStore.md
@@ -1,0 +1,38 @@
+# DataStore
+
+A [`Store`](/store/Store) for a plain object value. `DataStore<T>` adds object-aware helpers on top of the base store: read the whole object with `.data`, or update it without replacing the reference yourself.
+
+`OptionalDataStore<T>` is the variant whose value may be `undefined` — it adds `.exists`, `.require()`, and `.delete()` for the absent case.
+
+## Usage
+
+### `DataStore`
+
+```ts
+import { DataStore } from "shelving/store";
+
+const state = new DataStore<{ name: string; count: number }>({ name: "Dave", count: 0 });
+
+state.update({ count: 1 });   // Partial update — merges into the current value.
+state.set("count", 2);        // Set a single named prop.
+console.log(state.get("name")); // "Dave"
+console.log(state.data);        // { name: "Dave", count: 2 }
+```
+
+### `OptionalDataStore`
+
+```ts
+import { OptionalDataStore, NONE } from "shelving/store";
+
+const profile = new OptionalDataStore<{ name: string }>(NONE);
+
+profile.value = { name: "Dave" };
+console.log(profile.exists);        // true
+console.log(profile.require().name); // "Dave" — throws RequiredError if absent
+profile.delete();                    // value is now undefined
+```
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [store](/store) — overview of all store classes.

--- a/modules/store/DictionaryStore.md
+++ b/modules/store/DictionaryStore.md
@@ -1,0 +1,25 @@
+# DictionaryStore
+
+A [`Store`](/store/Store) for a string-keyed object (a dictionary). `DictionaryStore<T>` defaults to an empty object and adds entry-level helpers — each mutation produces a new object so consumers see a genuine change.
+
+## Usage
+
+```ts
+import { DictionaryStore } from "shelving/store";
+
+const prices = new DictionaryStore<number>({ apple: 1 });
+
+prices.set("banana", 2);          // { apple: 1, banana: 2 }
+prices.update({ apple: 3 });      // { apple: 3, banana: 2 }
+prices.delete("banana");          // { apple: 3 }
+
+console.log(prices.get("apple")); // 3
+console.log(prices.count);        // 1
+
+for (const [key, value] of prices) console.log(key, value); // iterable over entries
+```
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [store](/store) — overview of all store classes.

--- a/modules/store/FetchStore.md
+++ b/modules/store/FetchStore.md
@@ -1,0 +1,32 @@
+# FetchStore
+
+A [`Store`](/store/Store) that fetches its value from a callback. `FetchStore<T>` calls its callback to produce a value, tracks staleness, and re-fetches on demand. Reading `.value` or `.loading` triggers the initial fetch automatically, and concurrent fetches are de-duplicated — only one runs at a time.
+
+It is the base class for the API and database stores (`EndpointStore`, `ItemStore`, `QueryStore`).
+
+## Usage
+
+Pass an initial value (or `NONE`) and a callback. The callback receives an `AbortSignal` it can pass to `fetch()` so a superseded request is cancelled:
+
+```ts
+import { FetchStore, NONE } from "shelving/store";
+
+const store = new FetchStore<User>(NONE, async (signal) => {
+  const res = await fetch("/api/me", { signal });
+  return res.json();
+});
+
+console.log(store.loading);    // true — reading this triggered the fetch
+const user = await store.next; // wait for the first value
+
+store.invalidate();            // mark stale; the next read re-fetches
+await store.refresh();         // re-fetch now
+```
+
+`refresh(maxAge)` accepts a max age in milliseconds: the exported `ALWAYS_REFRESH` (`0`, the default) always re-fetches, while `AVOID_REFRESH` (`Infinity`) only fetches if the store has no value yet.
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [PayloadFetchStore](/store/PayloadFetchStore) — a `FetchStore` driven by a payload store.
+- [store](/store) — overview of all store classes.

--- a/modules/store/PathStore.md
+++ b/modules/store/PathStore.md
@@ -1,0 +1,25 @@
+# PathStore
+
+A [`Store`](/store/Store) for an absolute path such as `/a/b/c`. `PathStore` resolves any relative path assigned to it against a fixed `base`, and adds route-matching helpers useful for navigation state.
+
+## Usage
+
+```ts
+import { PathStore } from "shelving/store";
+
+const route = new PathStore("/products/42");
+
+route.value = "../43";              // resolved against the current path → "/products/43"
+
+route.isActive("/products/43");     // true — exact match of the current path
+route.isProud("/products");         // true — current path is at or below "/products"
+route.getPath("./reviews");         // "/products/43/reviews" — resolve a relative path
+```
+
+The constructor takes an optional second `base` argument (default `/`) used to resolve relative paths assigned to the store.
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [URLStore](/store/URLStore) — the equivalent for full URLs.
+- [store](/store) — overview of all store classes.

--- a/modules/store/PayloadFetchStore.md
+++ b/modules/store/PayloadFetchStore.md
@@ -1,0 +1,32 @@
+# PayloadFetchStore
+
+A [`FetchStore`](/store/FetchStore) whose fetch is driven by a payload. `PayloadFetchStore<P, R>` holds an inner `.payload` store; whenever the payload changes, any in-flight fetch is cancelled and a fresh one starts with the new payload.
+
+This is the base class for `EndpointStore` in the [`api`](/api) module — the payload is the endpoint's request payload.
+
+## Usage
+
+Pass an initial payload, an initial value (or `NONE`), and a callback that receives the current payload:
+
+```ts
+import { PayloadFetchStore, NONE } from "shelving/store";
+
+const store = new PayloadFetchStore<string, User>(
+  "u_1",
+  NONE,
+  async (id, signal) => (await fetch(`/api/users/${id}`, { signal })).json(),
+);
+
+const first = await store.next; // fetches for "u_1"
+
+// Changing the payload cancels the previous fetch and starts a new one.
+store.payload.value = "u_2";
+```
+
+Pass a fourth `debounce` argument (milliseconds) to delay the fetch after a payload change — rapid changes reset the timer, so only the final payload is fetched.
+
+## See also
+
+- [FetchStore](/store/FetchStore) — the base class.
+- [store](/store) — overview of all store classes.
+- [api](/api) — `EndpointStore` extends `PayloadFetchStore`.

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -21,69 +21,30 @@ Observable value containers for reactive state. A `Store<T>` holds a single curr
 | `DataStore<T>` | Adds `.data`, `.update()`, `.get()`, `.set()` helpers for object values. |
 | `OptionalDataStore<T>` | Like `DataStore` but the value may be `undefined`; `.exists` and `.require()` handle the absent case. |
 | `ArrayStore<T>` | Stores an array; adds `.first`, `.last`, `.count`, `.add()`, `.delete()`, `.toggle()`. |
+| `DictionaryStore<T>` | Stores a string-keyed object; adds `.get()`, `.set()`, `.delete()`, `.update()`. |
 | `BooleanStore` | Stores a boolean; adds `.toggle()`. |
+| `PathStore` | Stores an absolute path; adds `.isActive()` / `.isProud()` route helpers. |
+| `URLStore` | Stores a URL; adds query-param helpers and `.isActive()` / `.isProud()`. |
+| `BusyStore<T>` | Adds a `.busy` boolean store that is `true` while awaiting a value. |
+| `FetchStore<T>` | Fetches its value from a callback; adds `refresh()` / `invalidate()`. |
+| `PayloadFetchStore<P, R>` | A `FetchStore` driven by a `.payload` store — changing the payload re-fetches. |
 
 `ItemStore` and `QueryStore` in the [`db`](/db) module extend `FetchStore` directly, adding database-aware fetch and subscription logic.
 
 ## Usage
 
-### Create and update a store
+Every store shares the same core: set `.value`, read it back (or `for await` it), and consumers see the change. The base [`Store`](/store/Store) page covers the full lifecycle; each subclass page covers its own helpers.
+
+As an integration example, `store.through(sequence)` bridges any `AsyncIterable` source into a store — it sets the store's value for each item yielded and re-yields it:
 
 ```ts
 import { Store, NONE } from "shelving/store";
 
-// Start loading (no value yet).
 const store = new Store<number>(NONE);
 
-// Provide a value — any waiting iterators are unblocked.
-store.value = 42;
-
-// Update again.
-store.value = 43;
-```
-
-### Iterate over changes
-
-```ts
-for await (const v of store) {
-  console.log(v); // receives 42, then 43, then any future values
-}
-```
-
-### Check state safely
-
-```ts
-if (store.loading) {
-  // No value yet — safe to check without risk of throwing.
-} else {
-  console.log(store.value);
-}
-```
-
-### Starter — run code only while subscribed
-
-```ts
-import { DataStore, NONE } from "shelving/store";
-
-const store = new DataStore<{ count: number }>(NONE);
-
-// The function runs when the first `for await` begins, and stops when the last one ends.
-store.starter = () => {
-  const id = setInterval(() => {
-    store.value = { count: Date.now() };
-  }, 1000);
-  return () => clearInterval(id);
-};
-```
-
-### Pipe from an async iterable
-
-`store.through(sequence)` is an async generator that sets the store's value for each item yielded by `sequence` and re-yields it. This is the bridge between any `AsyncIterable` source and a `Store`.
-
-```ts
 async function connect(stream: AsyncIterable<number>) {
   for await (const _ of store.through(stream)) {
-    // store.value is updated on each iteration
+    // store.value is updated on each iteration; any consumers re-render
   }
 }
 ```
@@ -92,3 +53,4 @@ async function connect(stream: AsyncIterable<number>) {
 
 - [`sequence`](/sequence) — `DeferredSequence` that powers the store's async iteration
 - [`db`](/db) — `ItemStore` and `QueryStore` extend `Store` for database-backed reactive state
+- [`react`](/react) — `useStore()` subscribes a React component to a store

--- a/modules/store/Store.md
+++ b/modules/store/Store.md
@@ -1,0 +1,68 @@
+# Store
+
+The base observable value container. A `Store<T>` holds one current value, broadcasts changes to every active consumer, and suppresses duplicate emissions using deep equality. It is the class `useStore()` subscribes to and the base every other store extends.
+
+A store starts in a loading state (pass the `NONE` sentinel) or with an initial value. Reading `.value` while loading throws a `Promise`; reading `.loading` is always safe.
+
+## Usage
+
+### Create and update
+
+```ts
+import { Store, NONE } from "shelving/store";
+
+// Start loading (no value yet).
+const store = new Store<number>(NONE);
+
+// Provide a value — any waiting iterators are unblocked.
+store.value = 42;
+
+// Update again.
+store.value = 43;
+```
+
+### Iterate over changes
+
+Iterating emits the current value first (if one exists), then each subsequent value:
+
+```ts
+for await (const v of store) {
+  console.log(v); // 43, then any future values
+}
+```
+
+### Check state safely
+
+```ts
+if (store.loading) {
+  // No value yet — safe to check without risk of throwing.
+} else {
+  console.log(store.value);
+}
+```
+
+### Starter — run code only while subscribed
+
+`store.starter` accepts a function that runs when the first `for await` begins and stops when the last one ends. Use it to wire up external subscriptions that should only be active while something is listening:
+
+```ts
+store.starter = () => {
+  const id = setInterval(() => { store.value = Date.now(); }, 1000);
+  return () => clearInterval(id);
+};
+```
+
+### Pipe from an async iterable
+
+`store.through(sequence)` is an async generator that sets the store's value for each item yielded by `sequence` and re-yields it — the bridge between any `AsyncIterable` source and a store:
+
+```ts
+for await (const _ of store.through(someStream)) {
+  // store.value is updated on each iteration
+}
+```
+
+## See also
+
+- [sequence](/sequence) — `DeferredSequence` that powers the store's iteration.
+- [store](/store) — overview of all store classes.

--- a/modules/store/URLStore.md
+++ b/modules/store/URLStore.md
@@ -1,0 +1,28 @@
+# URLStore
+
+A [`Store`](/store/Store) for a URL such as `https://example.com/a/b/c`. `URLStore` coerces any assigned URL or URL string (resolved against an optional `base`), exposes the URL's parts as accessors, and adds query-param and route-matching helpers.
+
+## Usage
+
+```ts
+import { URLStore } from "shelving/store";
+
+const url = new URLStore("https://example.com/search?q=hats");
+
+console.log(url.hostname);        // "example.com"
+console.log(url.getParam("q"));   // "hats"
+
+url.setParam("page", "2");        // updates the stored URL's query
+url.value = "/search?q=shoes";    // assign a relative path — resolved against the current URL
+
+url.isActive("https://example.com/search?q=shoes"); // true
+url.isProud("https://example.com/search");          // true — current URL sits below this one
+```
+
+Param helpers come in mutating (`setParam`, `updateParams`, `deleteParam`, `clearParams`) and non-mutating (`withParam`, `withParams`, `omitParam`) forms — the latter return a new URL without changing the store.
+
+## See also
+
+- [Store](/store/Store) — the base class.
+- [PathStore](/store/PathStore) — the equivalent for absolute paths.
+- [store](/store) — overview of all store classes.


### PR DESCRIPTION
Restructure the README files across modules to move detailed usage examples and API documentation from monolithic READMEs into focused per-symbol pages, with READMEs serving as high-level guides and entry points.

## Key changes

- **schema module**: Split `README.md` into individual pages for `StringSchema`, `NumberSchema`, `BooleanSchema`, `ArraySchema`, `ChoiceSchema`, `NullableSchema`, `OptionalSchema`, `CurrencyAmountSchema`, and `DataSchema`. Updated the main README to provide a brief overview and composition guide instead of detailed examples.

- **store module**: Created dedicated pages for `Store`, `DataStore`, `ArrayStore`, `DictionaryStore`, `BooleanStore`, `PathStore`, `URLStore`, `FetchStore`, `PayloadFetchStore`, and `BusyStore`. Condensed the main README to focus on the store hierarchy and link to per-class documentation.

- **sequence module**: Added pages for `Sequence`, `DeferredSequence`, `ThroughSequence`, `LazySequence`, and `InspectSequence`. Updated the main README to explain core concepts and direct readers to individual class pages.

- **react module**: Created pages for `useStore`, `useInstance`, `useLazy`, `useReduce`, `useMap`, `useSequence`, `createAPIContext`, and `createDBContext`. Replaced detailed examples in the main README with a task-oriented guide showing how pieces fit together.

- **api/provider module**: Added individual pages for all provider classes (`APIProvider`, `ClientAPIProvider`, `ThroughAPIProvider`, `ValidationAPIProvider`, `LoggingAPIProvider`, `DebugAPIProvider`, `JSONAPIProvider`, `XMLAPIProvider`, `MockAPIProvider`, `MockEndpointAPIProvider`, `CachedAPIProvider`). Updated the main README to list providers and link to focused usage examples.

- **db/provider module**: Created pages for all provider classes (`DBProvider`, `MemoryDBProvider`, `ThroughDBProvider`, `ValidationDBProvider`, `DebugDBProvider`, `ChangesDBProvider`, `MockDBProvider`, `CacheDBProvider`, `SQLProvider`, `SQLiteProvider`, `PostgreSQLProvider`). Updated the main README to reference per-provider documentation.

- **error module**: Added individual pages for each error class (`RequiredError`, `ValueError`, `NetworkError`, `RequestError`, `ResponseError`, `UnexpectedError`, `UnimplementedError`). Condensed the main README to focus on choosing the right class.

- **Minor updates**: Updated `CURRENCY` to `CURRENCY_AMOUNT(code)` in the schema README table; adjusted provider chain documentation in api and db modules to note that each provider has its own page.

## Implementation details

All per-symbol pages follow a consistent structure: one-sentence summary, usage examples with `@example` blocks, and links to related symbols. READMEs now serve as navigation hubs that compose the pieces together for real tasks, with links directing readers to detailed class/function pages for specifics.

https://claude.ai/code/session_01Q95qZXvXVnwjuYEk1U51U4