### PR TITLE
fix(markup): treat masked code spans as content not whitespace

### DIFF
--- a/modules/markup/MarkupParser.ts
+++ b/modules/markup/MarkupParser.ts
@@ -307,10 +307,16 @@ function _findFrom(rule: MarkupRule, masked: string, input: string, from: number
 	}
 }
 
-/** Blank the `[start, end)` region of `text` — every character becomes a space, except newlines. */
+// Placeholder a claimed region is blanked to: non-whitespace and non-word, so lower tiers see a
+// masked region as opaque *content* rather than whitespace. Blanking to a space made a leading or
+// trailing code span look like whitespace to inline emphasis (which rejects whitespace at its
+// start/end), so `**`code`**` failed to form. Newlines are kept so block structure survives.
+const _MASK_CHAR = "\u0000";
+
+/** Blank the `[start, end)` region of `text` — every character becomes `_MASK_CHAR`, except newlines. */
 function _mask(text: string, start: number, end: number): string {
 	let blanked = "";
-	for (let i = start; i < end; i++) blanked += text[i] === "\n" ? "\n" : " ";
+	for (let i = start; i < end; i++) blanked += text[i] === "\n" ? "\n" : _MASK_CHAR;
 	return `${text.slice(0, start)}${blanked}${text.slice(end)}`;
 }
 

--- a/modules/markup/rule/inline.test.ts
+++ b/modules/markup/rule/inline.test.ts
@@ -285,6 +285,46 @@ test("INLINE_RULE <mark>", () => {
 	expect(PARSER.parse("== AAA ==", "inline")).toBe("== AAA ==");
 });
 
+test("INLINE_RULE around code spans", () => {
+	// Inline emphasis must still form when its content starts or ends with a code span. Code
+	// spans are a higher-priority tier that is masked before emphasis resolves, so a leading or
+	// trailing code span must be treated as content — not mistaken for whitespace.
+
+	// The exact markdown from the bug report (`**` strong starting with a code span).
+	expect(PARSER.parse("**`<TreeApp>` is the entry point.**", "inline")).toMatchObject({
+		type: "strong",
+		props: {
+			children: [{ type: "code", props: { children: "<TreeApp>" } }, " is the entry point."],
+		},
+	});
+
+	// Strong wrapping only a code span.
+	expect(PARSER.parse("**`CODE`**", "inline")).toMatchObject({
+		type: "strong",
+		props: { children: { type: "code", props: { children: "CODE" } } },
+	});
+
+	// Code span at the start.
+	expect(PARSER.parse("*`CODE` AFTER*", "inline")).toMatchObject({
+		type: "strong",
+		props: { children: [{ type: "code", props: { children: "CODE" } }, " AFTER"] },
+	});
+
+	// Code span at the end.
+	expect(PARSER.parse("**BEFORE `CODE`**", "inline")).toMatchObject({
+		type: "strong",
+		props: { children: ["BEFORE ", { type: "code", props: { children: "CODE" } }] },
+	});
+
+	// Code spans at both ends (with `_` emphasis).
+	expect(PARSER.parse("__`AAA` and `BBB`__", "inline")).toMatchObject({
+		type: "em",
+		props: {
+			children: [{ type: "code", props: { children: "AAA" } }, " and ", { type: "code", props: { children: "BBB" } }],
+		},
+	});
+});
+
 test("INLINE_RULE nesting", () => {
 	expect(PARSER.parse("BEFORE ***BEFORE __ITALIC__ AFTER*** AFTER", "inline")).toMatchObject([
 		"BEFORE ",


### PR DESCRIPTION
Inline emphasis rejects whitespace at its start/end, but the parsing
engine blanked claimed regions to spaces. A code span at the start or
end of an emphasis run (e.g. `**`code`**`) was masked to spaces before
emphasis resolved, so the emphasis rule saw leading/trailing whitespace
and failed to form. Blank claimed regions to a non-whitespace, non-word
sentinel instead so lower tiers see them as opaque content.

https://claude.ai/code/session_01T2dKxnNsTaCU4ZriZADANB