### PR TITLE
fix(extract): strip @see lines from rendered docs content

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -547,6 +547,37 @@ export function add(a: number, b: number): number { return a + b; }
 		);
 	});
 
+	test("strips `@see` lines from content (VS Code hover affordance, never rendered)", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Add two numbers.
+ * @see https://dhoulb.github.io/shelving/math/add
+ */
+export function add(a: number, b: number): number { return a + b; }
+`),
+		);
+		const children = element.props.children as { props: { content?: string } }[];
+		// The description survives; the `@see` link is discarded rather than leaking into the page body.
+		expect(children[0]?.props.content).toBe("Add two numbers.");
+	});
+
+	test("strips `@see` while still appending other unhandled `@rule` blocks", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Add two numbers.
+ * @see https://dhoulb.github.io/shelving/math/add
+ * @deprecated Use \`sum()\` instead.
+ */
+export function add(a: number, b: number): number { return a + b; }
+`),
+		);
+		const children = element.props.children as { props: { content?: string } }[];
+		// `@see` is dropped; `@deprecated` (genuinely unhandled) is still appended.
+		expect(children[0]?.props.content).toBe("Add two numbers.\n\n@deprecated Use `sum()` instead.");
+	});
+
 	test("derives description from the first paragraph of a symbol's JSDoc", async () => {
 		const element = await extractor.extract(
 			file(`

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -193,7 +193,7 @@ function _getHeritage(
 
 /**
  * Combine the JSDoc leading-description text and any unhandled `@rule` blocks into a single markup content string.
- * - Unhandled rules (anything not `@param`/`@returns`/`@throws`/`@example`) are appended after the description, separated by blank lines, with their `@name` preserved.
+ * - Unhandled rules (anything not `@param`/`@returns`/`@throws`/`@example`/`@see`) are appended after the description, separated by blank lines, with their `@name` preserved.
  * - Returns `undefined` if both are empty.
  */
 function _buildJSDocContent(description: string | undefined, unhandled: string | undefined): string | undefined {
@@ -471,8 +471,12 @@ interface JSDocResult {
 	unhandled?: string | undefined;
 }
 
-/** `@rule` names handled by dedicated parsers — everything else is appended to `unhandled` as raw markup. */
-const _HANDLED_RULES = new Set(["param", "params", "return", "returns", "throw", "throws", "example", "examples"]);
+/**
+ * `@rule` names handled (parsed or deliberately discarded) — everything else is appended to `unhandled` as raw markup.
+ * - `@see` is recognised here purely to strip it: it's a VS Code hover affordance (a link back to the docs site) and must
+ *   never leak into the rendered page content. It has no dedicated parser; it's simply discarded from the `unhandled` bucket.
+ */
+const _HANDLED_RULES = new Set(["param", "params", "return", "returns", "throw", "throws", "example", "examples", "see"]);
 
 /** Extract JSDoc from a node. */
 function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefined {


### PR DESCRIPTION
@see docblock lines are a VS Code hover affordance and must never leak
into the rendered docs page body. TypescriptExtractor routed any tag
outside its allowlist into the unhandled bucket, which _buildJSDocContent
concatenates into content — so every @see line rendered as literal text.

Add "see" to _HANDLED_RULES so the extractor recognises and discards it.
The line stays in source for hover, but never enters the docs content.

Fixes #161

https://claude.ai/code/session_01PXkaqmubyegoUmqd9se73w