### PR TITLE
fix(extract): de-dup overload fields and align type/interface signatures

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -106,7 +106,7 @@ export type NullableString = string | null;
 		expect(element.props.children).toMatchObject([
 			{
 				type: "tree-documentation",
-				props: { kind: "type", name: "NullableString", title: "NullableString", signatures: ["NullableString = string | null"] },
+				props: { kind: "type", name: "NullableString", title: "NullableString", signatures: ["string | null"] },
 			},
 		]);
 	});
@@ -453,6 +453,112 @@ export function first<T>(arr: T[]): T | undefined {
 		const element = await extractor.extract(file("export const X = 1;"));
 		const children = element.props.children as { props: { description?: string } }[];
 		expect(children[0]?.props.description).toBeUndefined();
+	});
+
+	test("emits only the type body for a type alias (no alias name)", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A pair of values. */
+export type Pair = { a: string; b: number };
+`),
+		);
+		expect(element.props.children).toMatchObject([
+			{ type: "tree-documentation", props: { kind: "type", name: "Pair", signatures: ["{ a: string; b: number }"] } },
+		]);
+	});
+
+	test("emits a brace-wrapped signature for an interface, matching the type body shape", async () => {
+		const element = await extractor.extract(
+			file(`
+/** Options for the thing. */
+export interface ThingOptions {
+	verbose?: boolean;
+	retries: number;
+}
+`),
+		);
+		expect(element.props.children).toMatchObject([
+			{
+				type: "tree-documentation",
+				props: { kind: "interface", name: "ThingOptions", signatures: ["{ verbose?: boolean; retries: number }"] },
+			},
+		]);
+	});
+
+	test("de-duplicates identical overload signatures, keeping distinct ones", async () => {
+		const element = await extractor.extract(
+			file(`
+/** Add values. */
+export function add(a: number, b: number): number;
+/** Add values. */
+export function add(a: number, b: number): number;
+/** Add values. */
+export function add(a: string, b: string): string;
+export function add(a: any, b: any): any { return a + b; }
+`),
+		);
+		const props = (element.props.children as { props: { signatures: string[] } }[])[0]?.props;
+		expect(props?.signatures).toEqual([
+			"add(a: number, b: number): number",
+			"add(a: string, b: string): string",
+			"add(a: any, b: any): any",
+		]);
+	});
+
+	test("de-duplicates identical params and returns across overloads, keeping distinct ones", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Combine values.
+ * @returns {number} The combined value.
+ */
+export function combine(a: number, b: number): number;
+/**
+ * Combine values.
+ * @returns {number} The combined value.
+ */
+export function combine(a: number, b: number): number;
+export function combine(a: number, b: number): number { return a + b; }
+`),
+		);
+		const props = (element.props.children as { props: { params: unknown; returns: unknown } }[])[0]?.props;
+		// All three declarations share the same params — deduped to a single (a, b) pair.
+		expect(props?.params).toEqual([
+			{ name: "a", type: "number", description: undefined, optional: false },
+			{ name: "b", type: "number", description: undefined, optional: false },
+		]);
+		// The two documented overloads share a return; the implementation's bare `number` return differs by description and is kept.
+		expect(props?.returns).toEqual([
+			{ type: "number", description: "The combined value." },
+			{ type: "number", description: undefined },
+		]);
+	});
+
+	test("de-duplicates identical throws and examples across overloads, keeping distinct ones", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Do a thing.
+ * @throws {RangeError} Bad range.
+ * @example doThing(1)
+ */
+export function doThing(a: number): number;
+/**
+ * Do a thing.
+ * @throws {RangeError} Bad range.
+ * @throws {TypeError} Bad type.
+ * @example doThing(1)
+ * @example doThing(2)
+ */
+export function doThing(a: any): any { return a; }
+`),
+		);
+		const props = (element.props.children as { props: { throws: unknown; examples: unknown } }[])[0]?.props;
+		expect(props?.throws).toEqual([
+			{ type: "RangeError", description: "Bad range." },
+			{ type: "TypeError", description: "Bad type." },
+		]);
+		expect(props?.examples).toEqual([{ description: "doThing(1)" }, { description: "doThing(2)" }]);
 	});
 
 	test("strips directory path from filename when computing key/name", async () => {

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -53,13 +53,13 @@ function _mergeOverloads(existing: DocumentationElement, next: DocumentationElem
 		...a,
 		// Keep first content encountered; fill in if `existing` had none.
 		content: a.content ?? b.content,
-		// Append signatures.
-		signatures: _concat(a.signatures, b.signatures),
-		// Append params, returns, throws, examples — never dedupe (per spec).
-		params: _concat(a.params, b.params),
-		returns: _concat(a.returns, b.returns),
-		throws: _concat(a.throws, b.throws),
-		examples: _concat(a.examples, b.examples),
+		// Append incoming entries, skipping any already present (by field identity), preserving insertion order.
+		// Identity: signatures/examples/throws by rendered string; params by (name, type, description, optional); returns by (type, description).
+		signatures: _concatUnique(a.signatures, b.signatures, s => s),
+		params: _concatUnique(a.params, b.params, p => `${p.name}\0${p.type}\0${p.description}\0${p.optional}`),
+		returns: _concatUnique(a.returns, b.returns, r => `${r.type}\0${r.description}`),
+		throws: _concatUnique(a.throws, b.throws, t => `${t.type}\0${t.description}`),
+		examples: _concatUnique(a.examples, b.examples, e => e.description ?? ""),
 	};
 	return { ...existing, props: merged };
 }
@@ -68,6 +68,26 @@ function _concat<T>(a: readonly T[] | undefined, b: readonly T[] | undefined): r
 	if (!a) return b;
 	if (!b) return a;
 	return [...a, ...b];
+}
+
+/** Concatenate `b` onto `a`, skipping entries whose identity already appears, preserving insertion order. */
+function _concatUnique<T>(
+	a: readonly T[] | undefined,
+	b: readonly T[] | undefined,
+	identity: (item: T) => string,
+): readonly T[] | undefined {
+	if (!a) return b;
+	if (!b) return a;
+	const seen = new Set(a.map(identity));
+	const result = [...a];
+	for (const item of b) {
+		const key = identity(item);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		result.push(item);
+	}
+	// Preserve the original reference when nothing new was added.
+	return result.length === a.length ? a : result;
 }
 
 /** Get the leading JSDoc comment of the file (before the first statement). */
@@ -199,8 +219,14 @@ function _getSignature(statement: ts.Statement, source: ts.SourceFile, name: str
 		const ret = statement.type ? statement.type.getText(source) : "void";
 		return `${name}(${params}): ${ret}`;
 	}
+	if (ts.isInterfaceDeclaration(statement)) {
+		// Emit `{ member; member }` — the same shape a `type` object body produces, distinguished only by the `kind` badge.
+		const members = statement.members.map(m => m.getText(source).replace(/;\s*$/, "").trim()).join("; ");
+		return members ? `{ ${members} }` : "{}";
+	}
 	if (ts.isTypeAliasDeclaration(statement)) {
-		return `${name} = ${statement.type.getText(source)}`;
+		// Emit only the type body (e.g. `{ a: string }` or `string | null`) — the alias name is already the page title.
+		return statement.type.getText(source);
 	}
 	if (ts.isVariableStatement(statement)) {
 		const declaration = statement.declarationList.declarations[0];


### PR DESCRIPTION
Batch 2 of the extractor cleanup. Both changes are localised to `modules/extract/TypescriptExtractor.ts` and its test file.

## #146 — de-duplicate identical signatures / params / returns in `_mergeOverloads`

Dropped the "never dedupe" rule. When merging an overload into an existing documentation element, incoming entries already present are now skipped, preserving insertion order:

- `signatures` / `examples` / `throws` — identity by rendered string.
- `params` — identity by `(name, type, description, optional)`.
- `returns` — identity by `(type, description)`.

A new `_concatUnique` helper does the order-preserving, identity-keyed merge (and returns the original reference when nothing new is added). `_concat` is retained for the within-class member merges, which are out of scope.

## #151 — `type` / `interface` signature consistency

In `_getSignature`:

1. The `ts.isTypeAliasDeclaration` branch now emits only the type body (e.g. `{ a: string; b: number }` or `string | null`), dropping the redundant `MyType = …` alias-name prefix — the name is already the page title.
2. A new `ts.isInterfaceDeclaration` branch emits a signature of the same shape — `{ member; member }` — joining members with `; ` to match the `type` object-body convention. The two now read identically except for the `kind` badge.

## Tests

- Updated the existing type-alias test to the new body-only signature.
- Added tests for the type-body and interface signatures.
- Added overload de-dup tests covering each field with both duplicate and distinct entries.

`bun run fix` and `bun run test` both pass (1110 pass, 0 fail).

Closes #146
Closes #151

https://claude.ai/code/session_017jKyn7H7A71N81VMAEwBvu

---
_Generated by [Claude Code](https://claude.ai/code/session_017jKyn7H7A71N81VMAEwBvu)_