### PR TITLE
fix(extract): strip title heading from markdown content

### DIFF
--- a/modules/extract/MarkupExtractor.test.ts
+++ b/modules/extract/MarkupExtractor.test.ts
@@ -19,11 +19,22 @@ describe("MarkupExtractor", () => {
 		expect(element.props.title).toBe("My Title");
 	});
 
-	test("stores raw markdown as content", async () => {
-		const text = "# Hello\n\nWorld.";
-		const element = await extractor.extract(file(text));
+	test("strips the title heading from the stored content", async () => {
+		const element = await extractor.extract(file("# Hello\n\nWorld."));
 		expect(element.type).toBe("tree-file");
-		expect(element.props.content).toBe(text);
+		expect(element.props.title).toBe("Hello");
+		expect(element.props.content).toBe("World.");
+	});
+
+	test("keeps body headings other than the title in the content", async () => {
+		const element = await extractor.extract(file("# Title\n\nIntro.\n\n## Section\n\nMore."));
+		expect(element.props.content).toBe("Intro.\n\n## Section\n\nMore.");
+	});
+
+	test("leaves content untouched when there is no title heading", async () => {
+		const element = await extractor.extract(file("## Subheading\n\nBody.", "/tmp/TEMPLATE.md"));
+		expect(element.props.title).toBeUndefined();
+		expect(element.props.content).toBe("## Subheading\n\nBody.");
 	});
 
 	test("leaves title undefined when no h1 heading is found", async () => {

--- a/modules/extract/MarkupExtractor.ts
+++ b/modules/extract/MarkupExtractor.ts
@@ -4,9 +4,11 @@ import { FileExtractor } from "./FileExtractor.js";
 
 /**
  * File extractor for Markdown files.
- * - Stores the raw markdown text as `content`; rendering happens at output time via `<Markup>`.
+ * - Stores the markdown text as `content`; rendering happens at output time via `<Markup>`.
  * - Sets `title` from the first `# h1` heading if one is present — otherwise leaves it undefined
  *   (a confident title only).
+ * - When a `title` is found, strips the leading `# h1` from `content` so renderers (which show
+ *   `title` separately) don't display the heading twice.
  * - Sets `description` to the first prose paragraph as a plain-text summary (used for card listings and `<meta>`).
  */
 export class MarkupExtractor extends FileExtractor {
@@ -15,7 +17,8 @@ export class MarkupExtractor extends FileExtractor {
 
 	override extractProps(name: string, text: string): Partial<FileElementProps> & { name: string } {
 		const { title, description } = extractMarkdownProps(text);
-		return { name, title, description, content: text };
+		// The title `# h1` is surfaced separately as `title`, so strip it from the body to avoid rendering it twice.
+		return { name, title, description, content: title ? _stripTitle(text) : text };
 	}
 }
 
@@ -43,4 +46,9 @@ export function extractMarkdownProps(text: string): { title: string | undefined;
 /** Flatten an element to a single-line plain-text summary, or `undefined` if it has no text. */
 function _plain(element: Element): string | undefined {
 	return getElementText(element).replace(/\s+/g, " ").trim() || undefined;
+}
+
+/** Strip a leading `# h1` heading (and any blank lines after it) from markdown text. */
+function _stripTitle(text: string): string {
+	return text.replace(/^\s*#[^\n\S]+\S[^\n]*(?:\n+|$)/, "");
 }

--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
 import { Prose } from "../block/Prose.js";
+import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
 import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
@@ -12,6 +13,7 @@ export function DirectoryPage({ title, name, description, content, children }: D
 	const path = url?.pathname ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
+			<Title>{title ?? name}</Title>
 			{content && (
 				<Prose>
 					<Markup>{content}</Markup>

--- a/modules/ui/docs/FilePage.tsx
+++ b/modules/ui/docs/FilePage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
 import { Prose } from "../block/Prose.js";
+import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
 import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
@@ -12,6 +13,7 @@ export function FilePage({ title, name, description, content, children }: FileEl
 	const path = url?.pathname ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
+			<Title>{title ?? name}</Title>
 			{content && (
 				<Prose>
 					<Markup>{content}</Markup>

--- a/modules/util/element.ts
+++ b/modules/util/element.ts
@@ -48,7 +48,7 @@ export interface TreeElementProps extends ElementProps {
 	/**
 	 * Markup source string that should be rendered as the element's visible body content.
 	 * - Rendered via the `<Markup>` component (typically inside a `<Prose>` wrapper).
-	 * - For Markdown files this is the file's text; for TypeScript symbols this is the JSDoc description.
+	 * - For Markdown files this is the file's body (the title `# h1` is lifted into `title`); for TypeScript symbols this is the JSDoc description.
 	 */
 	readonly content?: string | undefined;
 	/** Children of a tree element must be other tree elements. */


### PR DESCRIPTION
The markdown extractor lifted the first `# h1` into the `title` prop but
also kept it in `content`, so pages rendering both showed the heading
twice. Strip the leading `# h1` from `content`, and render a visible
`<Title>` in FilePage and DirectoryPage (matching DocumentationPage) so
every doc page shows its title exactly once.

https://claude.ai/code/session_011w5Jv8JZGojzzhDhVxMoLo