### PR TITLE
fix(ui): card links double the subfolder when APP_URL has a subdirectory

### DIFF
--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
+import { matchURLPrefix } from "../../util/url.js";
 import { Prose } from "../block/Prose.js";
 import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
@@ -9,8 +10,9 @@ import { TreeCards } from "../tree/TreeCards.js";
 
 /** Page renderer for a `tree-directory` element — shows title, content, and child cards. */
 export function DirectoryPage({ title, name, description, content, children }: DirectoryElementProps): ReactNode {
-	const { url } = requireMeta();
-	const path = url?.pathname ?? "/";
+	const { url, root } = requireMeta();
+	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
+	const path = matchURLPrefix(url, root) ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>{title ?? name}</Title>

--- a/modules/ui/docs/DirectoryPage.tsx
+++ b/modules/ui/docs/DirectoryPage.tsx
@@ -1,18 +1,19 @@
 import type { ReactNode } from "react";
 import type { DirectoryElementProps } from "../../util/element.js";
-import { matchURLPrefix } from "../../util/url.js";
+import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
-import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
 import { TreeCards } from "../tree/TreeCards.js";
 
+interface DirectoryPageProps extends DirectoryElementProps {
+	/** Site-root-relative path of this page — threaded down so child cards build correct hrefs. */
+	readonly path: AbsolutePath;
+}
+
 /** Page renderer for a `tree-directory` element — shows title, content, and child cards. */
-export function DirectoryPage({ title, name, description, content, children }: DirectoryElementProps): ReactNode {
-	const { url, root } = requireMeta();
-	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
-	const path = matchURLPrefix(url, root) ?? "/";
+export function DirectoryPage({ path, title, name, description, content, children }: DirectoryPageProps): ReactNode {
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>{title ?? name}</Title>

--- a/modules/ui/docs/DocumentationPage.test.tsx
+++ b/modules/ui/docs/DocumentationPage.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DocumentationElement } from "../../util/element.js";
+import { MetaContext } from "../misc/MetaContext.js";
+import { createMeta } from "../util/meta.js";
 import { DocumentationPage } from "./DocumentationPage.js";
 
 /** Make a minimal `tree-documentation` child element of a given kind. */
@@ -31,5 +33,18 @@ describe("DocumentationPage", () => {
 		expect(html).toContain("Properties");
 		expect(html).not.toContain("Functions");
 		expect(html).not.toContain("Interfaces");
+	});
+
+	test("card links resolve against the site root without doubling its subfolder", () => {
+		// `root` has a `/sub/` subfolder and the page sits at `/sub/Store` — card hrefs must include `/sub/` exactly once.
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./Store" })}>
+				<DocumentationPage name="Store" kind="class">
+					{[doc("get", "method")]}
+				</DocumentationPage>
+			</MetaContext>,
+		);
+		expect(html).toContain('href="http://x.com/sub/Store/get"');
+		expect(html).not.toContain("/sub/sub/");
 	});
 });

--- a/modules/ui/docs/DocumentationPage.test.tsx
+++ b/modules/ui/docs/DocumentationPage.test.tsx
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DocumentationElement } from "../../util/element.js";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
 import { DocumentationPage } from "./DocumentationPage.js";
 
 /** Make a minimal `tree-documentation` child element of a given kind. */
@@ -13,7 +11,7 @@ function doc(name: string, kind: string): DocumentationElement {
 describe("DocumentationPage", () => {
 	test("groups child symbols into kind-based sections, in order", () => {
 		const html = renderToStaticMarkup(
-			<DocumentationPage name="array">
+			<DocumentationPage path="/array" name="array">
 				{[doc("getThing", "function"), doc("Widget", "class"), doc("getOther", "function")]}
 			</DocumentationPage>,
 		);
@@ -25,7 +23,7 @@ describe("DocumentationPage", () => {
 
 	test("renders a section only for kinds that have children", () => {
 		const html = renderToStaticMarkup(
-			<DocumentationPage name="Store" kind="class">
+			<DocumentationPage path="/Store" name="Store" kind="class">
 				{[doc("get", "method"), doc("size", "property")]}
 			</DocumentationPage>,
 		);
@@ -33,18 +31,5 @@ describe("DocumentationPage", () => {
 		expect(html).toContain("Properties");
 		expect(html).not.toContain("Functions");
 		expect(html).not.toContain("Interfaces");
-	});
-
-	test("card links resolve against the site root without doubling its subfolder", () => {
-		// `root` has a `/sub/` subfolder and the page sits at `/sub/Store` — card hrefs must include `/sub/` exactly once.
-		const html = renderToStaticMarkup(
-			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./Store" })}>
-				<DocumentationPage name="Store" kind="class">
-					{[doc("get", "method")]}
-				</DocumentationPage>
-			</MetaContext>,
-		);
-		expect(html).toContain('href="http://x.com/sub/Store/get"');
-		expect(html).not.toContain("/sub/sub/");
 	});
 });

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { type DocumentationElementProps, type Element, queryElements, type TreeElement } from "../../util/element.js";
-import type { AbsolutePath } from "../../util/path.js";
 import type { Query } from "../../util/query.js";
+import { matchURLPrefix } from "../../util/url.js";
 import { Definition, Definitions } from "../block/Definitions.js";
 import { Flex } from "../block/Flex.js";
 import { Heading } from "../block/Heading.js";
@@ -48,8 +48,9 @@ export function DocumentationPage({
 	examples,
 	children,
 }: DocumentationElementProps): ReactNode {
-	const { url } = requireMeta();
-	const path = (url?.pathname ?? "/") as AbsolutePath;
+	const { url, root } = requireMeta();
+	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
+	const path = matchURLPrefix(url, root) ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { type DocumentationElementProps, type Element, queryElements, type TreeElement } from "../../util/element.js";
+import type { AbsolutePath } from "../../util/path.js";
 import type { Query } from "../../util/query.js";
-import { matchURLPrefix } from "../../util/url.js";
 import { Definition, Definitions } from "../block/Definitions.js";
 import { Flex } from "../block/Flex.js";
 import { Heading } from "../block/Heading.js";
@@ -11,7 +11,6 @@ import { Section } from "../block/Section.js";
 import { Title } from "../block/Title.js";
 import { Code } from "../inline/Code.js";
 import { Markup } from "../misc/Markup.js";
-import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
 import { TreeCards } from "../tree/TreeCards.js";
 import { DocumentationKind } from "./DocumentationKind.js";
@@ -29,6 +28,11 @@ const KIND_SECTIONS: ReadonlyArray<readonly [kind: string, label: string]> = [
 	["property", "Properties"],
 ];
 
+interface DocumentationPageProps extends DocumentationElementProps {
+	/** Site-root-relative path of this page — threaded down so child cards build correct hrefs. */
+	readonly path: AbsolutePath;
+}
+
 /**
  * Page renderer for a `tree-documentation` element (also used for `tree-file` elements, whose props are a compatible subset).
  * - Renders title, signatures (one per overload), content, parameters, returns, throws, and examples.
@@ -36,6 +40,7 @@ const KIND_SECTIONS: ReadonlyArray<readonly [kind: string, label: string]> = [
  * - All sections are conditional — only render when they have entries.
  */
 export function DocumentationPage({
+	path,
 	title,
 	name,
 	kind,
@@ -47,10 +52,7 @@ export function DocumentationPage({
 	throws,
 	examples,
 	children,
-}: DocumentationElementProps): ReactNode {
-	const { url, root } = requireMeta();
-	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
-	const path = matchURLPrefix(url, root) ?? "/";
+}: DocumentationPageProps): ReactNode {
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>

--- a/modules/ui/docs/FilePage.tsx
+++ b/modules/ui/docs/FilePage.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
+import { matchURLPrefix } from "../../util/url.js";
 import { Prose } from "../block/Prose.js";
 import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
@@ -9,8 +10,9 @@ import { TreeCards } from "../tree/TreeCards.js";
 
 /** Page renderer for a `tree-file` element — shows title, content, and child code symbols. */
 export function FilePage({ title, name, description, content, children }: FileElementProps): ReactNode {
-	const { url } = requireMeta();
-	const path = url?.pathname ?? "/";
+	const { url, root } = requireMeta();
+	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
+	const path = matchURLPrefix(url, root) ?? "/";
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>{title ?? name}</Title>

--- a/modules/ui/docs/FilePage.tsx
+++ b/modules/ui/docs/FilePage.tsx
@@ -1,18 +1,19 @@
 import type { ReactNode } from "react";
 import type { FileElementProps } from "../../util/element.js";
-import { matchURLPrefix } from "../../util/url.js";
+import type { AbsolutePath } from "../../util/path.js";
 import { Prose } from "../block/Prose.js";
 import { Title } from "../block/Title.js";
 import { Markup } from "../misc/Markup.js";
-import { requireMeta } from "../misc/MetaContext.js";
 import { Page } from "../page/Page.js";
 import { TreeCards } from "../tree/TreeCards.js";
 
+interface FilePageProps extends FileElementProps {
+	/** Site-root-relative path of this page — threaded down so child cards build correct hrefs. */
+	readonly path: AbsolutePath;
+}
+
 /** Page renderer for a `tree-file` element — shows title, content, and child code symbols. */
-export function FilePage({ title, name, description, content, children }: FileElementProps): ReactNode {
-	const { url, root } = requireMeta();
-	// Path must be site-root-relative: card hrefs are later resolved against `root`, so including its subfolder here would double it.
-	const path = matchURLPrefix(url, root) ?? "/";
+export function FilePage({ path, title, name, description, content, children }: FilePageProps): ReactNode {
 	return (
 		<Page title={title ?? name} description={description}>
 			<Title>{title ?? name}</Title>

--- a/modules/ui/misc/MetaContext.test.tsx
+++ b/modules/ui/misc/MetaContext.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createMeta } from "../util/meta.js";
+import { getMetaPath, MetaContext } from "./MetaContext.js";
+
+/** Render `getMetaPath()` from inside a component so its `use(MetaContext)` call is valid. */
+function Probe(): ReactNode {
+	return getMetaPath() ?? "none";
+}
+
+describe("getMetaPath", () => {
+	test("returns the page path relative to the site root", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./util/array" })}>
+				<Probe />
+			</MetaContext>,
+		);
+		expect(html).toBe("/util/array");
+	});
+
+	test("returns `/` when url and root resolve to the same location", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./" })}>
+				<Probe />
+			</MetaContext>,
+		);
+		expect(html).toBe("/");
+	});
+
+	test("returns undefined when url or root is unset", () => {
+		expect(renderToStaticMarkup(<Probe />)).toBe("none");
+	});
+
+	test("returns undefined when url and root are on different origins", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/", url: "http://y.com/foo" })}>
+				<Probe />
+			</MetaContext>,
+		);
+		expect(html).toBe("none");
+	});
+});

--- a/modules/ui/misc/MetaContext.tsx
+++ b/modules/ui/misc/MetaContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, use } from "react";
+import type { AbsolutePath } from "../../util/path.js";
 import { getURIParams, type URIParams } from "../../util/uri.js";
+import { matchURLPrefix } from "../../util/url.js";
 import { type Meta, mergeMeta, type PossibleMeta } from "../util/meta.js";
 import type { ChildProps } from "../util/props.js";
 
@@ -18,4 +20,16 @@ export function requireMeta(meta?: PossibleMeta): Meta {
 /** Get all URI/route params from the current meta context's URL. */
 export function requireMetaParams(): URIParams {
 	return getURIParams(requireMeta().url ?? {}, requireMetaParams);
+}
+
+/**
+ * Get the current page's path relative to the site root.
+ * - Strips the meta `root` (site base) prefix from the meta `url`, leaving a site-root-relative `AbsolutePath`.
+ * - Returns `undefined` when `url` or `root` is unset, or they sit on different origins — the path is then unknowable.
+ *
+ * @returns The site-root-relative path (e.g. `/util/array`), or `undefined` if it can't be determined.
+ */
+export function getMetaPath(): AbsolutePath | undefined {
+	const { url, root } = requireMeta();
+	return matchURLPrefix(url, root, getMetaPath);
 }

--- a/modules/ui/tree/TreePage.test.tsx
+++ b/modules/ui/tree/TreePage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { TreeElement } from "../../util/element.js";
+import { MetaContext } from "../misc/MetaContext.js";
+import { createMeta } from "../util/meta.js";
+import { TreePage } from "./TreePage.js";
+
+/** Minimal tree: root → `util` directory → `array` file. */
+const tree: TreeElement = {
+	type: "tree-directory",
+	key: "root",
+	props: {
+		name: "shelving",
+		children: [
+			{
+				type: "tree-directory",
+				key: "util",
+				props: { name: "util", children: [{ type: "tree-file", key: "array", props: { name: "array" } }] },
+			},
+		],
+	},
+};
+
+describe("TreePage", () => {
+	// When `APP_URL` has a subfolder, the page threads its site-root-relative path to child cards so hrefs include the subfolder exactly once.
+	test("card links include an APP_URL subfolder exactly once", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./util" })}>
+				<TreePage path="/util" tree={tree} />
+			</MetaContext>,
+		);
+		expect(html).toContain('href="http://x.com/sub/util/array"');
+		expect(html).not.toContain("/sub/sub/");
+	});
+
+	test("root page card links include an APP_URL subfolder exactly once", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./" })}>
+				<TreePage path="/" tree={tree} />
+			</MetaContext>,
+		);
+		expect(html).toContain('href="http://x.com/sub/util"');
+		expect(html).not.toContain("/sub/sub/");
+	});
+});

--- a/modules/ui/tree/TreePage.tsx
+++ b/modules/ui/tree/TreePage.tsx
@@ -7,8 +7,14 @@ import { DocumentationPage } from "../docs/DocumentationPage.js";
 import { FilePage } from "../docs/FilePage.js";
 import { createMapper } from "../misc/Mapper.js";
 
+/** Extras threaded through `TreePageMapper` to the page renderer — the site-root-relative path of the page. */
+interface TreePageExtras {
+	/** Site-root-relative URL path of the page being rendered. Each page forwards it to its child cards. */
+	readonly path: AbsolutePath;
+}
+
 /** Mapping + Mapper pair for tree pages — wrap children in `<TreePageMapping>` to override. */
-export const [TreePageMapping, TreePageMapper] = createMapper({
+export const [TreePageMapping, TreePageMapper] = createMapper<TreePageExtras>({
 	"tree-directory": DirectoryPage,
 	"tree-file": FilePage,
 	"tree-documentation": DocumentationPage,
@@ -23,6 +29,7 @@ export interface TreePageProps {
  * Resolve a URL path to a tree element and render it as a full page.
  * - Walks the tree by matching each path segment to a descendant's `key` (via `resolveElementPath()`).
  * - `/` renders the root itself; deeper paths render the matching descendant.
+ * - `path` is the site-root-relative path (already stripped of any `APP_URL` subfolder by `<Router>`); it is threaded to the page renderer so child cards build correct hrefs.
  * - Throws `NotFoundError` if no element matches at any level.
  * - To override the renderer for a specific element type, wrap in `<TreePageMapping mapping={…}>`.
  */
@@ -30,5 +37,5 @@ export function TreePage({ path = "/", tree }: TreePageProps): ReactNode {
 	const segments = splitPath(path);
 	const element = resolveElementPath(tree, segments);
 	if (!element) throw new NotFoundError("Element not found", { received: path });
-	return <TreePageMapper>{element}</TreePageMapper>;
+	return <TreePageMapper path={path}>{element}</TreePageMapper>;
 }


### PR DESCRIPTION
Documentation pages derived their card path from `url.pathname`, which is
origin-absolute and includes the `APP_URL` subfolder. Cards build a
site-absolute href from that path, and `getLink` later resolves it against
`root` (the subfolder) again — doubling the prefix (e.g. `/sub/sub/...`).

Use `matchURLPrefix(url, root)` to derive a site-root-relative path so the
subfolder is applied exactly once. With a root-level `root` this returns
`url.pathname` unchanged, so default builds are unaffected.

https://claude.ai/code/session_01DKQnghQN2U3JSmdJNsAPeq