### PR TITLE
chore: add SessionStart hook to run bun install on container init

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) containers.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+	exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install dependencies so linters and tests are ready before the session starts.
+bun install

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,7 +6,10 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 	exit 0
 fi
 
+# Run in the background so the session can start without waiting for the install.
+echo '{"async": true, "asyncTimeout": 300000}'
+
 cd "$CLAUDE_PROJECT_DIR"
 
-# Install dependencies so linters and tests are ready before the session starts.
+# Install dependencies so linters and tests are ready.
 bun install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-settings.json",
 	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+						"statusMessage": "Installing dependencies (bun install)"
+					}
+				]
+			}
+		],
 		"Stop": [
 			{
 				"hooks": [


### PR DESCRIPTION
Installs dependencies when a remote container starts so the Stop hook's
`bun run fix` no longer fails on its first run before deps are present.

https://claude.ai/code/session_012niFefPhcY7W9icQqqpL6w