### PR TITLE
fix(docs): repoint theme.css at the new --vivid-* tokens

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -11,32 +11,32 @@
  */
 :root {
 	/* Surfaces — warm cream page; soft peach `--color-surface` for prose-level chips, tags and code. */
-	--color-bg: color-mix(in srgb, var(--color-orange) 6%, white);
-	--color-surface: color-mix(in srgb, var(--color-orange) 13%, white);
+	--color-bg: color-mix(in srgb, var(--vivid-orange) 6%, white);
+	--color-surface: color-mix(in srgb, var(--vivid-orange) 13%, white);
 
 	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
-	--color-border: color-mix(in srgb, var(--color-purple) 22%, white);
+	--color-border: color-mix(in srgb, var(--vivid-purple) 22%, white);
 
 	/* Quiet text — table headers, captions, definition labels — picks up the same purple personality. */
-	--color-quiet: var(--color-purple);
+	--color-quiet: var(--vivid-purple);
 
 	/*
 	* Cards — a soft mid peach with no border. Content nested inside (code chips, tags) uses the
 	* deeper opaque `--card-color-surface`, giving it its own depth distinct from the lighter
 	* prose-level `--color-surface`.
 	*/
-	--card-color-bg: color-mix(in srgb, var(--color-orange) 14%, white);
+	--card-color-bg: color-mix(in srgb, var(--vivid-orange) 14%, white);
 	--card-border: 0;
-	--card-color-surface: color-mix(in srgb, var(--color-orange) 21%, white);
+	--card-color-surface: color-mix(in srgb, var(--vivid-orange) 21%, white);
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */
-	--color-link: var(--color-purple);
-	--color-focus: var(--color-pink);
+	--color-link: var(--vivid-purple);
+	--color-focus: var(--vivid-pink);
 
 	/* Buttons — bold purple blocks with white content; the site's signature interactive element. */
-	--button-color-bg: var(--color-purple);
+	--button-color-bg: var(--vivid-purple);
 	--button-color-text: var(--color-white);
-	--button-color-border: var(--color-purple);
+	--button-color-border: var(--vivid-purple);
 
 	/*
 	 * Sidebar navigation — a soft lavender panel with the divider dropped. Inactive links are
@@ -44,8 +44,8 @@
 	 * component's black, strong defaults. Hover is a deeper shade of the panel's own purple, so it
 	 * never reaches for the warm peach used by surfaces elsewhere.
 	 */
-	--sidebar-layout-bg: color-mix(in srgb, var(--color-purple) 18%, white);
+	--sidebar-layout-bg: color-mix(in srgb, var(--vivid-purple) 18%, white);
 	--sidebar-layout-border: 0;
-	--menu-color-text: color-mix(in srgb, var(--color-purple) 70%, black);
-	--menu-link-color-hover-bg: color-mix(in srgb, var(--color-purple) 30%, white);
+	--menu-color-text: color-mix(in srgb, var(--vivid-purple) 70%, black);
+	--menu-link-color-hover-bg: color-mix(in srgb, var(--vivid-purple) 30%, white);
 }


### PR DESCRIPTION
The colour-tokens refactor (f185915) replaced --color-{orange,purple,pink}
with the 5-step --vivid-/--light-/--dark- scale. docs/theme.css still
referenced the old names, so every color-mix() resolved to an invalid
value and the docs lost their custom theme.