### PR TITLE
fix: read NO_COLOR live so ANSI codes don't leak in late-env runtimes

### DIFF
--- a/modules/util/ansi.test.ts
+++ b/modules/util/ansi.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ANSI_RESET, ANSI_SUCCESS, ansiWrap } from "../index.js";
+
+// Save and restore `NO_COLOR` around each test so we can flip it at runtime.
+let _previous: string | undefined;
+beforeEach(() => {
+	_previous = process.env.NO_COLOR;
+});
+afterEach(() => {
+	if (_previous === undefined) delete process.env.NO_COLOR;
+	else process.env.NO_COLOR = _previous;
+});
+
+describe("ansiWrap()", () => {
+	test("wraps input in codes and reset when NO_COLOR is unset", () => {
+		delete process.env.NO_COLOR;
+		expect(ansiWrap("abc", "\x1b[31m")).toBe(`\x1b[31mabc${ANSI_RESET}`);
+	});
+	test("returns input unchanged when NO_COLOR is truthy", () => {
+		process.env.NO_COLOR = "1";
+		expect(ansiWrap("abc", "\x1b[31m")).toBe("abc");
+	});
+	test("reads NO_COLOR live on each call", () => {
+		// Same call, different environment, different result — proves there is no frozen capture.
+		process.env.NO_COLOR = "0";
+		const coloured = ansiWrap("abc", "\x1b[31m");
+		process.env.NO_COLOR = "true";
+		const plain = ansiWrap("abc", "\x1b[31m");
+		expect(coloured).toBe(`\x1b[31mabc${ANSI_RESET}`);
+		expect(plain).toBe("abc");
+	});
+});
+
+describe("ANSI icons", () => {
+	test("colour seamlessly inside template literals", () => {
+		delete process.env.NO_COLOR;
+		expect(`${ANSI_SUCCESS}`).toBe(`\x1b[32m✓${ANSI_RESET}`);
+	});
+	test("re-evaluate against the live NO_COLOR (late-populated env)", () => {
+		// Simulates a runtime that populates env vars after module-load: the icon must reflect the new value.
+		delete process.env.NO_COLOR;
+		expect(`${ANSI_SUCCESS}`).toBe(`\x1b[32m✓${ANSI_RESET}`);
+		process.env.NO_COLOR = "yes";
+		expect(`${ANSI_SUCCESS}`).toBe("✓");
+	});
+});

--- a/modules/util/ansi.ts
+++ b/modules/util/ansi.ts
@@ -1,6 +1,6 @@
 import type { ImmutableArray } from "./array.js";
 import { DOWN, FAILURE, LEFT, RIGHT, SUCCESS, UP, WAITING } from "./constants.js";
-import { NO_COLOR } from "./env.js";
+import { getEnvBoolean } from "./env.js";
 
 // Colors.
 export const ANSI_DEFAULT = "\x1b[39m" as const;
@@ -23,17 +23,37 @@ export const ANSI_INVERSE = "\x1b[7m" as const;
 // Reset.
 export const ANSI_RESET = "\x1b[0m";
 
-/** Wrap a string in `ANSI_RED` or the ANSI color/style codes (at the start), and `ANSI_RESET` at the end. */
+/**
+ * Wrap a string in the ANSI color/style codes (at the start), and `ANSI_RESET` at the end.
+ *
+ * - The `NO_COLOR` environment variable is read live on every call, so runtimes that populate `process.env` late (e.g. Cloudflare Workers, where `[vars]` bindings are only reliably available within the request scope) are honoured rather than baking in whatever `NO_COLOR` was at module-load time.
+ */
 export function ansiWrap(input: string, ...wrappers: ImmutableArray<string>) {
-	if (NO_COLOR) return input;
+	if (getEnvBoolean("NO_COLOR")) return input;
 	return `${wrappers.join("")}${input}${ANSI_RESET}`;
 }
 
+/**
+ * A lazily-coloured icon that re-evaluates its ANSI colouring against the live `NO_COLOR` environment variable every time it is converted to a string.
+ *
+ * - Used directly inside template literals (`${ANSI_SUCCESS}`), where JavaScript invokes `toString()` automatically, so the icon is coloured at use-time, not at module-load time.
+ */
+export type AnsiIcon = { toString(): string };
+
+/** Create a lazily-coloured {@link AnsiIcon} that wraps `icon` in `wrappers` on each `toString()`. */
+function _createAnsiIcon(icon: string, ...wrappers: ImmutableArray<string>): AnsiIcon {
+	return {
+		toString() {
+			return ansiWrap(icon, ...wrappers);
+		},
+	};
+}
+
 // Coloured icons.
-export const ANSI_WAITING = ansiWrap(WAITING, ANSI_BLUE);
-export const ANSI_SUCCESS = ansiWrap(SUCCESS, ANSI_GREEN);
-export const ANSI_FAILURE = ansiWrap(FAILURE, ANSI_RED);
-export const ANSI_UP = ansiWrap(UP, ANSI_BLUE);
-export const ANSI_DOWN = ansiWrap(DOWN, ANSI_BLUE);
-export const ANSI_RIGHT = ansiWrap(RIGHT, ANSI_BLUE);
-export const ANSI_LEFT = ansiWrap(LEFT, ANSI_BLUE);
+export const ANSI_WAITING = _createAnsiIcon(WAITING, ANSI_BLUE);
+export const ANSI_SUCCESS = _createAnsiIcon(SUCCESS, ANSI_GREEN);
+export const ANSI_FAILURE = _createAnsiIcon(FAILURE, ANSI_RED);
+export const ANSI_UP = _createAnsiIcon(UP, ANSI_BLUE);
+export const ANSI_DOWN = _createAnsiIcon(DOWN, ANSI_BLUE);
+export const ANSI_RIGHT = _createAnsiIcon(RIGHT, ANSI_BLUE);
+export const ANSI_LEFT = _createAnsiIcon(LEFT, ANSI_BLUE);

--- a/modules/util/env.ts
+++ b/modules/util/env.ts
@@ -40,6 +40,3 @@ export function requireEnvBoolean(name: string, caller: AnyCaller = requireEnvBo
 	if (typeof env !== "boolean") throw new RequiredError(`Environment variable "${name}" must be boolean`, { caller });
 	return env;
 }
-
-/** The `NO_COLOR` environment variable is commonly used to indicate that ANSI output shouldn't have color. */
-export const NO_COLOR = getEnvBoolean("NO_COLOR") ?? false;


### PR DESCRIPTION
`NO_COLOR` and the seven pre-coloured `ANSI_*` icon constants were
evaluated once at module-load time. In runtimes where `process.env` is
populated after top-level isolate evaluation — notably Cloudflare
Workers, where `[vars]` bindings are only reliably available within the
request scope — `NO_COLOR` resolved to `false` and colour codes were
permanently baked into the exported icon strings, leaking raw ANSI
escapes into logs intermittently (cold-start vs. warm-isolate timing).

- Drop the eager `NO_COLOR` const from `util/env.ts`; `ansiWrap` now
  calls `getEnvBoolean("NO_COLOR")` on every invocation.
- The seven `ANSI_*` icons are now lazy `AnsiIcon` objects whose
  `toString()` re-wraps against the live `NO_COLOR`. They still drop
  straight into template literals (`${ANSI_SUCCESS}`) unchanged, so no
  call sites needed updating.

BREAKING: `NO_COLOR` is removed, and the `ANSI_*` icon exports are now
objects (stringify on use) rather than plain strings. Consumers that
treated them as `string` values must coerce via `String(...)` /
`` `${...}` ``.

Closes #142