### PR TITLE
feat(markup): support todo list syntax (- [x] / - [ ])

### DIFF
--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -1,49 +1,62 @@
 # markup
 
-A rule-based Markdown renderer that produces JSX output for user-facing content.
+A rule-based Markdown renderer that turns user-facing text into React nodes.
 
 ## Concepts
 
-This module converts Markdown text into JSX nodes — suitable for rendering blog post bodies, user-written descriptions, or any rich text that originates outside your code. It does not depend on a specific JSX framework; it emits plain JSX element objects that React (or any compatible renderer) can consume.
+This module converts Markdown-ish text into React nodes — suitable for rendering blog post bodies, user-written descriptions, or any rich text that originates outside your code.
 
-The renderer is rule-based. Each block element type — heading, paragraph, blockquote, fenced code block, ordered list, unordered list, separator — is handled by an independent `MarkupRule`. Inline elements (bold, italic, inline code, links, autolinks, line breaks) are a separate rule set applied within block content. Rules match via regular expression and render to a JSX element; the engine picks the highest-priority earliest match at each position and recurses on the prefix and suffix.
+Rendering is done by a `MarkupParser` instance. Each block element type — heading, paragraph, blockquote, fenced code, ordered list, unordered list (including `[ ]` / `[x]` todo items), table, separator — is handled by an independent `MarkupRule`. Inline elements — bold, italic, inserted/deleted/highlighted text, inline code, links, autolinks, line breaks — are a separate rule set applied within block content.
 
-The default ruleset intentionally diverges from CommonMark in a few places:
+The engine groups rules into priority tiers and resolves the highest tier first. Once a tier claims a region of the text that region is "masked" so lower tiers cannot match into or across it. Each rule renders its match to a React element and recurses into its own children, optionally in a different context.
 
-- `*asterisk*` is always `<strong>`, `_underscore_` is always `<em>`. There is no ambiguity between the two.
-- A single `\n` newline is always a `<br />`. You do not need a trailing double-space.
-- Literal HTML tags and `&amp;` character entities are not supported — they are treated as plain text.
+The default ruleset intentionally diverges from CommonMark:
+
+- `*asterisk*` is always `<strong>`, `_underscore_` is always `<em>` — no ambiguity between the two.
+- A single `\n` newline is always a `<br />` — no trailing double-space needed.
+- Literal HTML tags and `&amp;` character entities are not supported — they render as plain text.
 - All bare URLs are autolinked.
+- Whitespace is not fussy: there is no four-space indented code block, and nesting (e.g. a sub-list) uses a single tab per level — see [Input normalisation](#input-normalisation).
 
 ## Usage
 
-### Rendering Markdown to JSX
+### Rendering markup
+
+Create a `MarkupParser` and call `.parse()`:
 
 ```ts
-import { renderMarkup, MARKUP_RULES } from "shelving/markup";
+import { MarkupParser } from "shelving/markup";
 
-const node = renderMarkup("# Hello\n\nThis is **bold** and _italic_.", {
-  rules: MARKUP_RULES,
-});
-
-// `node` is a JSXNode — pass it anywhere React expects children.
+const parser = new MarkupParser();
+const node = parser.parse("# Hello\n\nThis is *bold* and _italic_.");
+// `node` is a `ReactNode` — render it directly in JSX.
 ```
 
-`renderMarkup` returns a `JSXNode`: a single `JSXElement`, a `string`, an array of those, `null`, or `undefined`.
+`parse()` returns a `ReactNode`: a single element, a string, an array of those, or `null`.
+
+For the common case the shared `MARKUP_PARSER` sentinel — a `MarkupParser` with default options — saves constructing one:
+
+```ts
+import { MARKUP_PARSER } from "shelving/markup";
+
+const node = MARKUP_PARSER.parse(content);
+```
 
 ### Options
 
+`MarkupParser` is constructed with `MarkupOptions`:
+
 | Option | Type | Description |
 |---|---|---|
-| `rules` | `MarkupRules` | The rules to apply (required). Use `MARKUP_RULES` for the default set. |
-| `rel` | `string` | `rel` attribute applied to all rendered links, e.g. `"nofollow ugc"`. |
-| `url` | `ImmutableURL` | Current page URL — base for resolving relative refs (`./foo`, `#x`, bare segments). |
-| `root` | `ImmutableURL` | Site root URL — base for resolving site-absolute paths (`/foo`), honoring its subfolder. |
+| `rules` | `MarkupRules` | Rules to apply. Defaults to `MARKUP_RULES` (all block + inline rules). |
+| `rel` | `string` | `rel` attribute applied to every rendered link, e.g. `"nofollow ugc"`. |
+| `url` | `ImmutableURL` | Current page URL — base for resolving relative refs (`./foo`, `#x`). |
+| `root` | `ImmutableURL` | Site root URL — base for resolving site-absolute paths (`/foo`). |
 | `schemes` | `URISchemes` | Allowed URI schemes for links. Defaults to `["http:", "https:"]`. |
+| `context` | `string` | Default starting context. Defaults to `"block"`. |
 
 ```ts
-const node = renderMarkup(content, {
-  rules: MARKUP_RULES,
+const parser = new MarkupParser({
   rel: "nofollow ugc",
   url: requireURL("https://example.com/page/"),
   root: requireURL("https://example.com/"),
@@ -51,41 +64,61 @@ const node = renderMarkup(content, {
 });
 ```
 
-Link href resolution goes through [`getLink`](/util) — site-absolute paths resolve against `root`, relative refs resolve against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
+Link href resolution goes through [`getLink`](/util) — site-absolute paths resolve against `root`, relative refs against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
 
 ### Block-only or inline-only rendering
 
-If you need to render only block-level content or only inline content, use the focused rule sets directly:
+`parse()` takes an optional second argument — the starting context. Rules declare which contexts they apply in, so `"inline"` skips every block-level rule:
 
 ```ts
-import { renderMarkup, MARKUP_RULES_BLOCK, MARKUP_RULES_INLINE } from "shelving/markup";
-
 // Inline only — no block wrappers like <p> or <h1>.
-const inline = renderMarkup("Some *bold* text", { rules: MARKUP_RULES_INLINE }, "inline");
+const inline = MARKUP_PARSER.parse("Some *bold* text", "inline");
 ```
 
-The third argument to `renderMarkup` is the starting context (`"block"` by default). Rules declare which contexts they apply in, so passing `"inline"` skips all block-level rules.
+`MARKUP_RULES_BLOCK` and `MARKUP_RULES_INLINE` expose the block and inline rule sets separately if you want a parser with only one.
 
 ### Custom rules
 
 Build custom rules with `createMarkupRule` and combine them with the defaults:
 
-```ts
-import { createElement } from "react";
-import { createMarkupRule, MARKUP_RULES, renderMarkup } from "shelving/markup";
+```tsx
+import { createMarkupRule, MARKUP_RULES, MarkupParser } from "shelving/markup";
 
-const HIGHLIGHT_RULE = createMarkupRule(
+const HIGHLIGHT_RULE = createMarkupRule<{ text: string }>(
   /==(?<text>[^=]+)==/,
-  ({ groups: { text } }, _options, key) => createElement("mark", { key }, text),
+  (key, { text }) => <mark key={key}>{text}</mark>,
   ["inline"],
 );
 
-const node = renderMarkup(content, {
-  rules: [...MARKUP_RULES, HIGHLIGHT_RULE],
-});
+const parser = new MarkupParser({ rules: [...MARKUP_RULES, HIGHLIGHT_RULE] });
 ```
+
+`createMarkupRule` takes a regexp (named captures are typed), a render function `(key, data, parser) => ReactElement`, the `contexts` the rule applies in, and an optional `priority` (default `0`; higher priorities form earlier-resolved tiers). See [markup/rule](/markup/rule) for the full built-in rule set.
+
+## Input normalisation
+
+The parser expects **normalised** input and deliberately does not try to absorb every whitespace variation. Normalised text means:
+
+- Indentation is **tabs** — one tab per nesting level. Leading spaces are not significant.
+- No trailing whitespace at the end of a line.
+- No runs of more than two `\n` newlines; `\r\n` / `\r` line endings are normalised to `\n`.
+- Control characters are removed.
+
+Keeping this guarantee out of the rules is what keeps them simple: nesting — a sub-list inside a list item, a quote inside a quote — is always exactly one extra tab, never an ambiguous run of spaces.
+
+Normalisation is **not** performed by the parser — give it text that is already clean. `sanitizeMultilineText()` from [`shelving/util`](/util) produces exactly this form: it converts four-space indents to tabs, strips sub-tab leading spaces, trims trailing whitespace, and collapses three-or-more newlines to two. [`StringSchema`](/schema) runs `sanitizeMultilineText()` automatically when validating any multi-line field (`rows > 1`), so text stored through a schema is already normalised.
+
+```ts
+import { sanitizeMultilineText } from "shelving/util";
+
+// Raw / untrusted text — normalise before parsing.
+const node = MARKUP_PARSER.parse(sanitizeMultilineText(untrustedInput));
+```
+
+If the text reaches you straight from a `StringSchema`-validated field it is already normalised, and you can parse it directly.
 
 ## See also
 
-- [error](/error) — error classes used elsewhere in shelving
-- [util](/util) — shared utilities including JSX types and regexp helpers
+- [markup/rule](/markup/rule) — the built-in rule set and per-rule syntax reference
+- [util](/util) — shared utilities, including `sanitizeMultilineText` and the regexp helpers used by rules
+- [schema](/schema) — `StringSchema`, which normalises multi-line text on validation

--- a/modules/markup/rule/README.md
+++ b/modules/markup/rule/README.md
@@ -24,7 +24,7 @@ Rules declare which contexts they apply in. Block rules only fire in a `"block"`
 | `FENCED_RULE` | `<pre><code>` | ` ``` ` or `~~~` fenced code block; optional language after the fence |
 | `HEADING_RULE` | `<h1>`–`<h6>` | `#` through `######` followed by a space |
 | `SEPARATOR_RULE` | `<hr>` | Three or more repeated `-`, `*`, `•`, `+`, `_`, or `=` characters |
-| `UNORDERED_RULE` | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab; blank lines between items make the list loose (`<p>`-wrapped) |
+| `UNORDERED_RULE` | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab; blank lines between items make the list loose (`<p>`-wrapped); items starting with `[ ]` / `[x]` render a todo checkbox |
 | `ORDERED_RULE` | `<ol>` | Lines starting with a number followed by `.`, `)`, or `:`; blank lines between items make the list loose (`<p>`-wrapped) |
 | `BLOCKQUOTE_RULE` | `<blockquote>` | Lines starting with `>` |
 | `TABLE_RULE` | `<table>` | Pipe table: header row, `\|---|` delimiter row, body rows |

--- a/modules/markup/rule/README.md
+++ b/modules/markup/rule/README.md
@@ -4,9 +4,11 @@ The built-in rule set that drives the [markup](/markup) renderer. This directory
 
 ## Concepts
 
-Each `MarkupRule` in this directory handles one element type. Rules are combined into `MarkupRules` arrays and passed to `renderMarkup` as `options.rules`. The renderer tries every rule against the current input, picks the highest-priority earliest match, renders that element, then recurses on the text before and after it.
+Each `MarkupRule` in this directory handles one element type. Rules are combined into `MarkupRules` arrays and handed to a `MarkupParser` (via the `rules` option, or the default `MARKUP_RULES`).
 
-Rules declare which contexts they apply in. Block rules only fire in a `"block"` context; inline rules fire in `"inline"`, `"list"`, or `"link"` contexts. The `priority` field (default `0`) breaks ties when two rules match at the same position.
+The engine groups rules into priority tiers and resolves the highest tier first; once a tier claims a region of the text that region is masked so lower tiers cannot match into or across it. `priority` (default `0`) sets the tier — higher resolves first.
+
+Rules declare which contexts they apply in. Block rules fire in a `"block"` context; inline rules fire in `"inline"`, `"list"`, or `"link"` contexts.
 
 ## Available rule sets
 
@@ -15,7 +17,6 @@ Rules declare which contexts they apply in. Block rules only fire in a `"block"`
 | `MARKUP_RULES` | All block and inline rules — the default, use this unless you have a reason not to |
 | `MARKUP_RULES_BLOCK` | Block-only rules: fenced code, heading, separator, lists, blockquote, table, paragraph |
 | `MARKUP_RULES_INLINE` | Inline-only rules: inline code, link, autolink, strong/em/del/ins/mark, linebreak |
-| `MARKUP_OPTIONS` | `{ rules: MARKUP_RULES }` — a ready-made options object |
 
 ## Block rules
 
@@ -42,33 +43,31 @@ Rules declare which contexts they apply in. Block rules only fire in a `"block"`
 
 ## Adding a custom rule
 
-Use `createMarkupRule` from `shelving/markup` to build a typed rule, then merge it into the rules array you pass to `renderMarkup`:
+Use `createMarkupRule` from `shelving/markup` to build a typed rule, then merge it into the rules array you give a `MarkupParser`:
 
-```ts
-import { createMarkupRule, MARKUP_RULES, renderMarkup } from "shelving/markup";
+```tsx
+import { createMarkupRule, MARKUP_RULES, MarkupParser } from "shelving/markup";
 
-const HIGHLIGHT_RULE = createMarkupRule(
+const HIGHLIGHT_RULE = createMarkupRule<{ text: string }>(
   /==(?<text>[^=]+)==/,
-  ({ groups: { text } }, _options, key) => <mark key={key}>{text}</mark>,
+  (key, { text }) => <mark key={key}>{text}</mark>,
   ["inline"],
   5, // optional priority; default is 0
 );
 
-const node = renderMarkup(content, {
-  rules: [...MARKUP_RULES, HIGHLIGHT_RULE],
-});
+const parser = new MarkupParser({ rules: [...MARKUP_RULES, HIGHLIGHT_RULE] });
 ```
 
 `createMarkupRule` accepts:
 
 1. A `RegExp` or named-capture `NamedRegExp`.
-2. A render function `(match, options, key) => ReactElement`. Named captures are typed when you use `NamedRegExp`.
+2. A render function `(key, data, parser) => ReactElement`. `data` is the regexp's named capture groups, typed when you pass a `NamedRegExp`.
 3. A `contexts` array — at least one of `"block"`, `"inline"`, `"list"`, `"link"`.
-4. An optional `priority` number (default `0`). Higher values win over same-position matches.
+4. An optional `priority` number (default `0`). Higher priorities form earlier-resolved tiers.
 
 To replace the built-in rule for a specific element, omit that constant from the base array and add your own.
 
 ## See also
 
-- [markup](/markup) — `renderMarkup`, `MarkupRule`, `createMarkupRule`, and the full renderer
+- [markup](/markup) — `MarkupParser`, `MarkupRule`, `createMarkupRule`, and the full renderer
 - [markup/util](/markup/util) — regexp helpers and internal types used by the rules

--- a/modules/markup/rule/unordered.test.ts
+++ b/modules/markup/rule/unordered.test.ts
@@ -217,3 +217,181 @@ test("UNORDERED loose lists", () => {
 		},
 	});
 });
+
+test("UNORDERED todo lists", () => {
+	// A checked `[x]` todo item — a checked checkbox plus the content, wrapped in a label.
+	expect(PARSER.parse("- [x] DONE")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [{ type: "input", props: { type: "checkbox", defaultChecked: true } }, "DONE"],
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+
+	// An unchecked `[ ]` todo item — an unchecked checkbox.
+	expect(PARSER.parse("- [ ] TODO")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [{ type: "input", props: { type: "checkbox", defaultChecked: false } }, "TODO"],
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+
+	// The checkbox letter is case-insensitive.
+	expect(PARSER.parse("- [X] DONE")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: { children: { type: "label", props: { children: [{ type: "input", props: { defaultChecked: true } }, "DONE"] } } },
+				},
+			],
+		},
+	});
+
+	// Todo and plain items can be mixed in the same list.
+	expect(PARSER.parse("- [x] DONE\n- PLAIN")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: { children: { type: "label", props: { children: [{ type: "input", props: { defaultChecked: true } }, "DONE"] } } },
+				},
+				{ type: "li", props: { children: "PLAIN" } },
+			],
+		},
+	});
+
+	// A `[x]` not followed by whitespace is literal text, not a checkbox.
+	expect(PARSER.parse("- [x]NOTASK")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [{ type: "li", props: { children: "[x]NOTASK" } }],
+		},
+	});
+
+	// Todo items can contain inline markup.
+	expect(PARSER.parse("- [ ] BEFORE **STRONG** AFTER")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [
+									{ type: "input", props: { defaultChecked: false } },
+									["BEFORE ", { type: "strong", props: { children: "STRONG" } }, " AFTER"],
+								],
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+
+	// Todo lists nest within each other.
+	expect(PARSER.parse("- [x] PARENT\n\t- [ ] CHILD")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [
+									{ type: "input", props: { defaultChecked: true } },
+									[
+										"PARENT",
+										{
+											type: "ul",
+											props: {
+												children: [
+													{
+														type: "li",
+														props: {
+															children: {
+																type: "label",
+																props: { children: [{ type: "input", props: { defaultChecked: false } }, "CHILD"] },
+															},
+														},
+													},
+												],
+											},
+										},
+									],
+								],
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+
+	// Todo lists can be loose — items are wrapped in `<p>`.
+	expect(PARSER.parse("- [x] DONE\n\n- [ ] TODO")).toMatchObject({
+		type: "ul",
+		props: {
+			children: [
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [
+									{ type: "input", props: { defaultChecked: true } },
+									{ type: "p", props: { children: "DONE" } },
+								],
+							},
+						},
+					},
+				},
+				{
+					type: "li",
+					props: {
+						children: {
+							type: "label",
+							props: {
+								children: [
+									{ type: "input", props: { defaultChecked: false } },
+									{ type: "p", props: { children: "TODO" } },
+								],
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+});

--- a/modules/markup/rule/unordered.tsx
+++ b/modules/markup/rule/unordered.tsx
@@ -10,6 +10,10 @@ const _ITEM = new RegExp(
 	"g",
 );
 
+// A GitHub-style todo checkbox at the start of an item: `[ ]` (unchecked) or `[x]` (checked,
+// case-insensitive), which must be followed by whitespace or the end of the item.
+const _CHECKBOX = /^\[([ xX])\](?!\S)[^\n\S]*/;
+
 // End of a list block: the end of the string, or a blank line that is *not* followed by another
 // item or an indented continuation line. A blank line before a new item or a continuation
 // paragraph keeps the list going (a "loose" list); anything else ends the list.
@@ -27,6 +31,7 @@ const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n(?!\\t)`);
  * - Second-level list can be created by indenting with `\t` one tab.
  * - List block runs until a blank line that is not followed by another item or an indented continuation line.
  * - A list with blank lines between its items (or before a continuation paragraph) is "loose": its items are wrapped in `<p>` tags.
+ * - An item starting with `[ ]` or `[x]` (case-insensitive) is a todo item: a checkbox `<input>` plus the content wrapped in a `<label>` so clicking it toggles the checkbox.
  * - Sparse lists are not supported.
  */
 export const UNORDERED_RULE = createMarkupRule<{
@@ -42,5 +47,21 @@ export function* _getItems(list: string, parser: MarkupParser): Iterable<ReactEl
 	// Items of a loose list are parsed as blocks so `PARAGRAPH_RULE` wraps their content in `<p>`.
 	const context = _LOOSE.test(list) ? "block" : "list";
 	let key = 0;
-	for (const [_unused, item = ""] of list.matchAll(_ITEM)) yield <li key={key++}>{parser.parse(item.replace(_INDENT, ""), context)}</li>;
+	for (const [_unused, raw = ""] of list.matchAll(_ITEM)) {
+		const item = raw.replace(_INDENT, "");
+		// A todo item renders a checkbox; the `<label>` wrapping the content toggles it on click.
+		const checkbox = _CHECKBOX.exec(item);
+		if (checkbox) {
+			yield (
+				<li key={key++}>
+					<label>
+						<input type="checkbox" defaultChecked={checkbox[1] !== " "} />
+						{parser.parse(item.slice(checkbox[0].length), context)}
+					</label>
+				</li>
+			);
+		} else {
+			yield <li key={key++}>{parser.parse(item, context)}</li>;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Adds GitHub-style **todo list** syntax to `UNORDERED_RULE`.

- An unordered list item whose text starts with `[ ]` (unchecked) or `[x]` (checked, case-insensitive) renders as a todo item. The marker must be followed by whitespace or the end of the item, so `[x]literal` stays plain text.
- A todo item renders a checkbox `<input type="checkbox">` reflecting the checked state, with the item content wrapped in a `<label>` — so clicking anywhere on the item toggles the checkbox.
- The checkbox is **uncontrolled** (`defaultChecked` rather than `checked`), so it stays natively toggleable via the label without needing a React state handler. *Note: this intentionally diverges from issue #54's suggestion of a `disabled` checkbox — a disabled checkbox can't be toggled, which contradicts the "label toggles the checkbox" requirement.*
- Detection happens per-item inside `_getItems`, so a list can mix todo and plain items, todo lists nest within ordered/unordered/todo lists, and todo lists become loose-capable for free via the loose-list mechanism.
- Ordered lists are unaffected — they don't use checkboxes.

Closes #54

## Stacked PR

This PR is **stacked on #115** (loose lists) — todo lists reuse that PR's loose-list mechanism so they can be loose. Its base is `claude/markup-loose-lists`; review #115 first. GitHub will retarget this PR to `main` automatically once #115 merges.

## Test plan

- [x] `bun run test` — 1055 unit tests pass, lint + type checks clean
- [x] New `UNORDERED todo lists` test cases: checked/unchecked, case-insensitive `[X]`, mixed todo/plain items, `[x]literal` staying plain, inline markup inside a todo, nested todo lists, loose todo lists
- [x] Ordered lists and existing unordered behaviour unaffected

https://claude.ai/code/session_01Xb7iiX1Tm8TLQfwPWiQK4E

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb7iiX1Tm8TLQfwPWiQK4E)_