### PR TITLE
fix(extract): case-preserving keys, skip override members, drop class-prefixed titles

### DIFF
--- a/modules/api/provider/ClientAPIProvider.ts
+++ b/modules/api/provider/ClientAPIProvider.ts
@@ -56,7 +56,7 @@ export interface ClientAPIProviderOptions {
  */
 export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, R> {
 	/** The common base URL for all rendered endpoint requests. */
-	readonly url: URL;
+	override readonly url: URL;
 
 	/** Default options used for HTTP requests created with `this.createRequest()` and `this.fetch()` */
 	readonly options: RequestOptions;
@@ -71,7 +71,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		this.timeout = timeout;
 	}
 
-	renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
+	override renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
 		// Construct the full URL from `this.url` and the rendered path.
 		// Adding the `.` turns the absolute path from `renderPath()` into a relative URL.
 		// `requireURL()` resolves that path relative to `this.url`
@@ -90,7 +90,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 		return url;
 	}
 
-	createRequest<PP extends P, RR extends R>(
+	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
@@ -135,11 +135,11 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	}
 
 	// Override to set default functionality of a client provider to send requests over the network with `fetch()` and parse responses with `parseResponse()`.
-	async fetch(request: Request): Promise<Response> {
+	override async fetch(request: Request): Promise<Response> {
 		return fetch(request);
 	}
 
-	async parseResponse<PP extends P, RR extends R>(
+	override async parseResponse<PP extends P, RR extends R>(
 		_endpoint: Endpoint<PP, RR>,
 		response: Response,
 		caller: AnyCaller = this.parseResponse,

--- a/modules/api/provider/ThroughAPIProvider.ts
+++ b/modules/api/provider/ThroughAPIProvider.ts
@@ -10,7 +10,7 @@ import { APIProvider } from "./APIProvider.js";
  * - Extend this when you want to intercept only selected API operations, such as injecting auth headers or logging.
  */
 export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourceable<APIProvider<P, R>> {
-	get url(): URL {
+	override get url(): URL {
 		return this.source.url;
 	}
 
@@ -21,11 +21,11 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 		this.source = source;
 	}
 
-	renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
+	override renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
 		return this.source.renderURL(endpoint, payload, caller);
 	}
 
-	createRequest<PP extends P, RR extends R>(
+	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		payload: PP,
 		options?: RequestOptions,
@@ -34,7 +34,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 		return this.source.createRequest(endpoint, payload, options, caller);
 	}
 
-	parseResponse<PP extends P, RR extends R>(
+	override parseResponse<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
 		response: Response,
 		caller: AnyCaller = this.parseResponse,

--- a/modules/bun/BunPostgreSQLProvider.ts
+++ b/modules/bun/BunPostgreSQLProvider.ts
@@ -13,7 +13,7 @@ export class BunPostgreSQLProvider<I extends Identifier = Identifier, T extends 
 	}
 
 	// Implement `SQLProvider` using `Bun.SQL` instance.
-	exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<ImmutableArray<X>> {
+	override exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<ImmutableArray<X>> {
 		return this._sql(strings, ...values);
 	}
 

--- a/modules/cloudflare/CloudflareKVProvider.ts
+++ b/modules/cloudflare/CloudflareKVProvider.ts
@@ -38,26 +38,26 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 		this._kv = kv;
 	}
 
-	async getItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const data = (await this._kv.get(_getKey(name, id), { type: "json" })) as TT | null; // `as TT` needed: KV returns unknown from JSON parse.
 		if (data) return getItem(id, data);
 	}
 
-	getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError("CloudflareKVProvider does not support realtime subscriptions");
 	}
 
-	async addItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = randomUUID() as II; // `as II` needed: TypeScript can't narrow II from string return type.
 		await this._kv.put(_getKey(name, id), JSON.stringify(data));
 		return id;
 	}
 
-	async setItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this._kv.put(_getKey(name, id), JSON.stringify(data));
 	}
 
-	async updateItem<II extends I, TT extends T>(
+	override async updateItem<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_id: II,
 		_updates: Updates<Item<II, TT>>,
@@ -65,25 +65,25 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 		throw new UnimplementedError("CloudflareKVProvider does not support updates to items");
 	}
 
-	async deleteItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<void> {
 		await this._kv.delete(_getKey(name, id));
 	}
 
-	async getQuery<II extends I, TT extends T>(
+	override async getQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_query?: Query<Item<II, TT>>,
 	): Promise<Items<II, TT>> {
 		throw new UnimplementedError("CloudflareKVProvider does not support querying items");
 	}
 
-	getQuerySequence<II extends I, TT extends T>(
+	override getQuerySequence<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_query?: Query<Item<II, TT>>,
 	): ItemsSequence<II, TT> {
 		throw new UnimplementedError("CloudflareKVProvider does not support realtime subscriptions");
 	}
 
-	async setQuery<II extends I, TT extends T>(
+	override async setQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_query: Query<Item<II, TT>>,
 		_data: TT,
@@ -91,7 +91,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 		throw new UnimplementedError("CloudflareKVProvider does not support querying items");
 	}
 
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_query: Query<Item<II, TT>>,
 		_updates: Updates<TT>,
@@ -99,7 +99,10 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 		throw new UnimplementedError("CloudflareKVProvider does not support updates to items");
 	}
 
-	async deleteQuery<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _query: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(
+		_collection: Collection<string, II, TT>,
+		_query: Query<Item<II, TT>>,
+	): Promise<void> {
 		throw new UnimplementedError("CloudflareKVProvider does not support querying items");
 	}
 }

--- a/modules/db/provider/CacheDBProvider.ts
+++ b/modules/db/provider/CacheDBProvider.ts
@@ -19,29 +19,29 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 		this.memory = cache;
 	}
 
-	async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const item = await this.source.getItem(collection, id);
 		const table = this.memory.getTable(collection);
 		item ? table.setItem(id, item) : table.deleteItem(id);
 		return item;
 	}
 
-	getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		return this.memory.getTable(collection).setItemSequence(id, this.source.getItemSequence(collection, id));
 	}
 
-	async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = await this.source.addItem(collection, data);
 		this.memory.getTable(collection).setItem(id, data);
 		return id;
 	}
 
-	async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this.source.setItem(collection, id, data);
 		this.memory.getTable(collection).setItem(id, data);
 	}
 
-	async updateItem<II extends I, TT extends T>(
+	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		id: II,
 		updates: Updates<Item<II, TT>>,
@@ -50,7 +50,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 		this.memory.getTable(collection).updateItem(id, updates);
 	}
 
-	async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await this.source.deleteItem(collection, id);
 		this.memory.getTable(collection).deleteItem(id);
 	}
@@ -59,22 +59,32 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 		return this.source.countQuery(collection, query);
 	}
 
-	async getQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query?: Query<Item<II, TT>>,
+	): Promise<Items<II, TT>> {
 		const items = await this.source.getQuery(collection, query);
 		this.memory.getTable(collection).setItems(items);
 		return items;
 	}
 
-	getQuerySequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
+	override getQuerySequence<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query?: Query<Item<II, TT>>,
+	): ItemsSequence<II, TT> {
 		return this.memory.getTable(collection).setItemsSequence(this.source.getQuerySequence(collection, query));
 	}
 
-	async setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+		data: TT,
+	): Promise<void> {
 		await this.source.setQuery(collection, query, data);
 		this.memory.getTable(collection).setQuery(query, data);
 	}
 
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -83,7 +93,10 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 		this.memory.getTable(collection).updateQuery(query, updates);
 	}
 
-	async deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+	): Promise<void> {
 		await this.source.deleteQuery(collection, query);
 		this.memory.getTable(collection).deleteQuery(query);
 	}

--- a/modules/db/provider/MemoryDBProvider.ts
+++ b/modules/db/provider/MemoryDBProvider.ts
@@ -28,23 +28,26 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 		return ((this._tables[collection.name] as MemoryTable<II, TT>) ||= new MemoryTable<II, TT>(collection));
 	}
 
-	async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return this.getTable(collection).getItem(id);
 	}
 
-	async *getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
+	override async *getItemSequence<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		id: II,
+	): OptionalItemSequence<II, TT> {
 		yield* this.getTable(collection).getItemSequence(id);
 	}
 
-	async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		return this.getTable(collection).addItem(data);
 	}
 
-	async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		this.getTable(collection).setItem(id, data);
 	}
 
-	async updateItem<II extends I, TT extends T>(
+	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		id: II,
 		updates: Updates<Item<II, TT>>,
@@ -52,7 +55,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 		this.getTable(collection).updateItem(id, updates);
 	}
 
-	async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		this.getTable(collection).deleteItem(id);
 	}
 
@@ -63,22 +66,29 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 		return this.getTable(collection).countQuery(query);
 	}
 
-	async getQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query?: Query<Item<II, TT>>,
+	): Promise<Items<II, TT>> {
 		return this.getTable(collection).getQuery(query);
 	}
 
-	async *getQuerySequence<II extends I, TT extends T>(
+	override async *getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query?: Query<Item<II, TT>>,
 	): ItemsSequence<II, TT> {
 		return yield* this.getTable(collection).getQuerySequence(query);
 	}
 
-	async setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+		data: TT,
+	): Promise<void> {
 		this.getTable(collection).setQuery(query, data);
 	}
 
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -86,7 +96,10 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 		this.getTable(collection).updateQuery(query, updates);
 	}
 
-	async deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+	): Promise<void> {
 		this.getTable(collection).deleteQuery(query);
 	}
 

--- a/modules/db/provider/SQLProvider.ts
+++ b/modules/db/provider/SQLProvider.ts
@@ -23,7 +23,7 @@ type CountRow = {
 export abstract class SQLProvider<I extends Identifier = Identifier, T extends Data = Data> extends DBProvider<I, T> {
 	abstract exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<ImmutableArray<X>>;
 
-	async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const rows = await this.exec<Item<II, TT>>`
 			SELECT * FROM ${this.sqlIdentifier(collection.name)}
 			WHERE ${this.sqlIdentifier("id")} = ${id}
@@ -32,11 +32,11 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 		return rows[0];
 	}
 
-	getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError(`SQLProvider does not support realtime subscriptions`);
 	}
 
-	async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const rows = await this.exec<{ id: II }>`
 			INSERT INTO ${this.sqlIdentifier(collection.name)} ${this.sqlValues(data)}
 			RETURNING ${this.sqlIdentifier("id")}
@@ -46,14 +46,14 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 		return id;
 	}
 
-	async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this.exec`
 			INSERT INTO ${this.sqlIdentifier(collection.name)} ${this.sqlValues({ id, ...data })}
 			ON CONFLICT (${this.sqlIdentifier("id")}) DO UPDATE SET ${this.sqlSetters(data)}
 		`;
 	}
 
-	async updateItem<II extends I, TT extends T>(
+	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		id: II,
 		updates: Updates<Item<II, TT>>,
@@ -65,7 +65,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 		`;
 	}
 
-	async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await this.exec`DELETE FROM ${this.sqlIdentifier(collection.name)} WHERE ${this.sqlIdentifier("id")} = ${id}`;
 	}
 
@@ -80,25 +80,32 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 		return rows[0]?.count ?? 0;
 	}
 
-	async getQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query?: Query<Item<II, TT>>,
+	): Promise<Items<II, TT>> {
 		return this.exec<Item<II, TT>>`
 			SELECT * FROM ${this.sqlIdentifier(collection.name)}
 			${query ? this.sqlClauses(query) : this.sql``}
 		`;
 	}
 
-	getQuerySequence<II extends I, TT extends T>(
+	override getQuerySequence<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
 		_query?: Query<Item<II, TT>>,
 	): ItemsSequence<II, TT> {
 		throw new UnimplementedError(`SQLProvider does not support realtime subscriptions`);
 	}
 
-	async setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+		data: TT,
+	): Promise<void> {
 		await this.exec`UPDATE ${this.sqlIdentifier(collection.name)} SET ${this.sqlSetters(data)}${this.sqlClauses(query)}`;
 	}
 
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -106,7 +113,10 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 		await this.exec`UPDATE ${this.sqlIdentifier(collection.name)} SET ${this.sqlUpdates(updates)}${this.sqlClauses(query)}`;
 	}
 
-	async deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(
+		collection: Collection<string, II, TT>,
+		query: Query<Item<II, TT>>,
+	): Promise<void> {
 		await this.exec`DELETE FROM ${this.sqlIdentifier(collection.name)}${this.sqlClauses(query)}`;
 	}
 

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -75,9 +75,9 @@ export class Store {
 		expect(cls.props.children).toMatchObject([
 			{
 				type: "tree-documentation",
-				props: { kind: "property", name: "value", title: "Store.value", class: "Store", signatures: ["value: string"] },
+				props: { kind: "property", name: "value", title: "value", class: "Store", signatures: ["value: string"] },
 			},
-			{ type: "tree-documentation", props: { kind: "method", name: "set", title: "Store.set()", class: "Store" } },
+			{ type: "tree-documentation", props: { kind: "method", name: "set", title: "set()", class: "Store" } },
 		]);
 	});
 
@@ -196,8 +196,8 @@ export class Widget {
 					name: "Widget",
 					title: "Widget",
 					children: [
-						{ props: { kind: "property", name: "size", title: "Widget.size" } },
-						{ props: { kind: "method", name: "resize", title: "Widget.resize()" } },
+						{ props: { kind: "property", name: "size", title: "size" } },
+						{ props: { kind: "method", name: "resize", title: "resize()" } },
 					],
 				},
 			},
@@ -221,7 +221,7 @@ export class MemoryStore extends AbstractStore implements Serializable, Disposab
 		]);
 	});
 
-	test("stamps the owning class onto members and qualifies overrides with the base class", async () => {
+	test("stamps the owning class onto members and skips `override` members", async () => {
 		const element = await extractor.extract(
 			file(`
 /** A store. */
@@ -230,14 +230,17 @@ export class MemoryStore extends AbstractStore {
 	readonly value: string;
 	/** Get a thing. */
 	override get(): string { return ""; }
+	/** Override a property. */
+	override readonly size: number;
 }
 `),
 		);
 		const cls = (element.props.children as { props: { children: { props: Record<string, unknown> }[] } }[])[0];
+		// Only the directly-implemented `value` survives — `get()` and `size` carry `override` and are documented on the base class.
 		expect(cls?.props.children).toMatchObject([
-			{ props: { kind: "property", name: "value", title: "MemoryStore.value", class: "MemoryStore", readonly: true } },
-			{ props: { kind: "method", name: "get", title: "MemoryStore.get()", class: "MemoryStore", overrides: "AbstractStore.get" } },
+			{ props: { kind: "property", name: "value", title: "value", class: "MemoryStore", readonly: true } },
 		]);
+		expect(cls?.props.children).toHaveLength(1);
 	});
 
 	test("treats a getter without a setter as readonly, and a getter+setter pair as writable", async () => {
@@ -259,13 +262,13 @@ export class Store {
 				props: {
 					kind: "property",
 					name: "size",
-					title: "Store.size",
+					title: "size",
 					class: "Store",
 					readonly: true,
 					signatures: ["readonly size: number"],
 				},
 			},
-			{ props: { kind: "property", name: "name", title: "Store.name", class: "Store", signatures: ["name: string"] } },
+			{ props: { kind: "property", name: "name", title: "name", class: "Store", signatures: ["name: string"] } },
 		]);
 		// The getter+setter pair must NOT be flagged readonly.
 		expect((cls?.props.children[1]?.props as { readonly?: boolean }).readonly).toBeUndefined();
@@ -291,6 +294,25 @@ export function add(a: any, b: any): any { return a + b; }
 				signatures: ["add(a: number, b: number): number", "add(a: string, b: string): string", "add(a: any, b: any): any"],
 			},
 		});
+	});
+
+	test("keeps case-distinct exports separate (Class vs FACTORY) with case-preserving keys", async () => {
+		// `Collection` and `COLLECTION` differ only in case — they must not collapse into one entity.
+		const element = await extractor.extract(
+			file(`
+/** A collection. */
+export class Collection {
+	name: string;
+}
+/** Make a collection. */
+export function COLLECTION(): Collection { return new Collection(); }
+`),
+		);
+		const children = element.props.children as { key: string; props: { name: string; kind: string } }[];
+		expect(children).toHaveLength(2);
+		expect(children.map(c => c.key)).toEqual(["Collection", "COLLECTION"]);
+		expect(children.map(c => c.props.name)).toEqual(["Collection", "COLLECTION"]);
+		expect(children.map(c => c.props.kind)).toEqual(["class", "function"]);
 	});
 
 	test("parses @returns with type and description", async () => {

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -296,6 +296,24 @@ export function add(a: any, b: any): any { return a + b; }
 		});
 	});
 
+	test("skips `declare` members (ambient type-only re-declarations)", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A typed schema. */
+export class BooleanSchema extends Schema {
+	/** Narrowed value type. */
+	declare readonly value: boolean;
+	/** A real new method. */
+	check(): boolean { return true; }
+}
+`),
+		);
+		const cls = (element.props.children as { props: { children: { props: Record<string, unknown> }[] } }[])[0];
+		// The `declare` field is omitted; only the genuinely-new `check()` survives.
+		expect(cls?.props.children).toMatchObject([{ props: { kind: "method", name: "check", title: "check()" } }]);
+		expect(cls?.props.children).toHaveLength(1);
+	});
+
 	test("keeps case-distinct exports separate (Class vs FACTORY) with case-preserving keys", async () => {
 		// `Collection` and `COLLECTION` differ only in case — they must not collapse into one entity.
 		const element = await extractor.extract(

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -1,6 +1,5 @@
 import ts from "typescript";
 import type { ImmutableArray } from "../util/array.js";
-import { requireSlug } from "../util/string.js";
 import type {
 	DocumentationElement,
 	DocumentationElementProps,
@@ -20,8 +19,10 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`.
  * - Top-of-file JSDoc comment becomes the file's `content`.
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on the file and every `tree-documentation` child.
- * - Sets `title` on every `tree-documentation` child — `name()` for functions, `Class.name()` for methods, `Class.name` for properties, bare `name` for other kinds.
- * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `overrides`, `extends`, `implements`.
+ * - Sets `title` on every `tree-documentation` child — `name()` for functions and methods, bare `name` for other kinds. Parent class context comes from the `class` prop ("member of …" affordance), never the title.
+ * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`.
+ * - Members declared with the `override` modifier are skipped — the base class already documents them.
+ * - Keys are the raw declared `name` (case-preserving) so case-distinct exports like `Collection` and `COLLECTION` stay separate.
  * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
  */
 export class TypescriptExtractor extends FileExtractor {
@@ -106,11 +107,11 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 	const examples = jsDoc?.examples;
 	// Heritage (`extends` / `implements`) is only meaningful for classes and interfaces.
 	const heritage = _getHeritage(statement, source);
-	const children = _getClassMembers(statement, source, name, heritage?.extends);
+	const children = _getClassMembers(statement, source, name);
 
 	return {
 		type: "tree-documentation",
-		key: requireSlug(name),
+		key: name,
 		props: {
 			name,
 			// Functions read as callable with `()`; other kinds use the bare name.
@@ -243,16 +244,11 @@ function _getReturns(
 
 /**
  * Extract class or interface members as child elements.
- * - `className` is stamped onto every member as its `class` prop, and prebaked into the member `title` (`Class.member` / `Class.member()`).
- * - `baseName` (the class's `extends` target) qualifies the `overrides` reference of any `override` member.
+ * - `className` is stamped onto every member as its `class` prop (the source of the qualified flat key and the "member of …" affordance); the title stays the bare member `name` / `name()`.
+ * - Members declared with the `override` modifier are skipped — the base class already documents them, so a subclass page lists only its newly-introduced API.
  * - Getters/setters fold into a single `property` element per name; a getter with no matching setter is `readonly`.
  */
-function _getClassMembers(
-	statement: ts.Statement,
-	source: ts.SourceFile,
-	className: string,
-	baseName: string | undefined,
-): DocumentationElement[] | undefined {
+function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, className: string): DocumentationElement[] | undefined {
 	if (!ts.isClassDeclaration(statement) && !ts.isInterfaceDeclaration(statement)) return;
 	const members: DocumentationElement[] = [];
 
@@ -262,22 +258,18 @@ function _getClassMembers(
 		if (!name || name.startsWith("_")) continue;
 		const modifiers = ts.canHaveModifiers(member) ? ts.getModifiers(member) : undefined;
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.PrivateKeyword || m.kind === ts.SyntaxKind.ProtectedKeyword)) continue;
+		// Skip `override` members — the base class already documents them, so a subclass page lists only its newly-introduced API.
+		if (modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword)) continue;
 
 		const memberJSDoc = _getJSDoc(member, source);
 		const content = _buildJSDocContent(memberJSDoc?.description, memberJSDoc?.unhandled);
 		const description = extractMarkdownProps(memberJSDoc?.description ?? "").description;
-		// An `override` member overrides the same-named member on the base class — qualify with the base name when known.
-		const overrides = modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword)
-			? baseName
-				? `${baseName}.${name}`
-				: name
-			: undefined;
 
 		if (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) {
 			const params = member.parameters.map(p => p.getText(source)).join(", ");
 			const ret = member.type ? member.type.getText(source) : "void";
 			const signature = `${name}(${params}): ${ret}`;
-			const key = requireSlug(name);
+			const key = name;
 			const existingIndex = members.findIndex(m => m.key === key);
 			const existing = members[existingIndex];
 			if (existing) {
@@ -291,12 +283,11 @@ function _getClassMembers(
 					key,
 					props: {
 						name,
-						title: `${className}.${name}()`,
+						title: `${name}()`,
 						description,
 						content,
 						kind: "method",
 						class: className,
-						overrides,
 						signatures: [signature],
 					},
 				});
@@ -306,23 +297,22 @@ function _getClassMembers(
 			const readonly = modifiers?.some(m => m.kind === ts.SyntaxKind.ReadonlyKeyword) || undefined;
 			members.push({
 				type: "tree-documentation",
-				key: requireSlug(name),
+				key: name,
 				props: {
 					name,
-					title: `${className}.${name}`,
+					title: name,
 					description,
 					content,
 					kind: "property",
 					class: className,
 					readonly,
-					overrides,
 					signatures: type ? [`${readonly ? "readonly " : ""}${name}: ${type}`] : undefined,
 				},
 			});
 		} else if (ts.isGetAccessor(member) || ts.isSetAccessor(member)) {
 			// Getters/setters fold into one `property`. A getter alone (no setter) is read-only; a setter clears that.
 			const type = ts.isGetAccessor(member) ? member.type?.getText(source) : member.parameters[0]?.type?.getText(source);
-			const key = requireSlug(name);
+			const key = name;
 			const existingIndex = members.findIndex(m => m.key === key);
 			const existing = members[existingIndex];
 			if (existing) {
@@ -333,7 +323,6 @@ function _getClassMembers(
 						// A getter + setter pair is writable — drop the read-only flag and the `readonly ` signature prefix.
 						readonly: undefined,
 						signatures: type ? [`${name}: ${type}`] : existing.props.signatures,
-						overrides: existing.props.overrides ?? overrides,
 					},
 				};
 			} else {
@@ -342,13 +331,12 @@ function _getClassMembers(
 					key,
 					props: {
 						name,
-						title: `${className}.${name}`,
+						title: name,
 						description,
 						content,
 						kind: "property",
 						class: className,
 						readonly: ts.isGetAccessor(member) || undefined,
-						overrides,
 						signatures: type ? [`${ts.isGetAccessor(member) ? "readonly " : ""}${name}: ${type}`] : undefined,
 					},
 				});

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -21,7 +21,7 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on the file and every `tree-documentation` child.
  * - Sets `title` on every `tree-documentation` child — `name()` for functions and methods, bare `name` for other kinds. Parent class context comes from the `class` prop ("member of …" affordance), never the title.
  * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`.
- * - Members declared with the `override` modifier are skipped — the base class already documents them.
+ * - Members declared with the `override` or `declare` modifier are skipped — the base class already documents overrides, and `declare` members are ambient type-only re-declarations rather than new API.
  * - Keys are the raw declared `name` (case-preserving) so case-distinct exports like `Collection` and `COLLECTION` stay separate.
  * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
  */
@@ -246,6 +246,7 @@ function _getReturns(
  * Extract class or interface members as child elements.
  * - `className` is stamped onto every member as its `class` prop (the source of the qualified flat key and the "member of …" affordance); the title stays the bare member `name` / `name()`.
  * - Members declared with the `override` modifier are skipped — the base class already documents them, so a subclass page lists only its newly-introduced API.
+ * - Members declared with the `declare` modifier are skipped — they're ambient type-only re-declarations (e.g. narrowing an inherited property's type), not new API.
  * - Getters/setters fold into a single `property` element per name; a getter with no matching setter is `readonly`.
  */
 function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, className: string): DocumentationElement[] | undefined {
@@ -260,6 +261,8 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.PrivateKeyword || m.kind === ts.SyntaxKind.ProtectedKeyword)) continue;
 		// Skip `override` members — the base class already documents them, so a subclass page lists only its newly-introduced API.
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword)) continue;
+		// Skip `declare` members — ambient type-only re-declarations (e.g. a subclass narrowing an inherited property's type), not new API.
+		if (modifiers?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword)) continue;
 
 		const memberJSDoc = _getJSDoc(member, source);
 		const content = _buildJSDocContent(memberJSDoc?.description, memberJSDoc?.unhandled);

--- a/modules/firestore/client/FirestoreClientProvider.ts
+++ b/modules/firestore/client/FirestoreClientProvider.ts
@@ -126,11 +126,11 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 		return q ? query(this._collection(c), ..._getConstraints(q)) : this._collection(c);
 	}
 
-	async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const snapshot = await getDoc(this._doc(c, id));
 		return _getOptionalItem<II, TT>(snapshot);
 	}
-	getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		const sequence = new DeferredSequence<OptionalItem<II, TT>>();
 		return new LazySequence(sequence, () =>
 			onSnapshot(
@@ -140,27 +140,31 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 			),
 		);
 	}
-	async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		const reference = await addDoc(this._collection(c), data);
 		return reference.id as II; // `as II` needed: Firestore returns string, not II.
 	}
-	async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await setDoc(this._doc(c, id), data);
 	}
-	async updateItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, updates: Updates<Item<II, TT>>): Promise<void> {
+	override async updateItem<II extends I, TT extends T>(
+		c: Collection<string, II, TT>,
+		id: II,
+		updates: Updates<Item<II, TT>>,
+	): Promise<void> {
 		await updateDoc(this._doc(c, id), _getFieldValues(updates));
 	}
-	async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await deleteDoc(this._doc(c, id));
 	}
 	override async countQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<number> {
 		const snapshot = await getCountFromServer(this._query(c, q));
 		return snapshot.data().count;
 	}
-	async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await getDocs(this._query(c, q)));
 	}
-	getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
+	override getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		const sequence = new DeferredSequence<Items<II, TT>>();
 		return new LazySequence(sequence, () =>
 			onSnapshot(
@@ -170,11 +174,11 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 			),
 		);
 	}
-	async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
 		await Promise.all(snapshot.docs.map(s => setDoc(s.ref, data)));
 	}
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
 		q: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -183,7 +187,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 		const fieldValues = _getFieldValues(updates);
 		await Promise.all(snapshot.docs.map(s => updateDoc(s.ref, fieldValues)));
 	}
-	async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
 		await Promise.all(snapshot.docs.map(s => deleteDoc(s.ref)));
 	}

--- a/modules/firestore/lite/FirestoreLiteProvider.ts
+++ b/modules/firestore/lite/FirestoreLiteProvider.ts
@@ -124,41 +124,45 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 		return q ? query(this._collection(c), ..._getConstraints(q)) : this._collection(c);
 	}
 
-	async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const snapshot = await getDoc(this._doc(c, id));
 		return _getOptionalItem<II, TT>(snapshot);
 	}
-	getItemSequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError("FirestoreLiteProvider does not support realtime subscriptions");
 	}
-	async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		const reference = await addDoc(this._collection(c), data);
 		return reference.id as II; // `as II` needed: Firestore returns string, not II.
 	}
-	async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await setDoc(this._doc(c, id), data);
 	}
-	async updateItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, updates: Updates<Item<II, TT>>): Promise<void> {
+	override async updateItem<II extends I, TT extends T>(
+		c: Collection<string, II, TT>,
+		id: II,
+		updates: Updates<Item<II, TT>>,
+	): Promise<void> {
 		await updateDoc(this._doc(c, id), _getFieldValues(updates));
 	}
-	async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await deleteDoc(this._doc(c, id));
 	}
 	override async countQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<number> {
 		const snapshot = await getCount(this._query(c, q));
 		return snapshot.data().count;
 	}
-	async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await getDocs(this._query(c, q)));
 	}
-	getQuerySequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
+	override getQuerySequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		throw new UnimplementedError("FirestoreLiteProvider does not support realtime subscriptions");
 	}
-	async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
 		await Promise.all(snapshot.docs.map(s => setDoc(s.ref, data)));
 	}
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
 		q: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -167,7 +171,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 		const fieldValues = _getFieldValues(updates);
 		await Promise.all(snapshot.docs.map(s => updateDoc(s.ref, fieldValues)));
 	}
-	async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
 		await Promise.all(snapshot.docs.map(s => deleteDoc(s.ref)));
 	}

--- a/modules/firestore/server/FirestoreServerProvider.ts
+++ b/modules/firestore/server/FirestoreServerProvider.ts
@@ -118,11 +118,11 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 		await writer.close();
 	}
 
-	async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
+	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return _getOptionalItem<II, TT>(await this._getCollection(collection).doc(id).get());
 	}
 
-	getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
+	override getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		const ref = this._getCollection(c).doc(id);
 		const sequence = new DeferredSequence<OptionalItem<II, TT>>();
 		return new LazySequence(sequence, () =>
@@ -133,19 +133,23 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 		);
 	}
 
-	async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
+	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		return (await this._getCollection(c).add(data)).id as II; // `as II` needed: Firestore returns string, not II.
 	}
 
-	async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
+	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this._getCollection(c).doc(id).set(data);
 	}
 
-	async updateItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, updates: Updates<Item<II, TT>>): Promise<void> {
+	override async updateItem<II extends I, TT extends T>(
+		c: Collection<string, II, TT>,
+		id: II,
+		updates: Updates<Item<II, TT>>,
+	): Promise<void> {
 		await this._getCollection(c).doc(id).update(_getFieldValues(updates));
 	}
 
-	async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
+	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await this._getCollection(c).doc(id).delete();
 	}
 
@@ -154,11 +158,11 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 		return snapshot.data().count;
 	}
 
-	async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
+	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await this._getQuery(c, q).get());
 	}
 
-	getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
+	override getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		const ref = this._getQuery(c, q);
 		const sequence = new DeferredSequence<Items<II, TT>>();
 		return new LazySequence(sequence, () =>
@@ -169,11 +173,11 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 		);
 	}
 
-	async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
+	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		return await this._bulkWrite(c, q, (w, s) => void w.set(s.ref, data));
 	}
 
-	async updateQuery<II extends I, TT extends T>(
+	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
 		q: Query<Item<II, TT>>,
 		updates: Updates<TT>,
@@ -182,7 +186,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 		return await this._bulkWrite(c, q, (w, s) => void w.update(s.ref, fieldValues));
 	}
 
-	async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
+	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		return await this._bulkWrite(c, q, (w, s) => void w.delete(s.ref));
 	}
 }

--- a/modules/ui/docs/DocumentationButtons.tsx
+++ b/modules/ui/docs/DocumentationButtons.tsx
@@ -8,18 +8,16 @@ import { getClass } from "../util/css.js";
 
 /** Props for `DocumentationButtons` — the relational metadata of a documented symbol, plus block-space overrides. */
 export interface DocumentationButtonsProps
-	extends Pick<DocumentationElementProps, "class" | "overrides" | "extends" | "implements">,
+	extends Pick<DocumentationElementProps, "class" | "extends" | "implements">,
 		SpaceVariants,
 		FlexVariants {}
 
 /** One labelled relation — a sentence-case prefix plus the symbol it points at. */
 function* _relations({
 	class: className,
-	overrides,
 	extends: extendsName,
 	implements: implementsNames,
 }: DocumentationButtonsProps): Iterable<readonly [label: string, to: string]> {
-	if (overrides) yield ["overrides", overrides];
 	if (extendsName) yield ["extends", extendsName];
 	for (const name of implementsNames ?? []) yield ["implements", name];
 	// `member of` comes last — it's the broadest relation, the others are more specific.
@@ -28,7 +26,7 @@ function* _relations({
 
 /**
  * Render a symbol's relational metadata as a `<nav>` column of labelled links.
- * - Each relation reads as `"{label} {Target}"` — e.g. `overrides AbstractStore.get`, `implements Serializable`, `member of Store`.
+ * - Each relation reads as `"{label} {Target}"` — e.g. `extends AbstractStore`, `implements Serializable`, `member of Store`.
  * - The target is a `<DocumentationButton>`, so it links to the referenced page when it exists in the tree and stays a plain label otherwise.
  * - Block spacing defaults to paragraph spacing (via `PARAGRAPH_CLASS`); pass `space` to override. Inner spacing is the flex gap.
  * - Renders nothing when the symbol has no relations.

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -36,7 +36,7 @@ const KIND_SECTIONS = {
 
 /**
  * Page renderer for a `tree-documentation` element.
- * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`, `overrides`), signatures (one per overload), content, parameters, returns, throws, and examples.
+ * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`), signatures (one per overload), content, parameters, returns, throws, and examples.
  * - Child symbols are grouped by `kind` into card sections (Functions, Classes, Methods, Properties, …), each under its own heading.
  * - All sections are conditional — only render when they have entries.
  */

--- a/modules/util/tree.ts
+++ b/modules/util/tree.ts
@@ -107,8 +107,6 @@ export interface DocumentationElementProps extends TreeElementProps {
 	readonly class?: string | undefined;
 	/** Whether the property is read-only — a `readonly` field, or a getter with no matching setter. */
 	readonly readonly?: boolean | undefined;
-	/** Name of the base-class member this member overrides, qualified with the base class (e.g. `"AbstractStore.get"`). Raw string — resolved to a link at render time. */
-	readonly overrides?: string | undefined;
 	/** Name of the class/interface this class/interface extends (e.g. `"AbstractStore"`). Raw string — resolved to a link at render time. */
 	readonly extends?: string | undefined;
 	/** Names of the interfaces this class/interface implements (e.g. `["Serializable"]`). Raw strings — resolved to links at render time; builtins simply stay as text. */
@@ -139,7 +137,7 @@ declare module "react" {
  * Flatten a tree into a `Map` for O(1) lookup, stamping a canonical `path` onto every element as it walks.
  * - Returns a *copy* of the tree, indexed. Each element is rebuilt with its canonical site-root-relative `path`: the root is `/`, each descendant is `parentPath + "/" + name` — so a module `schema` → `/schema`, its class `BooleanSchema` → `/schema/BooleanSchema`, its member `validate` → `/schema/BooleanSchema/validate`. A composite module name (e.g. `"util/string"`) becomes its own multi-segment chunk.
  * - Every element is registered under two keys, both pointing at the (stamped) element:
- *   - its **flat key** — bare `name` (e.g. `"BooleanSchema"`), or qualified `"Class.member"` for members (e.g. `"BooleanSchema.validate"`). This is what cross-refs (`extends` / `overrides`) and README links resolve through.
+ *   - its **flat key** — bare `name` (e.g. `"BooleanSchema"`), or qualified `"Class.member"` for members (e.g. `"BooleanSchema.validate"`). This is what cross-refs (`extends` / `implements`) and README links resolve through.
  *   - its **canonical path** (`element.props.path`, e.g. `"/schema/BooleanSchema"`) — what the router resolves a URL to.
  * - The map values keep their (stamped) children, so the map doubles as the navigable tree: `map.get("/")` is the stamped root and flattening never throws away the hierarchy. The router resolves a URL with `map.get(path)`; the static builder enumerates pages from the path-shaped keys.
  * - Exported names are unique across the package (barrel re-exports enforce it at compile time), so flat-key collisions are vanishingly rare; on a collision the last writer simply wins.


### PR DESCRIPTION
Batch of `_getClassMembers` / key fixes, rebased onto `main`.

## #147 — case-insensitive key collision
`Collection.ts` exports both `class Collection` and `function COLLECTION` in one file; `requireSlug(name)` lowercased both to `collection`, so they collapsed into a single documentation entity. Keys now use the raw declared `name` (case-preserving) — TS identifiers are already key-safe, so `requireSlug` is dropped from the extractor entirely. The flat-key index and path resolution key off `name`/`class` (not the element `key`), so cross-linking is unaffected. Added a regression test.

## #150 — skip `override` (and `declare`) members
- One-line guard in `_getClassMembers` bails on the `OverrideKeyword` modifier, so a subclass page lists only its newly-introduced API (the base class already documents overridden members). The now-dead `overrides` relational metadata is removed entirely — the field on `DocumentationElementProps` and the link in `DocumentationButtons` / `DocumentationPage` are gone.
- Follow-on: provider subclasses implemented their abstract base API (`DBProvider` / `APIProvider` / `SQLProvider`) **without** `override` (TS doesn't require it for abstract implementations), so the extractor re-listed all of them on every provider page. Added `override` to the **87** abstract-method implementations across the DB / API / Bun / Cloudflare / Firestore providers so they're documented once, on the base. e.g. `MemoryDBProvider` now lists just `getTable` / `setItems`.
- Also skip `declare` members — ambient type-only re-declarations (e.g. a schema narrowing the inherited `value` type with `declare readonly value: boolean`). `override` is forbidden on ambient members (TS1040), so the extractor skips them instead; each schema's genuinely-new API (e.g. `validate()`) stays visible.

## #149 — drop class-prefix from member titles
Member titles go from `Class.member` / `Class.member()` → `member` / `member()`. The `class` prop is retained (it drives the flat key and the "member of …" affordance, now the sole source of parent context).

Tests, type-check, and lint all pass (1107 unit tests green).

Fixes #147
Fixes #149
Fixes #150

https://claude.ai/code/session_01XSDuoFpkk4SYi7vuJqgSUA