### PR TITLE
refactor: convert arrow-const factories to function declarations and document the factory convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,3 +353,23 @@ Conventions for the upcoming reusable component layer.
 - Each module has a `README.md` that acts as the module's guide page. It covers **purpose, key concepts, and integration examples** — how to combine the module's classes and functions to accomplish real tasks (and, for families like `error`, shared traits). When module behaviour changes, check whether the README needs updating
 - **Per-class / per-function usage examples** live in a sibling `MyClass.md` / `myFunction.md` next to the source file. `DirectoryExtractor` merges that markdown onto the symbol's own page (`MarkupExtractor` outranks `TypescriptExtractor`), so detailed usage belongs there rather than in the module README. `modules/util/template.md` is the precedent
 - Trust source and tests over README if they conflict — but fix the README rather than leaving it wrong
+
+### Factory functions
+
+A **factory** is a function (or constant) whose purpose is to call `new SomeClass(...)` with sensible defaults — e.g. `DATA` is a factory for `DataSchema`, `NULLABLE` for `NullableSchema`.
+
+- Write factories as regular `function` declarations, not arrow-consts. A `function` declaration classifies as `kind: "function"` on the docs site (an arrow-const wrongly shows as a `constant`), gives a named stack trace, and is the preferred form for public-API exports anyway (see the Functions section)
+- Mark a factory in its docblock with a short italic line naming the class it builds, on its own paragraph after the summary:
+
+  ```ts
+  /**
+   * Create a `DataSchema` for a set of properties.
+   *
+   * *Factory for `DataSchema`.*
+   */
+  export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
+  	return new DataSchema({ props });
+  }
+  ```
+
+- The canonical wording is exactly `*Factory for \`ClassName\`.*` (italicised, backtick-quoted class name). When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -86,5 +86,11 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 	}
 }
 
-/** Valid array with specifed items. */
-export const ARRAY = <T>(items: Schema<T>): ArraySchema<T> => new ArraySchema({ items });
+/**
+ * Valid array with specifed items.
+ *
+ * *Factory for `ArraySchema`.*
+ */
+export function ARRAY<T>(items: Schema<T>): ArraySchema<T> {
+	return new ArraySchema({ items });
+}

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -1,5 +1,6 @@
 import { type CurrencyCode, getCurrencyStep, getCurrencySymbol, requireCurrencyCode } from "../util/currency.js";
 import { formatCurrency } from "../util/format.js";
+import type { NullableSchema } from "./NullableSchema.js";
 import { NULLABLE } from "./NullableSchema.js";
 import { NumberSchema, type NumberSchemaOptions } from "./NumberSchema.js";
 
@@ -43,14 +44,26 @@ export class CurrencyAmountSchema extends NumberSchema {
 	}
 }
 
-/** Valid non-negative monetary amount in the a currency. */
-export const CURRENCY_AMOUNT = (currency: CurrencyCode) => new CurrencyAmountSchema({ currency });
+/**
+ * Valid non-negative monetary amount in the a currency.
+ *
+ * *Factory for `CurrencyAmountSchema`.*
+ */
+export function CURRENCY_AMOUNT(currency: CurrencyCode): CurrencyAmountSchema {
+	return new CurrencyAmountSchema({ currency });
+}
 export const USD_AMOUNT = new CurrencyAmountSchema({ currency: "USD" });
 export const GBP_AMOUNT = new CurrencyAmountSchema({ currency: "GBP" });
 export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
 
-/** Valid optional monetary amount in the default currency, or `null`. */
-export const NULLABLE_CURRENCY_AMOUNT = (currency: CurrencyCode) => NULLABLE(CURRENCY_AMOUNT(currency));
+/**
+ * Valid optional monetary amount in the default currency, or `null`.
+ *
+ * *Factory for `NullableSchema`.*
+ */
+export function NULLABLE_CURRENCY_AMOUNT(currency: CurrencyCode): NullableSchema<number> {
+	return NULLABLE(CURRENCY_AMOUNT(currency));
+}
 export const NULLABLE_USD_AMOUNT = NULLABLE(USD_AMOUNT);
 export const NULLABLE_GBP_AMOUNT = NULLABLE(GBP_AMOUNT);
 export const NULLABLE_EUR_AMOUNT = NULLABLE(EUR_AMOUNT);

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -51,13 +51,29 @@ function _getSchemaValue<T extends Data>([, { value }]: Prop<Schemas<T>>): Value
 	return value as Value<T>;
 }
 
-/** Create a `DataSchema` for a set of properties. */
-export const DATA = <T extends Data>(props: Schemas<T>): DataSchema<T> => new DataSchema({ props });
+/**
+ * Create a `DataSchema` for a set of properties.
+ *
+ * *Factory for `DataSchema`.*
+ */
+export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
+	return new DataSchema({ props });
+}
 
-/** Valid data object with specifed properties, or `null` */
-export const NULLABLE_DATA = <T extends Data>(props: Schemas<T>): NullableSchema<T> => NULLABLE(new DataSchema({ props }));
+/**
+ * Valid data object with specifed properties, or `null`
+ *
+ * *Factory for `NullableSchema`.*
+ */
+export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema<T> {
+	return NULLABLE(new DataSchema({ props }));
+}
 
-/** Create a `DataSchema` that validates partially, i.e. properties can be their value, or `undefined` */
+/**
+ * Create a `DataSchema` that validates partially, i.e. properties can be their value, or `undefined`
+ *
+ * *Factory for `DataSchema`.*
+ */
 export function PARTIAL<T extends Data>(source: Schemas<T> | DataSchema<T>): DataSchema<PartialData<T>>;
 export function PARTIAL(source: Schemas<Data> | DataSchema<Data>): DataSchema<PartialData<Data>> {
 	const props: Schemas<Data> = source instanceof DataSchema ? source.props : source;
@@ -69,7 +85,11 @@ function _optionalProp([, v]: Prop<Schemas<Data>>): Schema<unknown> {
 	return OPTIONAL(v);
 }
 
-/** Create a `DataSchema` that validates a data item, i.e. it has a string or number `.id` identifier property. */
+/**
+ * Create a `DataSchema` that validates a data item, i.e. it has a string or number `.id` identifier property.
+ *
+ * *Factory for `DataSchema`.*
+ */
 export function ITEM<I extends Identifier, T extends Data>(id: Schema<I>, schemas: Schemas<T> | DataSchema<T>): DataSchema<Item<I, T>> {
 	const props: Schemas<T> = schemas instanceof DataSchema ? schemas.props : schemas;
 	return new DataSchema<Item<I, T>>({

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -52,5 +52,11 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 	}
 }
 
-/** Valid dictionary object with specifed items. */
-export const DICTIONARY = <T>(items: Schema<T>): DictionarySchema<T> => new DictionarySchema({ items });
+/**
+ * Valid dictionary object with specifed items.
+ *
+ * *Factory for `DictionarySchema`.*
+ */
+export function DICTIONARY<T>(items: Schema<T>): DictionarySchema<T> {
+	return new DictionarySchema({ items });
+}

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -22,5 +22,11 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 	}
 }
 
-/** Create a new nullable schema from a source schema. */
-export const NULLABLE = <T>(source: Schema<T>): NullableSchema<T> => new NullableSchema({ source });
+/**
+ * Create a new nullable schema from a source schema.
+ *
+ * *Factory for `NullableSchema`.*
+ */
+export function NULLABLE<T>(source: Schema<T>): NullableSchema<T> {
+	return new NullableSchema({ source });
+}

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -26,5 +26,11 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 	}
 }
 
-/** Make a property of a set of data optional, i.e. it can be the value or `undefined` */
-export const OPTIONAL = <T>(source: Schema<T>): OptionalSchema<T> => new OptionalSchema({ source });
+/**
+ * Make a property of a set of data optional, i.e. it can be the value or `undefined`
+ *
+ * *Factory for `OptionalSchema`.*
+ */
+export function OPTIONAL<T>(source: Schema<T>): OptionalSchema<T> {
+	return new OptionalSchema({ source });
+}

--- a/modules/schema/RequiredSchema.ts
+++ b/modules/schema/RequiredSchema.ts
@@ -10,5 +10,11 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
 	}
 }
 
-/** Create a new required schema from a source schema. */
-export const REQUIRED = <T>(source: Schema<T>): RequiredSchema<T> => new RequiredSchema({ source });
+/**
+ * Create a new required schema from a source schema.
+ *
+ * *Factory for `RequiredSchema`.*
+ */
+export function REQUIRED<T>(source: Schema<T>): RequiredSchema<T> {
+	return new RequiredSchema({ source });
+}

--- a/modules/util/data.ts
+++ b/modules/util/data.ts
@@ -117,7 +117,9 @@ export function assertData(value: unknown, caller: AnyCaller = assertData): asse
 }
 
 /** Is an unknown value the key for an own prop of a data object. */
-export const isDataProp = <T extends Data>(data: T, key: unknown): key is DataKey<T> => typeof key === "string" && Object.hasOwn(data, key);
+export function isDataProp<T extends Data>(data: T, key: unknown): key is DataKey<T> {
+	return typeof key === "string" && Object.hasOwn(data, key);
+}
 
 /** Assert that an unknown value is the key for an own prop of a data object. */
 export function assertDataProp<T extends Data>(data: T, key: unknown, caller: AnyCaller = assertDataProp): asserts key is DataKey<T> {

--- a/modules/util/debug.ts
+++ b/modules/util/debug.ts
@@ -28,7 +28,9 @@ export function debug(value: unknown, depth = 1): string {
 }
 
 /** Debug a string. */
-export const debugString = (value: string): string => `"${value.replace(ESCAPE_REGEXP, _escapeChar)}"`;
+export function debugString(value: string): string {
+	return `"${value.replace(ESCAPE_REGEXP, _escapeChar)}"`;
+}
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentional.
 const ESCAPE_REGEXP = /[\x00-\x08\x0B-\x1F\x7F-\x9F"\\]/g; // Match control characters, `"` double quote, `\` backslash.
 const ESCAPE_LIST: { [key: string]: string } = {

--- a/modules/util/iterate.ts
+++ b/modules/util/iterate.ts
@@ -1,5 +1,7 @@
 /** Is an unknown value an iterable? */
-export const isIterable = (value: unknown): value is Iterable<unknown> => typeof value === "object" && !!value && Symbol.iterator in value;
+export function isIterable(value: unknown): value is Iterable<unknown> {
+	return typeof value === "object" && !!value && Symbol.iterator in value;
+}
 
 /** An iterable containing items or nested iterables of items. */
 export type DeepIterable<T> = T | Iterable<DeepIterable<T>>;

--- a/modules/util/object.ts
+++ b/modules/util/object.ts
@@ -45,7 +45,9 @@ export function assertPlainObject(value: unknown): asserts value is ImmutableObj
 }
 
 /** Is an unknown value the key for an own prop of an object. */
-export const isProp = <T extends ImmutableObject>(obj: T, key: PropertyKey): key is keyof T => Object.hasOwn(obj, key);
+export function isProp<T extends ImmutableObject>(obj: T, key: PropertyKey): key is keyof T {
+	return Object.hasOwn(obj, key);
+}
 
 /** Assert that an unknown value is the key for an own prop of an object. */
 export function assertProp<T extends ImmutableObject>(obj: T, key: PropertyKey): asserts key is keyof T {


### PR DESCRIPTION
## Summary

Implements #148. Functions defined as **arrow-consts** classify as `kind: "constant"` on the docs site, because `TypescriptExtractor._getKind` maps any `VariableStatement` to `"constant"` regardless of its initializer. This rewrites them at the source — proper `function` declarations classify as `kind: "function"` (no extractor change needed), give named stack traces, and are the AGENTS.md-preferred form for public-API exports.

### 1. Audit and rewrite

Swept `modules/**/*.ts` and `*.tsx` for `export const FOO = (...) => …` patterns that are actually functions and rewrote each as a `function` declaration:

- **Schema factories:** `DATA`, `NULLABLE_DATA` (`DataSchema.ts`), `NULLABLE` (`NullableSchema.ts`), `OPTIONAL` (`OptionalSchema.ts`), `REQUIRED` (`RequiredSchema.ts`), `DICTIONARY` (`DictionarySchema.ts`), `ARRAY` (`ArraySchema.ts`), `CURRENCY_AMOUNT` / `NULLABLE_CURRENCY_AMOUNT` (`CurrencyAmountSchema.ts`).
- **Util helpers:** `isProp` (`object.ts`), `isDataProp` (`data.ts`), `isIterable` (`iterate.ts`), `debugString` (`debug.ts`).

The genuine constants nearby (`USD_AMOUNT`, `GBP_AMOUNT`, `EUR_AMOUNT` — pre-built instances, not factory functions) are left as-is.

### 2. Factory convention

Each function that is a **factory for a class** gets a canonical italic docblock line naming the class it builds — `*Factory for \`SomeClass\`.*` — including the already-`function` factories `PARTIAL` and `ITEM`. The convention (and the rule to prefer `function` declarations for factories) is recorded in `AGENTS.md` under Documentation → Factory functions.

The extractor is deliberately untouched — the rewrite naturally produces `kind: "function"` because `_getKind` already maps function declarations correctly.

`bun run fix` and `bun run test` both pass.

Closes #148

---
ℹ️ Stacked on #156 (base `agent/152`); will retarget to `main` automatically once that merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnVUNLKCGr3ym7WD4GwnFu)_