### PR TITLE
fix(ui): return component-valued route match and drop unused NavigationIsolate

### DIFF
--- a/modules/ui/block/Block.module.css
+++ b/modules/ui/block/Block.module.css
@@ -18,7 +18,7 @@
 	.scrollable,
 	.prose [role="region"][tabindex="0"] {
 		overflow-x: auto;
-		overscroll-behavior-x: contain;
+		overscroll-behavior: contain;
 
 		&:focus-visible {
 			outline: var(--focus-stroke, var(--stroke-thick)) solid var(--focus-color, var(--color-focus));

--- a/modules/ui/form/Popover.module.css
+++ b/modules/ui/form/Popover.module.css
@@ -20,7 +20,7 @@
 		z-index: 1000;
 		max-height: var(--popover-max-height, 30vh);
 		overflow-y: auto;
-		overscroll-behavior: none;
+		overscroll-behavior: contain;
 		border-radius: var(--popover-radius, var(--radius-xsmall));
 		border: var(--popover-border, var(--stroke-normal)) solid var(--popover-color-border, var(--color-vivid));
 		padding: var(--popover-padding, var(--space-small));

--- a/modules/ui/layout/CenteredLayout.tsx
+++ b/modules/ui/layout/CenteredLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { MetaPathIsolate } from "../misc/MetaContext.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import CENTERED_LAYOUT_CSS from "./CenteredLayout.module.css";
@@ -16,7 +17,7 @@ export function CenteredLayout({ children, fullWidth = false }: CenteredLayoutPr
 	return (
 		<main className={getClass(CENTERED_LAYOUT_CSS.main, LAYOUT_CLASS)}>
 			<div className={CENTERED_LAYOUT_CSS.mainInner} style={fullWidth ? { maxWidth: "none" } : undefined}>
-				{children}
+				<MetaPathIsolate>{children}</MetaPathIsolate>
 			</div>
 		</main>
 	);

--- a/modules/ui/layout/CenteredLayout.tsx
+++ b/modules/ui/layout/CenteredLayout.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { MetaPathIsolate } from "../misc/MetaContext.js";
+import { requireMetaURL } from "../misc/MetaContext.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import CENTERED_LAYOUT_CSS from "./CenteredLayout.module.css";
@@ -14,10 +14,11 @@ export interface CenteredLayoutProps extends OptionalChildProps {
  * - Used for e.g. login/register/error/form pages where the content is the only focus.
  */
 export function CenteredLayout({ children, fullWidth = false }: CenteredLayoutProps): ReactElement {
+	const { path } = requireMetaURL();
 	return (
-		<main className={getClass(CENTERED_LAYOUT_CSS.main, LAYOUT_CLASS)}>
+		<main key={path} className={getClass(CENTERED_LAYOUT_CSS.main, LAYOUT_CLASS)}>
 			<div className={CENTERED_LAYOUT_CSS.mainInner} style={fullWidth ? { maxWidth: "none" } : undefined}>
-				<MetaPathIsolate>{children}</MetaPathIsolate>
+				{children}
 			</div>
 		</main>
 	);

--- a/modules/ui/layout/Layout.module.css
+++ b/modules/ui/layout/Layout.module.css
@@ -40,7 +40,6 @@
 		width: 100dvw;
 		overflow: hidden;
 		overflow-wrap: break-word; /* Break overlong words only as a last resort; `anywhere` would also break mid-word to fit narrow table/flex columns. */
-		overscroll-behavior: none;
 	}
 
 	body:has(.layout) {
@@ -61,6 +60,7 @@
 		/* Own the page's vertical scroll. */
 		overflow: hidden auto;
 		scroll-behavior: smooth;
-		overscroll-behavior: none;
+		/* `contain` keeps the elastic bounce on the layout itself but stops the scroll chain leaking up to the locked body. */
+		overscroll-behavior: contain;
 	}
 }

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -2,6 +2,7 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
 import { type ReactElement, type ReactNode, use, useEffect, useState } from "react";
 import { useStore } from "../../react/useStore.js";
 import { Button } from "../form/Button.js";
+import { MetaPathIsolate } from "../misc/MetaContext.js";
 import { NavigationContext } from "../router/NavigationContext.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
@@ -44,7 +45,9 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>
-			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
+			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>
+				<MetaPathIsolate>{children}</MetaPathIsolate>
+			</div>
 		</div>
 	);
 	const overlayEl = open && (

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -1,9 +1,7 @@
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
-import { type ReactElement, type ReactNode, use, useEffect, useState } from "react";
-import { useStore } from "../../react/useStore.js";
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
 import { Button } from "../form/Button.js";
-import { MetaPathIsolate } from "../misc/MetaContext.js";
-import { NavigationContext } from "../router/NavigationContext.js";
+import { requireMetaURL } from "../misc/MetaContext.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import { LAYOUT_CLASS } from "./Layout.js";
@@ -25,13 +23,13 @@ export interface SidebarLayoutProps extends OptionalChildProps {
  * - Use the `--sidebar-layout-width`, `--sidebar-layout-bg`, `--sidebar-layout-border`, and `--sidebar-layout-color-border` custom properties to override defaults.
  */
 export function SidebarLayout({ sidebar, children, right = false }: SidebarLayoutProps): ReactElement {
+	const { path } = requireMetaURL();
 	const [open, setOpen] = useState(false);
 
 	// Close the drawer whenever navigation changes the URL — covers tapping a link inside the sidebar.
-	const href = useStore(use(NavigationContext))?.href;
 	useEffect(() => {
-		if (href) setOpen(false);
-	}, [href]);
+		if (path) setOpen(false);
+	}, [path]);
 
 	const sidebarEl = (
 		<nav key="sidebar" className={getClass(SIDEBAR_LAYOUT_CSS.sidebar, open && SIDEBAR_LAYOUT_CSS.open)}>
@@ -39,15 +37,13 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 		</nav>
 	);
 	const contentEl = (
-		<div key="content" className={getClass(LAYOUT_CLASS, SIDEBAR_LAYOUT_CSS.content)}>
+		<div key={path} className={getClass(LAYOUT_CLASS, SIDEBAR_LAYOUT_CSS.content)}>
 			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
 				<Button fit title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>
-			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>
-				<MetaPathIsolate>{children}</MetaPathIsolate>
-			</div>
+			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
 		</div>
 	);
 	const overlayEl = open && (

--- a/modules/ui/misc/MetaContext.tsx
+++ b/modules/ui/misc/MetaContext.tsx
@@ -1,11 +1,10 @@
-import { createContext, Fragment, type ReactElement, use } from "react";
+import { createContext, use } from "react";
 import { RequiredError } from "../../error/RequiredError.js";
 import type { AnyCaller } from "../../util/function.js";
 import type { AbsolutePath } from "../../util/path.js";
 import { getURIParams, type URIParams } from "../../util/uri.js";
 import { type ImmutableURL, matchURLPrefix } from "../../util/url.js";
 import { type Meta, mergeMeta, type PossibleMeta } from "../util/meta.js";
-import type { ChildProps } from "../util/props.js";
 
 /** Context to store the `Config` object. */
 export const MetaContext = createContext<Meta>({});
@@ -45,14 +44,4 @@ export function requireMetaURL(meta?: PossibleMeta, caller: AnyCaller = requireM
 	if (!path) throw new RequiredError("Meta URL and meta root must share an origin", { url, root, caller });
 	const params = getURIParams(url, caller);
 	return { ...combined, url, root, path, params };
-}
-
-/**
- * Force a full remount of children whenever the meta URL `path` changes.
- * - Wraps `children` in a `<Fragment key={path}>` so React unmounts the previous subtree and mounts a fresh one on every navigation.
- * - Use around the main content area of a layout to reset scroll position, focus, and any other DOM state that lives on the underlying nodes.
- */
-export function MetaPathIsolate({ children }: ChildProps): ReactElement {
-	const { path } = requireMetaURL();
-	return <Fragment key={path}>{children}</Fragment>;
 }

--- a/modules/ui/misc/MetaContext.tsx
+++ b/modules/ui/misc/MetaContext.tsx
@@ -1,10 +1,11 @@
-import { createContext, use } from "react";
+import { createContext, Fragment, type ReactElement, use } from "react";
 import { RequiredError } from "../../error/RequiredError.js";
 import type { AnyCaller } from "../../util/function.js";
 import type { AbsolutePath } from "../../util/path.js";
 import { getURIParams, type URIParams } from "../../util/uri.js";
 import { type ImmutableURL, matchURLPrefix } from "../../util/url.js";
 import { type Meta, mergeMeta, type PossibleMeta } from "../util/meta.js";
+import type { ChildProps } from "../util/props.js";
 
 /** Context to store the `Config` object. */
 export const MetaContext = createContext<Meta>({});
@@ -44,4 +45,14 @@ export function requireMetaURL(meta?: PossibleMeta, caller: AnyCaller = requireM
 	if (!path) throw new RequiredError("Meta URL and meta root must share an origin", { url, root, caller });
 	const params = getURIParams(url, caller);
 	return { ...combined, url, root, path, params };
+}
+
+/**
+ * Force a full remount of children whenever the meta URL `path` changes.
+ * - Wraps `children` in a `<Fragment key={path}>` so React unmounts the previous subtree and mounts a fresh one on every navigation.
+ * - Use around the main content area of a layout to reset scroll position, focus, and any other DOM state that lives on the underlying nodes.
+ */
+export function MetaPathIsolate({ children }: ChildProps): ReactElement {
+	const { path } = requireMetaURL();
+	return <Fragment key={path}>{children}</Fragment>;
 }

--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -1,10 +1,10 @@
-import { Fragment, type ReactElement, useEffect } from "react";
+import { type ReactElement, useEffect } from "react";
 import { useInstance } from "../../react/useInstance.js";
 import { useStore } from "../../react/useStore.js";
 import { MetaContext, requireMeta } from "../misc/MetaContext.js";
 import type { PossibleMeta } from "../util/index.js";
-import type { ChildProps, OptionalChildProps } from "../util/props.js";
-import { NavigationContext, requireNavigation } from "./NavigationContext.js";
+import type { OptionalChildProps } from "../util/props.js";
+import { NavigationContext } from "./NavigationContext.js";
 import { NavigationStore } from "./NavigationStore.js";
 
 export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
@@ -58,15 +58,4 @@ export function Navigation({ children, ...meta }: NavigationProps): ReactElement
 			<MetaContext value={{ url: nav.value, root, ...merged }}>{children}</MetaContext>
 		</NavigationContext>
 	);
-}
-
-export interface NavigationIsolateProps extends ChildProps {}
-
-/**
- * Force a full remount of children whenever the navigation URL changes.
- * - Use to reset stateful sub-trees on navigation.
- */
-export function NavigationIsolate({ children }: NavigationIsolateProps): ReactElement {
-	const nav = useStore(requireNavigation());
-	return <Fragment key={nav.href}>{children}</Fragment>;
 }

--- a/modules/ui/router/Router.tsx
+++ b/modules/ui/router/Router.tsx
@@ -61,7 +61,7 @@ function _matchRoute(
 		if (typeof Route !== "function") return Route;
 
 		// Component — render with merged URL query params and route placeholders as props (placeholders win on conflict).
-		<Route key={path} {...meta.params} {...placeholders} />;
+		return <Route key={path} {...meta.params} {...placeholders} />;
 	}
 
 	// No match, try the fallback.


### PR DESCRIPTION
Router was constructing the matched `<Route>` element as an expression
statement and discarding it, so component-valued routes never rendered
and the router fell through to the fallback / NotFoundError.

Also removes the unused `NavigationIsolate` helper — the page-level
remount-on-navigation it offered is already covered by element-keyed
remounting in `Router` and `Mapper`.