### PR TITLE
fix(docs): map theme.css card and button overrides to current hooks

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,47 +1,42 @@
 /*
  * Documentation site theme.
  *
- * A token-only overlay on top of the base design tokens defined by `style/base.css`. Only CSS custom
- * properties (the `--variable` design tokens) are set here — never component selectors — so the docs
- * site gets a brighter, more colourful personality without forking a single component's styling.
+ * A token-only overlay on the base design tokens from `style/base.css`. Only CSS custom properties are
+ * set here at `:root` — never component selectors — so the docs site gets a warm peach personality
+ * purely through the cascade. Imported last in `client.tsx`, after the base tokens.
  *
- * Plain CSS, no layer participation: token overrides propagate via inheritance, not cascade competition.
- * Imported last in `client.tsx` so these `:root` declarations land after the base tokens and win on
- * source order (both are at `:root` specificity, both unlayered).
+ * Strategy: retheme the *global* 5-step colour scale rather than individual components. Every surface
+ * component (Card, Preformatted, Panel, Notice, Tag, Code, …) rebinds the scale from `inherit` (see
+ * `modules/ui/README.md` → "Retheming via the global scale"), so pointing the page-level
+ * `--color-light / --color-vivid / --color-dark` at the orange family repaints all of them at once —
+ * and identically, so a Preformatted matches a Card whether it's nested in one or standing alone.
  */
 :root {
-	/* Surfaces — warm cream page; soft peach `--color-surface` for prose-level chips, tags and code. */
-	--color-bg: color-mix(in srgb, var(--vivid-orange) 6%, white);
-	--color-surface: color-mix(in srgb, var(--vivid-orange) 13%, white);
+	/* Brand hues. The `--light-*` / `--dark-*` family members derive from these in `base.css`, so the
+	   whole orange/purple ramp re-tints automatically when the vivid anchor moves. */
+	--vivid-orange: #ff7a1a; /* warm brand anchor — surfaces land as a soft peach via --light-orange */
+	--vivid-purple: #7c3aed; /* brand violet — drives buttons */
 
-	/* Borders keep a gentle purple tint for tables, inputs and inline surfaces. */
-	--color-border: color-mix(in srgb, var(--vivid-purple) 22%, white);
+	/* Page colour scale → orange family. This is the cascade root every surface component inherits, so
+	   Cards, Preformatteds, Panels, Tags, Code chips, etc. all paint from the same peach ramp. */
+	--color-light: var(--light-orange); /* surfaces — Card / Preformatted / chip backgrounds */
+	--color-vivid: var(--vivid-orange); /* borders and accents */
+	--color-dark: var(--dark-orange); /* text */
+	/* --color-black / --color-white deliberately stay the page extremes (black text, white page). */
 
-	/* Quiet text — table headers, captions, definition labels — picks up the same purple personality. */
-	--color-quiet: var(--vivid-purple);
-
-	/*
-	* Cards — a soft peach surface with no border of their own (`--card-thickness: 0`). All three inner
-	* scale steps are set, not just `light`, so components nested inside a card (Preformatted, Tag,
-	* Notice…) inherit a coherent peach ramp instead of falling back to the grey page defaults. Each
-	* rebinds `--color-light/vivid/dark` from `var(--<name>-color-*, inherit)`, and that `inherit`
-	* resolves to the card's values: `light` = surface, `vivid` = border/accent (e.g. a nested code
-	* block's border), `dark` = text. `black`/`white` deliberately stay the page extremes.
-	*/
-	--card-color-light: color-mix(in srgb, var(--vivid-orange) 14%, white);
-	--card-color-vivid: color-mix(in srgb, var(--vivid-orange) 50%, white);
-	--card-color-dark: color-mix(in srgb, var(--vivid-orange) 30%, black);
-	--card-thickness: 0;
-
-	/* Interactive colours — brighter and more characterful, straight from the palette. */
+	/* Interactive accents. */
 	--color-link: var(--vivid-purple);
 	--color-focus: var(--vivid-pink);
 
+	/* Cards and Preformatteds: borderless, so the peach surfaces read as flat tinted blocks. Colour
+	   itself now comes from the global scale above, so the two match exactly. */
+	--card-thickness: 0;
+	--preformatted-thickness: 0;
+
 	/*
-	 * Buttons — bold purple blocks with white content; the site's signature interactive element.
-	 * Button's palette drives the `strong` variant as `bg=vivid / text=white`, so the brand purple
-	 * goes on `--button-color-vivid` (also the default variant's border/label) and white on
-	 * `--button-color-white`.
+	 * Buttons stay purple while everything else goes peach. Button also rebinds from the scale, so with
+	 * the page now orange it would inherit orange too — pin its `vivid` step back to the brand purple.
+	 * The `strong` variant paints bg=vivid (purple) / text=white.
 	 */
 	--button-color-vivid: var(--vivid-purple);
 	--button-color-white: var(--color-white);

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,42 +1,34 @@
 /*
  * Documentation site theme.
  *
- * A token-only overlay on the base design tokens from `style/base.css`. Only CSS custom properties are
- * set here at `:root` — never component selectors — so the docs site gets a warm peach personality
- * purely through the cascade. Imported last in `client.tsx`, after the base tokens.
+ * Token-only overlay on the base design tokens from `style/base.css`, set at `:root` (never component
+ * selectors). Imported last in `client.tsx`, after the base tokens.
  *
- * Strategy: retheme the *global* 5-step colour scale rather than individual components. Every surface
- * component (Card, Preformatted, Panel, Notice, Tag, Code, …) rebinds the scale from `inherit` (see
- * `modules/ui/README.md` → "Retheming via the global scale"), so pointing the page-level
- * `--color-light / --color-vivid / --color-dark` at the orange family repaints all of them at once —
- * and identically, so a Preformatted matches a Card whether it's nested in one or standing alone.
+ * Surfaces-only peach: we retint just the `--color-light` surface step of the global scale. Every
+ * surface component (Card, Preformatted, Panel, Tag, Code, …) inherits it for its background, so they
+ * all go peach and match each other — nested or standalone.
+ *
+ * Deliberately NOT retinted: `--color-dark` (text) and `--color-vivid` (borders/accents). The page
+ * `body` paints its baseline text with `--color-dark`, and all body copy (titles, headings, prose,
+ * lists) inherits that — so moving it would recolour every word on the page, not just text on cards.
+ * Keeping it at the default leaves page and card text the normal near-black.
  */
 :root {
-	/* Brand hues. The `--light-*` / `--dark-*` family members derive from these in `base.css`, so the
-	   whole orange/purple ramp re-tints automatically when the vivid anchor moves. */
-	--vivid-orange: #ff7a1a; /* warm brand anchor — surfaces land as a soft peach via --light-orange */
-	--vivid-purple: #7c3aed; /* brand violet — drives buttons */
+	/* Surfaces → soft peach. Global `--color-light` is the cascade root every surface component inherits
+	   for its background, so Cards, Preformatteds, Tags and Code chips all match. */
+	--color-light: color-mix(in srgb, #ff7a1a 14%, white);
 
-	/* Page colour scale → orange family. This is the cascade root every surface component inherits, so
-	   Cards, Preformatteds, Panels, Tags, Code chips, etc. all paint from the same peach ramp. */
-	--color-light: var(--light-orange); /* surfaces — Card / Preformatted / chip backgrounds */
-	--color-vivid: var(--vivid-orange); /* borders and accents */
-	--color-dark: var(--dark-orange); /* text */
-	/* --color-black / --color-white deliberately stay the page extremes (black text, white page). */
+	/* Cards and Preformatteds borderless, so the peach reads as a flat tinted block. */
+	--card-thickness: 0;
+	--preformatted-thickness: 0;
 
 	/* Interactive accents. */
 	--color-link: var(--vivid-purple);
 	--color-focus: var(--vivid-pink);
 
-	/* Cards and Preformatteds: borderless, so the peach surfaces read as flat tinted blocks. Colour
-	   itself now comes from the global scale above, so the two match exactly. */
-	--card-thickness: 0;
-	--preformatted-thickness: 0;
-
 	/*
-	 * Buttons stay purple while everything else goes peach. Button also rebinds from the scale, so with
-	 * the page now orange it would inherit orange too — pin its `vivid` step back to the brand purple.
-	 * The `strong` variant paints bg=vivid (purple) / text=white.
+	 * Buttons stay purple. Button rebinds its `vivid` step from the scale, so pin it to the brand
+	 * purple — that drives the `strong` variant's background and the default variant's border/label.
 	 */
 	--button-color-vivid: var(--vivid-purple);
 	--button-color-white: var(--color-white);

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -27,9 +27,14 @@
 	--color-focus: var(--vivid-pink);
 
 	/*
-	 * Buttons stay purple. Button rebinds its `vivid` step from the scale, so pin it to the brand
-	 * purple — that drives the `strong` variant's background and the default variant's border/label.
+	 * Buttons stay purple. Button rebinds the whole scale from its own hooks, so pin every step it
+	 * paints from — otherwise unpinned steps inherit the page's peach `--color-*`. The default variant
+	 * paints `bg=light / text+border=vivid`; the `strong` variant paints `bg=vivid / text=white`. So:
+	 *   - light → light-purple surface (default button background)
+	 *   - vivid → brand purple (default border/label, strong background)
+	 *   - white → label on the strong variant
 	 */
+	--button-color-light: var(--light-purple);
 	--button-color-vivid: var(--vivid-purple);
 	--button-color-white: var(--color-white);
 

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -21,12 +21,16 @@
 	--color-quiet: var(--vivid-purple);
 
 	/*
-	* Cards — a soft mid peach with no border. Card now exposes a 5-step palette
-	* (`--card-color-light/vivid/dark/black/white`); the surface is its `light` step and the border is
-	* suppressed via `--card-thickness`. Content nested inside (code chips, tags) falls back to the
-	* prose-level `--color-surface` above, since the old card-specific nested surface step is gone.
+	* Cards — a soft peach surface with no border of their own (`--card-thickness: 0`). All three inner
+	* scale steps are set, not just `light`, so components nested inside a card (Preformatted, Tag,
+	* Notice…) inherit a coherent peach ramp instead of falling back to the grey page defaults. Each
+	* rebinds `--color-light/vivid/dark` from `var(--<name>-color-*, inherit)`, and that `inherit`
+	* resolves to the card's values: `light` = surface, `vivid` = border/accent (e.g. a nested code
+	* block's border), `dark` = text. `black`/`white` deliberately stay the page extremes.
 	*/
 	--card-color-light: color-mix(in srgb, var(--vivid-orange) 14%, white);
+	--card-color-vivid: color-mix(in srgb, var(--vivid-orange) 50%, white);
+	--card-color-dark: color-mix(in srgb, var(--vivid-orange) 30%, black);
 	--card-thickness: 0;
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -21,22 +21,26 @@
 	--color-quiet: var(--vivid-purple);
 
 	/*
-	* Cards — a soft mid peach with no border. Content nested inside (code chips, tags) uses the
-	* deeper opaque `--card-color-surface`, giving it its own depth distinct from the lighter
-	* prose-level `--color-surface`.
+	* Cards — a soft mid peach with no border. Card now exposes a 5-step palette
+	* (`--card-color-light/vivid/dark/black/white`); the surface is its `light` step and the border is
+	* suppressed via `--card-thickness`. Content nested inside (code chips, tags) falls back to the
+	* prose-level `--color-surface` above, since the old card-specific nested surface step is gone.
 	*/
-	--card-color-bg: color-mix(in srgb, var(--vivid-orange) 14%, white);
-	--card-border: 0;
-	--card-color-surface: color-mix(in srgb, var(--vivid-orange) 21%, white);
+	--card-color-light: color-mix(in srgb, var(--vivid-orange) 14%, white);
+	--card-thickness: 0;
 
 	/* Interactive colours — brighter and more characterful, straight from the palette. */
 	--color-link: var(--vivid-purple);
 	--color-focus: var(--vivid-pink);
 
-	/* Buttons — bold purple blocks with white content; the site's signature interactive element. */
-	--button-color-bg: var(--vivid-purple);
-	--button-color-text: var(--color-white);
-	--button-color-border: var(--vivid-purple);
+	/*
+	 * Buttons — bold purple blocks with white content; the site's signature interactive element.
+	 * Button's palette drives the `strong` variant as `bg=vivid / text=white`, so the brand purple
+	 * goes on `--button-color-vivid` (also the default variant's border/label) and white on
+	 * `--button-color-white`.
+	 */
+	--button-color-vivid: var(--vivid-purple);
+	--button-color-white: var(--color-white);
 
 	/*
 	 * Sidebar navigation — a soft lavender panel with the divider dropped. Inactive links are

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -155,6 +155,32 @@ Other tokens (`--*-padding`, `--*-spacing`, `--*-radius`, `--*-font`, `--*-size`
 
 This split is deliberate. The rebind is the right tool when an identity needs to propagate; for everything else, plain CSS inheritance (or no inheritance at all) is the right tool.
 
+### Retheming via the global scale
+
+The rebind pattern has a powerful consequence: because every surface component rebinds the scale from `inherit`, the page-level `:root` scale is the **cascade root they all fall back to**. Retinting it at `:root` repaints every surface component at once — and *identically*, so a standalone `<Preformatted>` matches one nested in a `<Card>`, and both match the `<Card>` itself. This is almost always preferable to overriding each component's own hook (`--card-color-light`, `--preformatted-color-light`, …) one by one, which only themes that single component and leaves its siblings on the grey defaults.
+
+A theme (e.g. `docs/theme.css`) repoints the scale at a hue family:
+
+```css
+:root {
+  /* Move the vivid anchor; the --light-*/--dark-* family derives from it in base.css. */
+  --vivid-orange: #ff7a1a;
+
+  /* Point the page scale at the orange family — every surface component inherits this. */
+  --color-light: var(--light-orange); /* surfaces (Card, Preformatted, chips) */
+  --color-vivid: var(--vivid-orange); /* borders and accents */
+  --color-dark: var(--dark-orange); /* text */
+  /* --color-black / --color-white stay the page extremes. */
+}
+```
+
+Two rules keep this clean:
+
+- **Move the anchor, not just the scale.** The `--light-<hue>` / `--dark-<hue>` tokens are defined in `base.css` as expressions over `--vivid-<hue>`, resolved lazily at use-time. Overriding `--vivid-orange` at `:root` re-tints the whole orange family for free, so `var(--light-orange)` and `var(--dark-orange)` stay coherent with the new anchor.
+- **Pin the exceptions back.** A component that should resist the global retint sets its own hook. The docs site keeps Buttons purple while everything else goes peach by pinning `--button-color-vivid: var(--vivid-purple)` — Button rebinds from the scale like everything else, so without the pin it would inherit the page orange too.
+
+Set the global scale to theme everything; set a per-component hook only for the deliberate exceptions.
+
 ### How `:first-child` / `:last-child` margin overrides work
 
 Every block-level component zeros its outer margins when it's the first or last child of its container — otherwise a Heading at the top of a Card would leave a strip of unwanted space. These rules live in `@layer overrides`, which beats every other layer including `variants`, so a `<Card space-large>` still collapses its abutting edges correctly.

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -157,29 +157,34 @@ This split is deliberate. The rebind is the right tool when an identity needs to
 
 ### Retheming via the global scale
 
-The rebind pattern has a powerful consequence: because every surface component rebinds the scale from `inherit`, the page-level `:root` scale is the **cascade root they all fall back to**. Retinting it at `:root` repaints every surface component at once — and *identically*, so a standalone `<Preformatted>` matches one nested in a `<Card>`, and both match the `<Card>` itself. This is almost always preferable to overriding each component's own hook (`--card-color-light`, `--preformatted-color-light`, …) one by one, which only themes that single component and leaves its siblings on the grey defaults.
+The rebind pattern has a powerful consequence: because every surface component rebinds the scale from `inherit`, the page-level `:root` scale is the **cascade root they all fall back to**. Retinting a step at `:root` repaints every surface component at once — and *identically*, so a standalone `<Preformatted>` matches one nested in a `<Card>`, and both match the `<Card>` itself. This is almost always preferable to overriding each component's own hook (`--card-color-light`, `--preformatted-color-light`, …) one by one, which only themes that single component and leaves its siblings on the grey defaults.
 
-A theme (e.g. `docs/theme.css`) repoints the scale at a hue family:
+**But retint one step at a time, and know what else reads it.** The global scale isn't surfaces-only — the page baseline reads from it too. In `base.css`:
+
+```css
+body { color: var(--color-dark); background: var(--color-white); }
+```
+
+All body copy (Titles, Headings, Paragraphs, lists) has no `color` of its own; it inherits this baseline. So moving `--color-dark` at `:root` recolours **every word on the page**, not just text sitting on a card. Likewise `--color-vivid` tints borders and accents app-wide. Retint only the step whose reach you actually want:
+
+- `--color-light` — **surfaces** (Card / Preformatted / Tag / Code backgrounds). Safe to retint broadly; nothing paints page text or the page background from it.
+- `--color-vivid` — borders and accents everywhere. Retint only if you want app-wide accent recolouring.
+- `--color-dark` — **the page text colour**, via the `body` baseline above. Retinting this is a whole-page text recolour; usually not what a "themed surfaces" look wants.
+- `--color-black` / `--color-white` — the page extremes (max-contrast text, page background). Leave unless inverting (e.g. dark mode).
+
+The docs theme wants peach surfaces with normal near-black text, so it retints **only** `--color-light`:
 
 ```css
 :root {
-  /* Move the vivid anchor; the --light-*/--dark-* family derives from it in base.css. */
-  --vivid-orange: #ff7a1a;
-
-  /* Point the page scale at the orange family — every surface component inherits this. */
-  --color-light: var(--light-orange); /* surfaces (Card, Preformatted, chips) */
-  --color-vivid: var(--vivid-orange); /* borders and accents */
-  --color-dark: var(--dark-orange); /* text */
-  /* --color-black / --color-white stay the page extremes. */
+  /* Surfaces go peach; text and the page background stay the library defaults. */
+  --color-light: color-mix(in srgb, #ff7a1a 14%, white);
 }
 ```
 
-Two rules keep this clean:
+Two more rules keep a theme clean:
 
-- **Move the anchor, not just the scale.** The `--light-<hue>` / `--dark-<hue>` tokens are defined in `base.css` as expressions over `--vivid-<hue>`, resolved lazily at use-time. Overriding `--vivid-orange` at `:root` re-tints the whole orange family for free, so `var(--light-orange)` and `var(--dark-orange)` stay coherent with the new anchor.
-- **Pin the exceptions back.** A component that should resist the global retint sets its own hook. The docs site keeps Buttons purple while everything else goes peach by pinning `--button-color-vivid: var(--vivid-purple)` — Button rebinds from the scale like everything else, so without the pin it would inherit the page orange too.
-
-Set the global scale to theme everything; set a per-component hook only for the deliberate exceptions.
+- **If you do move a whole hue, move the anchor.** The `--light-<hue>` / `--dark-<hue>` tokens are defined in `base.css` as expressions over `--vivid-<hue>`, resolved lazily at use-time. Overriding `--vivid-orange` at `:root` re-tints the whole orange family for free, so `var(--light-orange)` / `var(--dark-orange)` stay coherent.
+- **Pin the exceptions back.** A component that should resist a global retint sets its own hook. The docs site keeps Buttons purple by pinning `--button-color-vivid: var(--vivid-purple)` — Button rebinds from the scale like everything else, so without the pin it would inherit the page colour too.
 
 ### How `:first-child` / `:last-child` margin overrides work
 

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -184,7 +184,7 @@ The docs theme wants peach surfaces with normal near-black text, so it retints *
 Two more rules keep a theme clean:
 
 - **If you do move a whole hue, move the anchor.** The `--light-<hue>` / `--dark-<hue>` tokens are defined in `base.css` as expressions over `--vivid-<hue>`, resolved lazily at use-time. Overriding `--vivid-orange` at `:root` re-tints the whole orange family for free, so `var(--light-orange)` / `var(--dark-orange)` stay coherent.
-- **Pin the exceptions back.** A component that should resist a global retint sets its own hook. The docs site keeps Buttons purple by pinning `--button-color-vivid: var(--vivid-purple)` — Button rebinds from the scale like everything else, so without the pin it would inherit the page colour too.
+- **Pin the exceptions back — and pin *every* step the component paints.** A component that should resist a global retint sets its own hooks. But a component rebinds the *whole* scale, and any step you leave unpinned still inherits the page colour. The docs site keeps Buttons purple by pinning both steps the default variant paints — `--button-color-light: var(--light-purple)` (background) and `--button-color-vivid: var(--vivid-purple)` (border/label) — plus `--button-color-white` for the `strong` label. Pinning only `vivid` would leave the default button's `bg=light` background inheriting the page peach: a purple-bordered peach button. Check which steps the variant in use actually paints (default = `light`+`vivid`, `strong` = `vivid`+`white`) and pin all of them.
 
 ### How `:first-child` / `:last-child` margin overrides work
 


### PR DESCRIPTION
Card and Button were refactored to a 5-step colour palette
(--*-color-light/vivid/dark/black/white). docs/theme.css still set the
old hook names for these two components, which nothing reads any more, so
the peach card surface and purple buttons were a silent no-op.

- Card: --card-color-bg -> --card-color-light (the surface), and
  --card-border: 0 -> --card-thickness: 0 (the border-width hook was
  renamed too). The old --card-color-surface nested-surface step no
  longer exists in Card, so it is dropped; nested chips fall back to the
  prose-level --color-surface, which is still set here.
- Button: --button-color-bg/--button-color-text/--button-color-border ->
  --button-color-vivid (strong-variant background, plus default border
  and label) and --button-color-white (strong-variant label).

The sidebar (--sidebar-layout-bg/-border) and menu
(--menu-color-text/--menu-link-color-hover-bg) hooks flagged in the
audit are still read by SidebarLayout and Menu, so they are left as-is.
The global --color-* overrides are unchanged.

Fixes #138