### PR TITLE
feat(markup): support loose lists (paragraphs inside list items)

### DIFF
--- a/modules/markup/rule/README.md
+++ b/modules/markup/rule/README.md
@@ -24,8 +24,8 @@ Rules declare which contexts they apply in. Block rules only fire in a `"block"`
 | `FENCED_RULE` | `<pre><code>` | ` ``` ` or `~~~` fenced code block; optional language after the fence |
 | `HEADING_RULE` | `<h1>`–`<h6>` | `#` through `######` followed by a space |
 | `SEPARATOR_RULE` | `<hr>` | Three or more repeated `-`, `*`, `•`, `+`, `_`, or `=` characters |
-| `UNORDERED_RULE` | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab |
-| `ORDERED_RULE` | `<ol>` | Lines starting with a number followed by `.`, `)`, or `:` |
+| `UNORDERED_RULE` | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab; blank lines between items make the list loose (`<p>`-wrapped) |
+| `ORDERED_RULE` | `<ol>` | Lines starting with a number followed by `.`, `)`, or `:`; blank lines between items make the list loose (`<p>`-wrapped) |
 | `BLOCKQUOTE_RULE` | `<blockquote>` | Lines starting with `>` |
 | `TABLE_RULE` | `<table>` | Pipe table: header row, `\|---|` delimiter row, body rows |
 | `PARAGRAPH_RULE` | `<p>` | Any remaining block content (priority `-10`, matches last) |

--- a/modules/markup/rule/ordered.test.ts
+++ b/modules/markup/rule/ordered.test.ts
@@ -120,3 +120,53 @@ test("ORDERED", () => {
 		},
 	});
 });
+
+test("ORDERED loose lists", () => {
+	// Items separated by a blank line make the whole list "loose" — each item is wrapped in `<p>`.
+	expect(PARSER.parse("1. ITEM1\n\n2. ITEM2")).toMatchObject({
+		type: "ol",
+		props: {
+			children: [
+				{ type: "li", props: { value: 1, children: { type: "p", props: { children: "ITEM1" } } } },
+				{ type: "li", props: { value: 2, children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+
+	// A loose item can contain multiple paragraphs from indented continuation lines.
+	expect(PARSER.parse("1. ITEM1\n\n   CONTINUED\n2. ITEM2")).toMatchObject({
+		type: "ol",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						value: 1,
+						children: [
+							{ type: "p", props: { children: "ITEM1" } },
+							{ type: "p", props: { children: "CONTINUED" } },
+						],
+					},
+				},
+				{ type: "li", props: { value: 2, children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+
+	// A list with no blank lines stays "tight" — items are not wrapped in `<p>`.
+	expect(PARSER.parse("1. ITEM1\n2. ITEM2")).toMatchObject({
+		type: "ol",
+		props: {
+			children: [
+				{ type: "li", props: { value: 1, children: "ITEM1" } },
+				{ type: "li", props: { value: 2, children: "ITEM2" } },
+			],
+		},
+	});
+
+	// Two blank lines end the list — `\n\n\n` splits it into two separate lists.
+	expect(PARSER.parse("1. ITEM1\n\n\n2. ITEM2")).toMatchObject([
+		{ type: "ol", props: { children: [{ type: "li", props: { value: 1, children: "ITEM1" } }] } },
+		{ type: "ol", props: { children: [{ type: "li", props: { value: 2, children: "ITEM2" } }] } },
+	]);
+});

--- a/modules/markup/rule/ordered.tsx
+++ b/modules/markup/rule/ordered.tsx
@@ -15,10 +15,9 @@ const _ITEM = new RegExp(
 // paragraph keeps the list going (a "loose" list); anything else ends the list.
 const _END = `${BLOCK_SPACE_REGEXP}*(?:$|\\n${LINE_SPACE_REGEXP}*\\n(?!${LINE_SPACE_REGEXP}|${_NUMBER}))`;
 
-// A list is "loose" when it contains a blank line between top-level content — i.e. a blank line
-// that is not purely interior to a nested (tab-indented) sub-list. Loose items are rendered as
-// `<p>`-wrapped blocks instead of inline content.
-const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n(?!\\t)`);
+// A list is "loose" when it contains a blank line. Loose items are parsed as blocks so their
+// content is wrapped in `<p>` tags instead of rendered inline.
+const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n`);
 
 /**
  * Ordered list.

--- a/modules/markup/rule/ordered.tsx
+++ b/modules/markup/rule/ordered.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import type { MarkupParser } from "../MarkupParser.js";
 import { createMarkupRule } from "../MarkupRule.js";
-import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, BLOCK_START_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
 
 const _INDENT = /^\t/gm; // Nesting is recognised with tabs only.
 const _NUMBER = "\\d{1,9}[.):]"; // Number for a numbered list, e.g. `1.` or `2)` or `3:` followed by one or more spaces.
@@ -10,28 +10,42 @@ const _ITEM = new RegExp(
 	"g",
 );
 
+// End of a list block: the end of the string, or a blank line that is *not* followed by another
+// item or an indented continuation line. A blank line before a new item or a continuation
+// paragraph keeps the list going (a "loose" list); anything else ends the list.
+const _END = `${BLOCK_SPACE_REGEXP}*(?:$|\\n${LINE_SPACE_REGEXP}*\\n(?!${LINE_SPACE_REGEXP}|${_NUMBER}))`;
+
+// A list is "loose" when it contains a blank line between top-level content — i.e. a blank line
+// that is not purely interior to a nested (tab-indented) sub-list. Loose items are rendered as
+// `<p>`-wrapped blocks instead of inline content.
+const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n(?!\\t)`);
+
 /**
  * Ordered list.
  * - Line starting with number, followed by `.`, `)` or `:` character, then one or more space characters.
  * - No spaces can appear before the number character.
  * - Second-level list can be created by indenting with `\t` one tab.
+ * - List block runs until a blank line that is not followed by another item or an indented continuation line.
+ * - A list with blank lines between its items (or before a continuation paragraph) is "loose": its items are wrapped in `<p>` tags.
  * - Sparse lists are not supported.
  */
 export const ORDERED_RULE = createMarkupRule<{
 	list: string;
 }>(
-	createBlockRegExp(`(?<list>${_NUMBER}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`),
+	createBlockRegExp(`(?<list>${_NUMBER}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`, BLOCK_START_REGEXP, _END),
 	(key, { list }, parser) => <ol key={key}>{Array.from(_getOrderedItems(list, parser))}</ol>,
 	["block", "list"],
 );
 
 /** Parse a markdown list into a set of items elements. */
 function* _getOrderedItems(list: string, parser: MarkupParser): Iterable<ReactElement> {
+	// Items of a loose list are parsed as blocks so `PARAGRAPH_RULE` wraps their content in `<p>`.
+	const context = _LOOSE.test(list) ? "block" : "list";
 	let key = 0;
 	for (const [_unused, number = "", item = ""] of list.matchAll(_ITEM)) {
 		yield (
 			<li key={key++} value={Number.parseInt(number, 10)}>
-				{parser.parse(item.replace(_INDENT, ""), "list")}
+				{parser.parse(item.replace(_INDENT, ""), context)}
 			</li>
 		);
 	}

--- a/modules/markup/rule/unordered.test.ts
+++ b/modules/markup/rule/unordered.test.ts
@@ -130,3 +130,90 @@ test("UNORDERED", () => {
 		},
 	});
 });
+
+test("UNORDERED loose lists", () => {
+	// Items separated by a blank line make the whole list "loose" — each item is wrapped in `<p>`.
+	expect(PARSER.parse("- ITEM1\n\n- ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM1" } } } },
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+
+	// Works with any bullet symbol.
+	expect(PARSER.parse("* ITEM1\n\n* ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM1" } } } },
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+
+	// A loose item can contain multiple paragraphs from indented continuation lines.
+	expect(PARSER.parse("- ITEM1\n\n  CONTINUED\n- ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: [
+							{ type: "p", props: { children: "ITEM1" } },
+							{ type: "p", props: { children: "CONTINUED" } },
+						],
+					},
+				},
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+
+	// A list with no blank lines stays "tight" — items are not wrapped in `<p>`.
+	expect(PARSER.parse("- ITEM1\n- ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{ type: "li", props: { children: "ITEM1" } },
+				{ type: "li", props: { children: "ITEM2" } },
+			],
+		},
+	});
+
+	// Two blank lines end the list — `\n\n\n` splits it into two separate lists.
+	expect(PARSER.parse("- ITEM1\n\n\n- ITEM2")).toMatchObject([
+		{ type: "ul", props: { children: [{ type: "li", props: { children: "ITEM1" } }] } },
+		{ type: "ul", props: { children: [{ type: "li", props: { children: "ITEM2" } }] } },
+	]);
+
+	// A loose list can contain a nested (tight) sub-list.
+	expect(PARSER.parse("- ITEM1\n\t- SUB1\n\t- SUB2\n\n- ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: [
+							{ type: "p", props: { children: "ITEM1" } },
+							{
+								type: "ul",
+								props: {
+									children: [
+										{ type: "li", props: { children: "SUB1" } },
+										{ type: "li", props: { children: "SUB2" } },
+									],
+								},
+							},
+						],
+					},
+				},
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
+});

--- a/modules/markup/rule/unordered.test.ts
+++ b/modules/markup/rule/unordered.test.ts
@@ -216,4 +216,23 @@ test("UNORDERED loose lists", () => {
 			],
 		},
 	});
+
+	// A blank line before a nested sub-list keeps the sub-list intact, with no stray `<br>`.
+	expect(PARSER.parse("- ITEM1\n\n\t- SUB\n- ITEM2")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: [
+							{ type: "p", props: { children: "ITEM1" } },
+							{ type: "ul", props: { children: [{ type: "li", props: { children: "SUB" } }] } },
+						],
+					},
+				},
+				{ type: "li", props: { children: { type: "p", props: { children: "ITEM2" } } } },
+			],
+		},
+	});
 });

--- a/modules/markup/rule/unordered.tsx
+++ b/modules/markup/rule/unordered.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import type { MarkupParser } from "../MarkupParser.js";
 import { createMarkupRule } from "../MarkupRule.js";
-import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
+import { BLOCK_CONTENT_REGEXP, BLOCK_SPACE_REGEXP, BLOCK_START_REGEXP, createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
 
 const _INDENT = /^\t/gm; // Nesting is recognised with tabs only.
 const _BULLET = "[-*•+]"; // Allowed bullet symbol.
@@ -10,24 +10,37 @@ const _ITEM = new RegExp(
 	"g",
 );
 
+// End of a list block: the end of the string, or a blank line that is *not* followed by another
+// item or an indented continuation line. A blank line before a new item or a continuation
+// paragraph keeps the list going (a "loose" list); anything else ends the list.
+const _END = `${BLOCK_SPACE_REGEXP}*(?:$|\\n${LINE_SPACE_REGEXP}*\\n(?!${LINE_SPACE_REGEXP}|${_BULLET}))`;
+
+// A list is "loose" when it contains a blank line between top-level content — i.e. a blank line
+// that is not purely interior to a nested (tab-indented) sub-list. Loose items are rendered as
+// `<p>`-wrapped blocks instead of inline content.
+const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n(?!\\t)`);
+
 /**
  * Unordered list.
  * - Line starting with `-`, `*`, `•`, or `+` character followed by one or more space characters.
  * - No spaces can appear before the bullet character.
  * - Second-level list can be created by indenting with `\t` one tab.
- * - List block is ended by `\n\n` two newline characters.
+ * - List block runs until a blank line that is not followed by another item or an indented continuation line.
+ * - A list with blank lines between its items (or before a continuation paragraph) is "loose": its items are wrapped in `<p>` tags.
  * - Sparse lists are not supported.
  */
 export const UNORDERED_RULE = createMarkupRule<{
 	list: string;
 }>(
-	createBlockRegExp(`(?<list>${_BULLET}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`),
+	createBlockRegExp(`(?<list>${_BULLET}(?:${LINE_SPACE_REGEXP}+${BLOCK_CONTENT_REGEXP})?)`, BLOCK_START_REGEXP, _END),
 	(key, { list }, parser) => <ul key={key}>{Array.from(_getItems(list, parser))}</ul>,
 	["block", "list"],
 );
 
 /** Parse a markdown list into a set of items elements. */
 export function* _getItems(list: string, parser: MarkupParser): Iterable<ReactElement> {
+	// Items of a loose list are parsed as blocks so `PARAGRAPH_RULE` wraps their content in `<p>`.
+	const context = _LOOSE.test(list) ? "block" : "list";
 	let key = 0;
-	for (const [_unused, item = ""] of list.matchAll(_ITEM)) yield <li key={key++}>{parser.parse(item.replace(_INDENT, ""), "list")}</li>;
+	for (const [_unused, item = ""] of list.matchAll(_ITEM)) yield <li key={key++}>{parser.parse(item.replace(_INDENT, ""), context)}</li>;
 }

--- a/modules/markup/rule/unordered.tsx
+++ b/modules/markup/rule/unordered.tsx
@@ -15,10 +15,9 @@ const _ITEM = new RegExp(
 // paragraph keeps the list going (a "loose" list); anything else ends the list.
 const _END = `${BLOCK_SPACE_REGEXP}*(?:$|\\n${LINE_SPACE_REGEXP}*\\n(?!${LINE_SPACE_REGEXP}|${_BULLET}))`;
 
-// A list is "loose" when it contains a blank line between top-level content — i.e. a blank line
-// that is not purely interior to a nested (tab-indented) sub-list. Loose items are rendered as
-// `<p>`-wrapped blocks instead of inline content.
-const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n(?!\\t)`);
+// A list is "loose" when it contains a blank line. Loose items are parsed as blocks so their
+// content is wrapped in `<p>` tags instead of rendered inline.
+const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n`);
 
 /**
  * Unordered list.


### PR DESCRIPTION
## Summary

Adds **loose list** support to `UNORDERED_RULE` and `ORDERED_RULE`, built on top of the tiered markup parser from #113.

- **List blocks now span blank lines.** Previously a list ended at the first blank line. The list block now continues across a blank line as long as that blank line is followed by another item or an indented continuation line. Two consecutive blank lines still end the list, and a blank line followed by ordinary text still ends it.
- **Loose lists wrap items in `<p>`.** Following the CommonMark definition, a list is *loose* when it contains an interior blank line (items separated by a blank line, or an item with a continuation paragraph). Loose items are parsed in a `block` context so `PARAGRAPH_RULE` wraps each item's content in `<p>` tags. Tight lists (no blank lines) render exactly as before.
- Implemented by modifying the existing list rules — there is no separate "loose list" rule. A custom block-end regexp captures greedily up to a blank line that is "definitely not a list" (next line is neither an item marker nor indented), and a small `_LOOSE` test on the captured block picks the child render context.

Loose detection treats **any** interior blank line as making the list loose. This can slightly over-loosen a tight outer list that contains a loose nested sub-list (the outer item's text gets a `<p>`), but it keeps the implementation simple and avoids a stray `<br>` artifact that an earlier tab-aware heuristic produced.

Closes #53

## Test plan

- [x] `bun run test` — unit tests pass, lint + type checks clean
- [x] New `UNORDERED loose lists` / `ORDERED loose lists` test cases: items separated by blank lines, multi-paragraph items, tight lists staying tight, `\n\n\n` splitting into two lists, loose list with a nested sub-list (blank before and after the sub-list)
- [x] Existing tight-list and `Block combinations` integration tests unaffected

https://claude.ai/code/session_01Xb7iiX1Tm8TLQfwPWiQK4E