### PR TITLE
feat(docs): add colourful token-overrides theme for the docs site

### DIFF
--- a/docs/client.tsx
+++ b/docs/client.tsx
@@ -14,6 +14,8 @@ import type { PossibleMeta } from "../modules/ui/util/meta.js";
 import type { TreeElement } from "../modules/util/element.js";
 import { requireURL } from "../modules/util/index.js";
 import { App } from "./App.js";
+// Docs-site theme — token overrides layered after the base design tokens (must come last).
+import "./theme.css";
 
 async function hydrate(): Promise<void> {
 	const data = document.getElementById("docs-data")?.textContent;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -10,24 +10,37 @@
  */
 
 :root {
-	/* Surfaces — warm cream page, soft peach cards/buttons/notices instead of flat white and cool grey. */
+	/* Surfaces — warm cream page; soft peach `--color-surface` for chips, tags and code. */
 	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
 	--color-surface: color-mix(in srgb, var(--color-orange) 13%, white);
 
-	/* Borders pick up a gentle purple tint to tie surfaces to the accent colour. */
+	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
+
+	/*
+	 * Cards — a deeper apricot, a clear step up from `--color-surface` so peach code chips and
+	 * tags read against them. The border is dropped: a purple edge on the peach looked harsh.
+	 */
+	--card-color-bg: color-mix(in srgb, var(--color-orange) 24%, white);
+	--card-color-border: transparent;
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */
 	--color-link: var(--color-purple);
 	--color-focus: var(--color-pink);
 
+	/* Buttons — bold purple blocks with white content; the site's signature interactive element. */
+	--button-color-bg: var(--color-purple);
+	--button-color-text: var(--color-white);
+	--button-color-border: var(--color-purple);
+
 	/*
-	 * Sidebar navigation — a soft lavender panel with the divider line dropped. The only menu
-	 * recolour is inactive links → a deep purple readable on the lavender; active and proud links
-	 * keep the Menu component's own black, strong defaults (active on its default white pill) so
-	 * "black and strong" consistently signals the current page and the path leading to it.
+	 * Sidebar navigation — a soft lavender panel with the divider dropped. Inactive links are
+	 * recoloured to a deep purple readable on the lavender; active and proud links keep the Menu
+	 * component's black, strong defaults. Hover is a deeper shade of the panel's own purple, so it
+	 * never reaches for the warm peach used by surfaces elsewhere.
 	 */
 	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 18%, white);
 	--sidebar-layout-border: 0;
 	--menu-color-text: color-mix(in srgb, var(--color-purple) 70%, black);
+	--menu-link-color-hover-bg: color-mix(in srgb, var(--color-purple) 30%, white);
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -17,10 +17,22 @@
 	/* Borders pick up a gentle purple tint to tie surfaces to the accent colour. */
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
 
-	/* A distinct lavender sidebar so navigation reads as its own surface, separate from cards. */
-	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 11%, white);
-
 	/* Interactive colours — brighter and more characterful, straight from the palette. */
 	--color-link: var(--color-purple);
 	--color-focus: var(--color-pink);
+
+	/*
+	 * Sidebar navigation — a bold full-purple panel with white menu text, and an inverted
+	 * white-on-purple pill for the active item. These `--menu-*` hooks are global, but every
+	 * `<Menu>` on the docs site lives inside the sidebar, so the overrides only ever reach it.
+	 */
+	--sidebar-layout-bg: var(--color-purple);
+	--menu-color-text: var(--color-white);
+	--menu-link-color-proud: var(--color-white);
+	--menu-link-color-hover-bg: color-mix(in srgb, white 22%, transparent);
+	--menu-link-color-hover-text: var(--color-white);
+	--menu-link-color-focus: var(--color-white);
+	--menu-link-color-active-bg: var(--color-white);
+	--menu-link-color-active-text: var(--color-purple);
+	--menu-nested-color-border: color-mix(in srgb, white 40%, transparent);
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -22,14 +22,12 @@
 	--color-focus: var(--color-pink);
 
 	/*
-	 * Sidebar navigation — a soft lavender panel, distinct from the warm content area without
-	 * shouting. The divider line is dropped (the colour change separates it well enough). Regular
-	 * links use a deep purple readable on the panel; the active item lifts onto a white pill with
-	 * bright `--color-purple` text — the deep/bright split keeps each readable on its background.
+	 * Sidebar navigation — a soft lavender panel with the divider line dropped. The only menu
+	 * recolour is inactive links → a deep purple readable on the lavender; active and proud links
+	 * keep the Menu component's own black, strong defaults (active on its default white pill) so
+	 * "black and strong" consistently signals the current page and the path leading to it.
 	 */
 	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 18%, white);
 	--sidebar-layout-border: 0;
 	--menu-color-text: color-mix(in srgb, var(--color-purple) 70%, black);
-	--menu-link-color-active-bg: var(--color-white);
-	--menu-link-color-active-text: var(--color-purple);
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -23,12 +23,13 @@
 
 	/*
 	 * Sidebar navigation — a soft lavender panel, distinct from the warm content area without
-	 * shouting. The divider line is dropped (the colour change separates it well enough) and the
-	 * active item lifts onto a clean white pill. Menu text deliberately keeps the component's
-	 * default dark colours: an exact-match item is both `active` and `proud`, and `.proud > .link`
-	 * wins the cascade — so a light text override here would land as white-on-white on the pill.
+	 * shouting. The divider line is dropped (the colour change separates it well enough). Regular
+	 * links use a deep purple readable on the panel; the active item lifts onto a white pill with
+	 * bright `--color-purple` text — the deep/bright split keeps each readable on its background.
 	 */
 	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 18%, white);
 	--sidebar-layout-border: 0;
+	--menu-color-text: color-mix(in srgb, var(--color-purple) 70%, black);
 	--menu-link-color-active-bg: var(--color-white);
+	--menu-link-color-active-text: var(--color-purple);
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,0 +1,26 @@
+/*
+ * Documentation site theme.
+ *
+ * A token-only overlay on top of the base design tokens defined by `modules/ui/`. Only CSS custom
+ * properties (the `--variable` design tokens) are set here — never component selectors — so the docs
+ * site gets a brighter, more colourful personality without forking a single component's styling.
+ *
+ * Imported last in `client.tsx` so these `:root` declarations land after the base tokens and win.
+ * Every value leans on the existing palette (`--color-*`) rather than introducing new raw colours.
+ */
+
+:root {
+	/* Surfaces — warm cream page, soft peach cards/buttons/notices instead of flat white and cool grey. */
+	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
+	--color-surface: color-mix(in srgb, var(--color-orange) 13%, white);
+
+	/* Borders pick up a gentle purple tint to tie surfaces to the accent colour. */
+	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
+
+	/* A distinct lavender sidebar so navigation reads as its own surface, separate from cards. */
+	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 11%, white);
+
+	/* Interactive colours — brighter and more characterful, straight from the palette. */
+	--color-link: var(--color-purple);
+	--color-focus: var(--color-pink);
+}

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -10,18 +10,18 @@
  */
 
 :root {
-	/* Surfaces — warm cream page; soft peach `--color-surface` for chips, tags and code. */
+	/* Surfaces — warm cream page; a deeper peach `--color-surface` for inset chips, tags and code. */
 	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
-	--color-surface: color-mix(in srgb, var(--color-orange) 13%, white);
+	--color-surface: color-mix(in srgb, var(--color-orange) 24%, white);
 
 	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
 
 	/*
-	 * Cards — a deeper apricot, a clear step up from `--color-surface` so peach code chips and
-	 * tags read against them. The border is dropped: a purple edge on the peach looked harsh.
+	 * Cards — a soft mid peach, lighter than the `--color-surface` behind code chips and tags so
+	 * those read as darker insets against the card. The border is dropped: a purple edge looked harsh.
 	 */
-	--card-color-bg: color-mix(in srgb, var(--color-orange) 24%, white);
+	--card-color-bg: color-mix(in srgb, var(--color-orange) 14%, white);
 	--card-color-border: transparent;
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -10,16 +10,17 @@
  */
 
 :root {
-	/* Surfaces — warm cream page; a deeper peach `--color-surface` for inset chips, tags and code. */
+	/* Surfaces — warm cream page; a translucent peach `--color-surface` that deepens whatever it sits on. */
 	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
-	--color-surface: color-mix(in srgb, var(--color-orange) 24%, white);
+	--color-surface: color-mix(in srgb, var(--color-orange) 8%, transparent);
 
 	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
 
 	/*
-	 * Cards — a soft mid peach, lighter than the `--color-surface` behind code chips and tags so
-	 * those read as darker insets against the card. The border is dropped: a purple edge looked harsh.
+	 * Cards — a soft opaque mid peach. Code chips and tags use the translucent `--color-surface`,
+	 * so they sit a shade darker than the card — and darker again wherever surfaces stack. The
+	 * border is dropped: a purple edge looked harsh.
 	 */
 	--card-color-bg: color-mix(in srgb, var(--color-orange) 14%, white);
 	--card-color-border: transparent;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -22,17 +22,13 @@
 	--color-focus: var(--color-pink);
 
 	/*
-	 * Sidebar navigation — a bold full-purple panel with white menu text, and an inverted
-	 * white-on-purple pill for the active item. These `--menu-*` hooks are global, but every
-	 * `<Menu>` on the docs site lives inside the sidebar, so the overrides only ever reach it.
+	 * Sidebar navigation — a soft lavender panel, distinct from the warm content area without
+	 * shouting. The divider line is dropped (the colour change separates it well enough) and the
+	 * active item lifts onto a clean white pill. Menu text deliberately keeps the component's
+	 * default dark colours: an exact-match item is both `active` and `proud`, and `.proud > .link`
+	 * wins the cascade — so a light text override here would land as white-on-white on the pill.
 	 */
-	--sidebar-layout-bg: var(--color-purple);
-	--menu-color-text: var(--color-white);
-	--menu-link-color-proud: var(--color-white);
-	--menu-link-color-hover-bg: color-mix(in srgb, white 22%, transparent);
-	--menu-link-color-hover-text: var(--color-white);
-	--menu-link-color-focus: var(--color-white);
+	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 18%, white);
+	--sidebar-layout-border: 0;
 	--menu-link-color-active-bg: var(--color-white);
-	--menu-link-color-active-text: var(--color-purple);
-	--menu-nested-color-border: color-mix(in srgb, white 40%, transparent);
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -10,17 +10,17 @@
  */
 
 :root {
-	/* Surfaces — warm cream page; a translucent peach `--color-surface` that deepens whatever it sits on. */
+	/* Surfaces — warm cream page; soft peach `--color-surface` for prose-level chips, tags and code. */
 	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
-	--color-surface: color-mix(in srgb, var(--color-orange) 8%, transparent);
+	--color-surface: color-mix(in srgb, var(--color-orange) 13%, white);
 
 	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
 
 	/*
-	 * Cards — a soft mid peach with no border. Content inside (code, tags) sits on an opaque
-	 * `--card-color-surface` a few shades deeper, so `<pre><code>` reads as one clean block
-	 * instead of double-stacking the translucent page surface into a murky frame.
+	 * Cards — a soft mid peach with no border. Content nested inside (code chips, tags) uses the
+	 * deeper opaque `--card-color-surface`, giving it its own depth distinct from the lighter
+	 * prose-level `--color-surface`.
 	 */
 	--card-color-bg: color-mix(in srgb, var(--color-orange) 14%, white);
 	--card-border: 0;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -18,12 +18,13 @@
 	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
 
 	/*
-	 * Cards — a soft opaque mid peach. Code chips and tags use the translucent `--color-surface`,
-	 * so they sit a shade darker than the card — and darker again wherever surfaces stack. The
-	 * border is dropped: a purple edge looked harsh.
+	 * Cards — a soft mid peach with no border. Content inside (code, tags) sits on an opaque
+	 * `--card-color-surface` a few shades deeper, so `<pre><code>` reads as one clean block
+	 * instead of double-stacking the translucent page surface into a murky frame.
 	 */
 	--card-color-bg: color-mix(in srgb, var(--color-orange) 14%, white);
-	--card-color-border: transparent;
+	--card-border: 0;
+	--card-color-surface: color-mix(in srgb, var(--color-orange) 21%, white);
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */
 	--color-link: var(--color-purple);

--- a/modules/ui/block/Card.module.css
+++ b/modules/ui/block/Card.module.css
@@ -1,3 +1,8 @@
+:root {
+	/* Opaque surface colour for content nested inside a card — slightly darker than `--color-surface`. */
+	--card-color-surface: color-mix(in srgb, var(--color-surface) 92%, black);
+}
+
 .card {
 	/* Box */
 	position: relative;
@@ -45,6 +50,12 @@
 		position: relative;
 		z-index: 2;
 	}
+}
+
+/* Content nested in a card uses the card's opaque surface colour, so translucent surfaces don't double up. */
+/* `:where()` keeps specificity at zero so colour/status variant classes on descendants still win. */
+:where(.card) * {
+	--color-surface: var(--card-color-surface);
 }
 
 .overlay {

--- a/modules/ui/layout/SidebarLayout.module.css
+++ b/modules/ui/layout/SidebarLayout.module.css
@@ -24,7 +24,7 @@
 	overscroll-behavior: contain;
 	padding: var(--space-normal);
 	background: var(--sidebar-layout-bg, var(--color-surface));
-	border-right: 1px solid var(--color-border);
+	border-right: var(--sidebar-layout-border, 1px) solid var(--sidebar-layout-color-border, var(--color-border));
 }
 
 .content {

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -40,7 +40,7 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
 			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
-				<Button fit plain title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
+				<Button fit title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -21,7 +21,7 @@ export interface SidebarLayoutProps extends OptionalChildProps {
  * - On narrow viewports the sidebar becomes an off-canvas drawer toggled by a single menu button that switches between a burger and a close icon.
  * - While the drawer is open an overlay dims the rest of the page; clicking the overlay closes the drawer.
  * - Inside a `<Navigation>` the drawer closes itself whenever the route changes (e.g. tapping a sidebar link).
- * - Use the `--sidebar-layout-width` and `--sidebar-layout-bg` custom properties to override defaults.
+ * - Use the `--sidebar-layout-width`, `--sidebar-layout-bg`, `--sidebar-layout-border`, and `--sidebar-layout-color-border` custom properties to override defaults.
  */
 export function SidebarLayout({ sidebar, children, right = false }: SidebarLayoutProps): ReactElement {
 	const [open, setOpen] = useState(false);

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -40,7 +40,7 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 	const contentEl = (
 		<div key="content" className={getClass(LAYOUT_CSS.layout, SIDEBAR_LAYOUT_CSS.content)}>
 			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
-				<Button fit cyan={!open} orange={open} plain title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
+				<Button fit plain title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>

--- a/modules/ui/menu/Menu.module.css
+++ b/modules/ui/menu/Menu.module.css
@@ -48,7 +48,8 @@
 }
 
 /* "Proud" item — an ancestor of the active page; emphasised in colour and reveals its nested children. */
-.proud > .link {
+/* The active page is excluded so its own `[aria-current]` styling wins instead of the proud colour. */
+.proud > .link:not([aria-current="page"]) {
 	color: var(--menu-link-color-proud, var(--color-text));
 }
 

--- a/modules/ui/menu/Menu.module.css
+++ b/modules/ui/menu/Menu.module.css
@@ -11,7 +11,7 @@
 	font-family: var(--menu-font, var(--font-body));
 	font-size: var(--menu-size, var(--size-normal));
 	line-height: var(--menu-leading, var(--leading-normal));
-	color: var(--menu-color-text, var(--color-quiet));
+	color: var(--menu-color-text, var(--color-text));
 }
 
 .item {
@@ -41,16 +41,17 @@
 		outline-offset: 1px;
 	}
 	&[aria-current="page"] {
-		background: var(--menu-link-color-active-bg, var(--color-surface));
+		background: var(--menu-link-color-active-bg, var(--color-white));
 		color: var(--menu-link-color-active-text, var(--color-text));
 		font-weight: var(--menu-link-active-weight, var(--weight-strong));
 	}
 }
 
-/* "Proud" item — an ancestor of the active page; emphasised in colour and reveals its nested children. */
-/* The active page is excluded so its own `[aria-current]` styling wins instead of the proud colour. */
+/* "Proud" item — an ancestor of the active page; emphasised with a strong weight, and reveals its nested children. */
+/* The active page is excluded so its own `[aria-current]` styling wins instead of the proud styling. */
 .proud > .link:not([aria-current="page"]) {
 	color: var(--menu-link-color-proud, var(--color-text));
+	font-weight: var(--menu-link-proud-weight, var(--weight-strong));
 }
 
 /* Submenu — Blockquote-style left border to signal hierarchy. */

--- a/modules/ui/misc/StatusIcon.module.css
+++ b/modules/ui/misc/StatusIcon.module.css
@@ -1,5 +1,5 @@
 .icon {
-	flex: 0 0 fit-content;
+	flex: none;
 	border-radius: 999px;
 	width: var(--status-icon-size, 1lh);
 	height: var(--status-icon-size, 1lh);


### PR DESCRIPTION
Add `docs/theme.css`, a token-only overlay imported last in `client.tsx` so
its `:root` declarations land after the base design tokens and win. It leans
on the existing palette to give the docs site warmer surfaces, purple-tinted
borders, a distinct lavender sidebar, and brighter link/focus colours — no
component selectors are touched.

Also drop the hard-coded `cyan`/`orange` colour props from the SidebarLayout
menu toggle button so it picks up its styling purely from variables.

Closes #107