### PR TITLE
fix: use tilde only for inline del markup syntax

### DIFF
--- a/modules/markup/rule/README.md
+++ b/modules/markup/rule/README.md
@@ -38,7 +38,7 @@ Rules declare which contexts they apply in. Block rules fire in a `"block"` cont
 | `CODE_RULE` | `<code>` | `` `backtick-wrapped` `` text (priority `10`) |
 | `LINK_RULE` | `<a>` | `[title](url)` |
 | `AUTOLINK_RULE` | `<a>` | Bare URL starting with any scheme, e.g. `https://example.com` |
-| `INLINE_RULE` | `<strong>`, `<em>`, `<del>`, `<ins>`, `<mark>` | `*bold*`, `_italic_`, `-del-` or `~del~`, `+ins+`, `=mark=` |
+| `INLINE_RULE` | `<strong>`, `<em>`, `<del>`, `<ins>`, `<mark>` | `*bold*`, `_italic_`, `~del~`, `+ins+`, `=mark=` |
 | `LINEBREAK_RULE` | `<br>` | Any single `\n` newline inside inline content |
 
 ## Adding a custom rule

--- a/modules/markup/rule/inline.test.ts
+++ b/modules/markup/rule/inline.test.ts
@@ -147,7 +147,7 @@ test("INLINE_RULE <ins>", () => {
 	expect(PARSER.parse("++ AAA ++", "inline")).toBe("++ AAA ++");
 });
 
-test("INLINE_RULE <del> (with tilde)", () => {
+test("INLINE_RULE <del>", () => {
 	expect(PARSER.parse("~A~", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
 	expect(PARSER.parse("~~A~~", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
 	expect(PARSER.parse("~~~~~~A~~~~~~", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
@@ -192,49 +192,14 @@ test("INLINE_RULE <del> (with tilde)", () => {
 	expect(PARSER.parse("~~ AAA ~~", "inline")).toBe("~~ AAA ~~");
 });
 
-test("INLINE_RULE <del> (with hyphen)", () => {
-	expect(PARSER.parse("-A-", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
-	expect(PARSER.parse("--A--", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
-	expect(PARSER.parse("------A------", "inline")).toMatchObject({ type: "del", props: { children: "A" } });
-	expect(PARSER.parse("-AAA BBB-", "inline")).toMatchObject({ type: "del", props: { children: "AAA BBB" } });
-	expect(PARSER.parse("--AAA BBB--", "inline")).toMatchObject({ type: "del", props: { children: "AAA BBB" } });
-	expect(PARSER.parse("------AAA BBB------", "inline")).toMatchObject({ type: "del", props: { children: "AAA BBB" } });
-	expect(PARSER.parse("BEFORE --AAA--", "inline")).toMatchObject(["BEFORE ", { type: "del", props: { children: "AAA" } }]);
-	expect(PARSER.parse("--AAA-- AFTER", "inline")).toMatchObject([{ type: "del", props: { children: "AAA" } }, " AFTER"]);
-
-	// Matching is non--greedy.
-	expect(PARSER.parse("--AAA-- --AAA--", "inline")).toMatchObject([
-		{ type: "del", props: { children: "AAA" } },
-		" ",
-		{ type: "del", props: { children: "AAA" } },
-	]);
-
-	// Can contain other inline elements.
-	expect(PARSER.parse("--BEFORE *STRONG* AFTER--", "inline")).toMatchObject({
-		type: "del",
-		props: { children: ["BEFORE ", { type: "strong", props: { children: "STRONG" } }, " AFTER"] },
-	});
-	expect(PARSER.parse("--*STRONG*--", "inline")).toMatchObject({
-		type: "del",
-		props: { children: { type: "strong", props: { children: "STRONG" } } },
-	});
-
-	// Match even if the opening and closing punctuation is in the middle of the word.
-	// expect(PARSER.parse("TEXT--DEL--", "inline")).toMatchObject(["TEXT", {  type: "del", props: { children: "DEL" } }]);
-	// expect(PARSER.parse("--DEL--TEXT", "inline")).toMatchObject([{  type: "del", props: { children: "DEL" } }, "TEXT"]);
-	// expect(PARSER.parse("TEXT--DEL--TEXT", "inline")).toMatchObject([
-	// 	"TEXT",
-	// 	{  type: "del", props: { children: "DEL" } },
-	// 	"TEXT",
-	// ]);
-
-	// Only match if it doesn't contain whitespace at the start/end of the element.
-	expect(PARSER.parse("-AAA -", "inline")).toBe("-AAA -");
-	expect(PARSER.parse("- AAA-", "inline")).toBe("- AAA-");
-	expect(PARSER.parse("- AAA -", "inline")).toBe("- AAA -");
-	expect(PARSER.parse("--AAA --", "inline")).toBe("--AAA --");
-	expect(PARSER.parse("-- AAA--", "inline")).toBe("-- AAA--");
-	expect(PARSER.parse("-- AAA --", "inline")).toBe("-- AAA --");
+test("INLINE_RULE hyphens are not <del>", () => {
+	// Hyphens are no longer a delete delimiter — only `~` tildes are. Hyphen-flanked text stays
+	// literal so ordinary hyphenated prose (e.g. `00`-on-`90`) doesn't false-fire as strikethrough.
+	expect(PARSER.parse("-A-", "inline")).toBe("-A-");
+	expect(PARSER.parse("--A--", "inline")).toBe("--A--");
+	expect(PARSER.parse("-AAA BBB-", "inline")).toBe("-AAA BBB-");
+	expect(PARSER.parse("BEFORE -on- AFTER", "inline")).toBe("BEFORE -on- AFTER");
+	expect(PARSER.parse("--*STRONG*--", "inline")).toMatchObject(["--", { type: "strong", props: { children: "STRONG" } }, "--"]);
 });
 
 test("INLINE_RULE <mark>", () => {

--- a/modules/markup/rule/inline.tsx
+++ b/modules/markup/rule/inline.tsx
@@ -2,14 +2,14 @@ import { createMarkupRule } from "../MarkupRule.js";
 import { createWordRegExp } from "../util/regexp.js";
 
 /** Map characters, e.g. `*`, to their coresponding HTML tag, e.g. `strong` */
-const INLINE_CHARS = { "-": "del", "~": "del", "+": "ins", "*": "strong", _: "em", "=": "mark" } as const; // Hyphen must be first so it works when we use the keys as a character class.
+const INLINE_CHARS = { "~": "del", "+": "ins", "*": "strong", _: "em", "=": "mark" } as const;
 
 /**
  * Inline strong, emphasis, insert, delete, highlight.
  * - Inline strong text wrapped in one or more `*` asterisks.
  * - Inline emphasis text wrapped in one or more `_` underscores.
  * - Inline inserted text wrapped in one or more `+` pluses.
- * - Inline deleted text wrapped in one or more `-` minuses or `~` tildes.
+ * - Inline deleted text wrapped in one or more `~` tildes.
  * - Inline highlighted text wrapped in one or more `=` equals or `:` colons.
  * - Whitespace cannot be the first or last character of the element (e.g. `* abc *` will not work).
  * - Closing chars must match opening characters.


### PR DESCRIPTION
Drop `-` (single hyphen) from the inline markup delete delimiters so
`~text~` is the sole strikethrough syntax. Single-hyphen strikethrough
false-fired on ordinary hyphen-flanked prose (e.g. `00`-on-`90`), which
parsed the `-on-` as a struck-through "on". Tildes match common markdown
expectations and remove the ambiguity.

- Remove `"-": "del"` from INLINE_CHARS in modules/markup/rule/inline.tsx.
- Update inline rule docblock and the markup/rule README syntax table.
- Replace the hyphen <del> test with a guard that hyphen-flanked text
  stays literal.

Closes #163