### PR TITLE
fix(ui): tags are content-width and wrap instead of stretching

### DIFF
--- a/modules/ui/docs/DocumentationCard.tsx
+++ b/modules/ui/docs/DocumentationCard.tsx
@@ -19,7 +19,7 @@ export function DocumentationCard({ path, title, name, kind, description, signat
 	return (
 		<Card href={href}>
 			<Subheading>
-				<Flex left>
+				<Flex left wrap>
 					<Code>{title ?? name}</Code>
 					{kind && <DocumentationKind kind={kind} />}
 				</Flex>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -53,7 +53,7 @@ export function DocumentationPage({
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>
-				<Flex left>
+				<Flex left wrap>
 					{title ?? name}
 					{kind && <DocumentationKind kind={kind} />}
 				</Flex>

--- a/modules/ui/misc/Tag.module.css
+++ b/modules/ui/misc/Tag.module.css
@@ -1,6 +1,11 @@
 .tag {
 	display: inline-block;
-	flex-grow: var(--grow-none); /* Tags stay content-width in flex rows — never stretch to fill space. */
+	flex: 0 0 fit-content; /* Content-width; never grow or shrink, like icons. */
+	/* Truncate overlong text instead of overflowing the container. */
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	padding: 0 var(--space-xxsmall);
 	border: 0;
 	border-radius: var(--radius-xxsmall);

--- a/modules/ui/misc/Tag.module.css
+++ b/modules/ui/misc/Tag.module.css
@@ -1,5 +1,6 @@
 .tag {
 	display: inline-block;
+	flex-grow: var(--grow-timid); /* When displayed in a flex row, tags expand timidly compared to other elements. */
 	padding: 0 var(--space-xxsmall);
 	border: 0;
 	border-radius: var(--radius-xxsmall);

--- a/modules/ui/misc/Tag.module.css
+++ b/modules/ui/misc/Tag.module.css
@@ -1,6 +1,6 @@
 .tag {
 	display: inline-block;
-	flex-grow: var(--grow-timid); /* When displayed in a flex row, tags expand timidly compared to other elements. */
+	flex-grow: var(--grow-none); /* Tags stay content-width in flex rows — never stretch to fill space. */
 	padding: 0 var(--space-xxsmall);
 	border: 0;
 	border-radius: var(--radius-xxsmall);


### PR DESCRIPTION
## Summary

Kind tags inside a `<Flex>` (e.g. in documentation cards and page titles) looked stretched — the coloured background expanded to fill available space.

The cause: a flex child picks up `flex: var(--grow-normal) 1 auto` from `Flex.module.css`, so a tag grew to fill space.

### What changed

- **`Tag.module.css`** — tags now use `flex: 0 0 fit-content`, so a tag never grows or shrinks as a flex item. This matches how other small inline elements already behave (`StatusIcon` uses `flex: 0 0 fit-content`; flex icon children use `flex: none`). A tag is a small label and should never participate in flex sizing.
- **`Tag.module.css`** — added `max-width: 100%` plus `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap`, so an overlong tag label truncates with an ellipsis instead of overflowing its container.
- **`DocumentationCard.tsx` / `DocumentationPage.tsx`** — the kind-tag `<Flex>` rows now use `wrap`, so a tag flows onto the next line instead of overlapping when horizontal space runs out.

### Note on the approach

An earlier commit tried `flex-grow: var(--grow-timid)` (mirroring buttons). That only looked right because the symbol name beside the tag is greedy and absorbed the space — a tag *alone* on a line (a page title, or a wrapped line) still stretched into a full-width bar. `flex: 0 0 fit-content` is the correct, simpler model: tags are content-width, full stop.

## Test plan

- [x] `bun run test:lint` and `bun run test:type` pass
- [x] Built the docs site and verified kind tags on documentation cards and page titles hug their text
- [x] Verified a tag wraps onto its own line (narrow viewport) and stays content-width, left-aligned
- [x] Verified an overlong tag label truncates with an ellipsis and never overflows its container

https://claude.ai/code/session_01TSWSGe3EgYZdfWRvuFXeNz