### PR TITLE
feat: add sanitizeWord() and strip whitespace in email/URL/URI schemas

### DIFF
--- a/modules/schema/EmailSchema.test.ts
+++ b/modules/schema/EmailSchema.test.ts
@@ -78,6 +78,10 @@ describe("validate()", () => {
 		test("Domains have whitespace trimmed from start/end", () => {
 			expect(schema.validate("    jo@google.com   ")).toBe("jo@google.com");
 		});
+		test("Whitespace anywhere in the address is stripped", () => {
+			expect(schema.validate("jo @ google.com")).toBe("jo@google.com");
+			expect(schema.validate("j o @ g o o g l e . c o m")).toBe("jo@google.com");
+		});
 		test("Domains are lowercased", () => {
 			expect(schema.validate("JO@GOOGLE.COM")).toBe("jo@google.com");
 		});

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -1,3 +1,4 @@
+import { sanitizeWord } from "../util/string.js";
 import { NULLABLE } from "./NullableSchema.js";
 import type { StringSchemaOptions } from "./StringSchema.js";
 import { StringSchema } from "./StringSchema.js";
@@ -40,7 +41,8 @@ export class EmailSchema extends StringSchema {
 		});
 	}
 	override sanitize(str: string): string {
-		return super.sanitize(str).toLowerCase();
+		// Email addresses never contain whitespace, so strip it entirely, then lowercase (RFC says addresses should be case-insensitive).
+		return sanitizeWord(str).toLowerCase();
 	}
 }
 

--- a/modules/schema/URISchema.test.ts
+++ b/modules/schema/URISchema.test.ts
@@ -128,6 +128,10 @@ describe("validate()", () => {
 		test("Wwhitespace is trimmed from start/end", () => {
 			expect(schema.validate("    http://www.x.com/   ")).toBe("http://www.x.com/");
 		});
+		test("Whitespace anywhere in the URI is stripped", () => {
+			expect(schema.validate("http://www.x.com /path")).toBe("http://www.x.com/path");
+			expect(schema.validate("http :// www.x.com / path")).toBe("http://www.x.com/path");
+		});
 	});
 	describe("port", () => {
 		test("Valid ports are valid", () => {

--- a/modules/schema/URISchema.ts
+++ b/modules/schema/URISchema.ts
@@ -1,4 +1,5 @@
 import { formatURI } from "../util/format.js";
+import { sanitizeWord } from "../util/string.js";
 import { getURI, HTTP_SCHEMES, type URISchemes, type URIString } from "../util/uri.js";
 import { NULLABLE } from "./NullableSchema.js";
 import type { StringSchemaOptions } from "./StringSchema.js";
@@ -35,6 +36,10 @@ export class URISchema extends StringSchema {
 		if (!uri) throw str ? `Invalid ${this.one} format` : "Required";
 		if (this.schemes && !this.schemes.includes(uri.protocol)) throw `Invalid ${this.one} scheme`;
 		return uri.href;
+	}
+	override sanitize(str: string): string {
+		// URIs never contain whitespace (a real space must be `%20`-encoded), so strip it entirely.
+		return sanitizeWord(str);
 	}
 	override format(value: string): string {
 		return formatURI(value, this.format);

--- a/modules/schema/URLSchema.test.ts
+++ b/modules/schema/URLSchema.test.ts
@@ -134,6 +134,10 @@ describe("validate()", () => {
 		test("Wwhitespace is trimmed from start/end", () => {
 			expect(schema.validate("    http://www.x.com/   ")).toBe("http://www.x.com/");
 		});
+		test("Whitespace anywhere in the URL is stripped", () => {
+			expect(schema.validate("http://www.x.com /path")).toBe("http://www.x.com/path");
+			expect(schema.validate("http :// www.x.com / path")).toBe("http://www.x.com/path");
+		});
 	});
 	describe("port", () => {
 		test("Valid ports are valid", () => {

--- a/modules/schema/URLSchema.ts
+++ b/modules/schema/URLSchema.ts
@@ -1,4 +1,5 @@
 import { formatURL } from "../util/format.js";
+import { sanitizeWord } from "../util/string.js";
 import { HTTP_SCHEMES, type URISchemes } from "../util/uri.js";
 import { getURL, type URLString } from "../util/url.js";
 import { NULLABLE } from "./NullableSchema.js";
@@ -39,6 +40,10 @@ export class URLSchema extends StringSchema {
 		if (!url) throw str ? `Invalid ${this.one} format` : "Required";
 		if (this.schemes && !this.schemes.includes(url.protocol)) throw `Invalid ${this.one} scheme`;
 		return url.href;
+	}
+	override sanitize(str: string): string {
+		// URLs never contain whitespace (a real space must be `%20`-encoded), so strip it entirely.
+		return sanitizeWord(str);
 	}
 	override format(value: string): string {
 		return formatURL(value, this.base, this.format);

--- a/modules/util/string.test.ts
+++ b/modules/util/string.test.ts
@@ -10,6 +10,7 @@ import {
 	requireStringLength,
 	sanitizeMultilineText,
 	sanitizeText,
+	sanitizeWord,
 	simplifyString,
 	splitString,
 	THINSP,
@@ -59,6 +60,16 @@ test("requireStringLength()", () => {
 	expect(() => requireStringLength("abcde", 0, 3)).toThrow(/characters/i);
 });
 
+describe("sanitizeWord()", () => {
+	test("Strip all whitespace entirely", () => {
+		expect(sanitizeWord("aaa\t\t\t   \r\r\rbbb")).toBe("aaabbb");
+		expect(sanitizeWord("  a b c  ")).toBe("abc");
+	});
+	test("Strip control characters", () => {
+		expect(sanitizeWord("aaa\0bbb")).toBe("aaabbb");
+		expect(sanitizeWord("a\x01b\x1Fcd\x7Fe\x9Ff")).toBe("abcdef");
+	});
+});
 describe("sanitizeString()", () => {
 	test("Normalise runs of whitespace to single ` ` space", () => {
 		expect(sanitizeText("aaa\t\t\t   \r\r\rbbb")).toBe("aaa bbb");

--- a/modules/util/string.ts
+++ b/modules/util/string.ts
@@ -91,6 +91,20 @@ export function sanitizeText(str: string): string {
 }
 
 /**
+ * Sanitize a single word of text.
+ * - Used when you're sanitising a value that can never contain whitespace, e.g. an email address or token.
+ * - Remove all control characters (like `sanitizeText()`).
+ * - Strip all whitespace entirely (rather than collapsing runs to a single space like `sanitizeText()`).
+ *
+ * @example sanitizeWord("\x00 a b c "); // Returns `"abc"`
+ */
+export function sanitizeWord(str: string): string {
+	return str
+		.replace(/[^\P{C}\s]/gu, "") // Strip control characters (except whitespace).
+		.replace(/\s+/gu, ""); // Strip all whitespace entirely.
+}
+
+/**
  * Sanitize multiple lines of text.
  * - Used when you're sanitising a multi-line input, e.g. a description for something.
  * - Remove all control characters except `\n` newline.


### PR DESCRIPTION
## Summary

Adds a `sanitizeWord()` string utility for values that can never legitimately contain whitespace, and wires it into the schemas where that holds. This pairs with the `StringSchemaInput` blur-formatter (merged in #137): on blur these inputs now reset to a clean, whitespace-stripped value rather than collapsing runs to a single space and leaving an invalid value.

## Changes

**`sanitizeWord()` (`modules/util/string.ts`)** — sibling to `sanitizeText()`. Strips all control characters (same as `sanitizeText`) but removes whitespace **entirely** rather than collapsing runs to a single space.

**`EmailSchema`** — `sanitize()` now uses `sanitizeWord()` then lowercases. `"jo @ google.com"` → `"jo@google.com"` instead of staying `"jo @ google.com"` and failing validation.

**`URLSchema` / `URISchema`** — `sanitize()` now uses `sanitizeWord()`. URLs/URIs never contain raw whitespace (a real space must be `%20`-encoded), so a pasted value with stray spaces or newlines is cleaned before parsing.

## Behaviour note for review

Previously `URLSchema`/`URISchema` inherited `sanitizeText`, so the WHATWG parser saw internal spaces and either silently `%20`-encoded a space in the **path** (`http://x.com/a b` → `http://x.com/a%20b`) or threw for a space in the **host**. Now whitespace is stripped before parsing, so `http://x.com/a b` → `http://x.com/ab` (no `%20`). No existing test pinned the old `%20` behaviour. This is intended for the blur-formatter use case (clean up pasted/typo whitespace); flag it if you'd rather only strip from host/scheme and leave the path encoding alone.

## Tests

- `sanitizeWord()` unit tests (strips all whitespace, strips control chars)
- "Whitespace anywhere is stripped" cases added to `EmailSchema`, `URLSchema`, `URISchema` test files
- Full suite: 1103 pass, 0 fail; lint and type checks clean

https://claude.ai/code/session_0154U3EkV2o5Dxu5wcAjWoDa

---
_Generated by [Claude Code](https://claude.ai/code/session_0154U3EkV2o5Dxu5wcAjWoDa)_