### PR TITLE
Standardize sugar instance and factory documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,20 +462,20 @@ For convenience the `schema` module ships **sugar** — pre-built shortcuts that
 
   When the instance is built by composing a sugar factory rather than `new` (e.g. `NULLABLE_TITLE = NULLABLE(TITLE)`), name the equivalent factory call instead: `` Equivalent to `NULLABLE(TITLE)`. ``, and link the wrapped sugar instance (`` [`TITLE`](/schema/TITLE) ``).
 
-**Sugar factories.** Write them as regular `function` declarations, not arrow-consts. A `function` declaration classifies as `kind: "function"` on the docs site (an arrow-const wrongly shows as a `constant`), gives a named stack trace, and is the preferred form for public-API exports anyway (see the Functions section). Mark a factory in its docblock with a short italic line naming the class it builds, on its own paragraph after the summary:
+**Sugar factories.** Write them as regular `function` declarations, not arrow-consts. A `function` declaration classifies as `kind: "function"` on the docs site (an arrow-const wrongly shows as a `constant`), gives a named stack trace, and is the preferred form for public-API exports anyway (see the Functions section). Mark a factory in its docblock with a short line naming the class it builds, on its own paragraph after the summary:
 
   ```ts
   /**
    * Create a `DataSchema` for a set of properties.
    *
-   * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
+   * Sugar factory for [`DataSchema`](/schema/DataSchema).
    */
   export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
   	return new DataSchema({ props });
   }
   ```
 
-- The canonical wording is exactly `_Sugar factory for [\`ClassName\`](/schema/ClassName)._` — italic (the `markup` renderer makes `_underscores_` italic and `*asterisks*` bold, so use underscores here, not asterisks), with a backtick-quoted class name linked to its docs page. When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
+- The canonical wording is exactly `Sugar factory for [\`ClassName\`](/schema/ClassName).` — plain text (no `*asterisks*` or `_underscores_`; the `markup` renderer would make those bold or italic respectively), with a backtick-quoted class name linked to its docs page. When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
 
 ### Docblock standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,14 +468,14 @@ For convenience the `schema` module ships **sugar** — pre-built shortcuts that
   /**
    * Create a `DataSchema` for a set of properties.
    *
-   * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
+   * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
    */
   export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
   	return new DataSchema({ props });
   }
   ```
 
-- The canonical wording is exactly `*Sugar factory for [\`ClassName\`](/schema/ClassName).*` (italicised, backtick-quoted class name linked to its docs page). When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
+- The canonical wording is exactly `_Sugar factory for [\`ClassName\`](/schema/ClassName)._` — italic (the `markup` renderer makes `_underscores_` italic and `*asterisks*` bold, so use underscores here, not asterisks), with a backtick-quoted class name linked to its docs page. When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
 
 ### Docblock standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,25 +441,41 @@ A component that exposes no own hooks and only inherits says so explicitly in on
 
 The TypeScript extractor infers a symbol's `kind` from its declaration (`function`, `class`, `interface`, `type`, `constant`). A `@kind <name>` tag in the docblock overrides that. Its primary use is `@kind component` on every reusable React component so the docs site groups and colours components separately from plain functions. The tag is consumed by the extractor (it does not appear in the rendered page body), and a non-`function` kind renders the title as a bare name (`Card`, not `Card()`). New documented kinds need a colour in `DocumentationKind` and a section in `DocumentationPage`'s `KIND_SECTIONS`.
 
-### Factory functions
+### Sugar instances and factories
 
-A **factory** is a function (or constant) whose purpose is to call `new SomeClass(...)` with sensible defaults — e.g. `DATA` is a factory for `DataSchema`, `NULLABLE` for `NullableSchema`.
+For convenience the `schema` module ships **sugar** — pre-built shortcuts that improve the readability of code that creates schemas. There are two kinds, named consistently:
 
-- Write factories as regular `function` declarations, not arrow-consts. A `function` declaration classifies as `kind: "function"` on the docs site (an arrow-const wrongly shows as a `constant`), gives a named stack trace, and is the preferred form for public-API exports anyway (see the Functions section)
-- Mark a factory in its docblock with a short italic line naming the class it builds, on its own paragraph after the summary:
+- A **sugar instance** is a pre-instantiated copy of a `Schema` class exported as an `ALL_CAPS` constant — e.g. `STRING` is `new StringSchema({})`, `REQUIRED_STRING` is `new StringSchema({ min: 1 })`.
+- A **sugar factory** is a `function` whose purpose is to call `new SomeClass(...)` with sensible defaults — e.g. `DATA` builds a `DataSchema`, `NULLABLE` a `NullableSchema`.
+
+**Sugar instances.** Open the docblock with one line that states the class it instantiates (as a docs-site markdown link) and the equivalent constructor call, since that first line becomes the card `description`:
+
+  ```ts
+  /**
+   * Sugar instance of [`StringSchema`](/schema/StringSchema) for an unconstrained string. Equivalent to `new StringSchema({})`.
+   *
+   * @example STRING.validate(123); // Returns "123"
+   * @see https://dhoulb.github.io/shelving/schema/StringSchema/STRING
+   */
+  export const STRING = new StringSchema({});
+  ```
+
+  When the instance is built by composing a sugar factory rather than `new` (e.g. `NULLABLE_TITLE = NULLABLE(TITLE)`), name the equivalent factory call instead: `` Equivalent to `NULLABLE(TITLE)`. ``, and link the wrapped sugar instance (`` [`TITLE`](/schema/TITLE) ``).
+
+**Sugar factories.** Write them as regular `function` declarations, not arrow-consts. A `function` declaration classifies as `kind: "function"` on the docs site (an arrow-const wrongly shows as a `constant`), gives a named stack trace, and is the preferred form for public-API exports anyway (see the Functions section). Mark a factory in its docblock with a short italic line naming the class it builds, on its own paragraph after the summary:
 
   ```ts
   /**
    * Create a `DataSchema` for a set of properties.
    *
-   * *Factory for `DataSchema`.*
+   * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
    */
   export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
   	return new DataSchema({ props });
   }
   ```
 
-- The canonical wording is exactly `*Factory for \`ClassName\`.*` (italicised, backtick-quoted class name). When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
+- The canonical wording is exactly `*Sugar factory for [\`ClassName\`](/schema/ClassName).*` (italicised, backtick-quoted class name linked to its docs page). When a factory composes other factories (e.g. `NULLABLE_DATA` wraps a `DataSchema` in a `NullableSchema`), name the class it ultimately returns
 
 ### Docblock standards
 

--- a/modules/schema/AddressSchema.ts
+++ b/modules/schema/AddressSchema.ts
@@ -59,7 +59,7 @@ export class AddressSchema extends DataSchema<AddressData> {
 }
 
 /**
- * Valid postal address data.
+ * Sugar instance of [`AddressSchema`](/schema/AddressSchema) for postal address data. Equivalent to `new AddressSchema({})`.
  *
  * @example ADDRESS.validate({ address1: "1 High St", city: "London", postcode: "SW1A 1AA", country: "GB" });
  * @see https://dhoulb.github.io/shelving/schema/AddressSchema/ADDRESS
@@ -67,7 +67,7 @@ export class AddressSchema extends DataSchema<AddressData> {
 export const ADDRESS = new AddressSchema({});
 
 /**
- * Valid postal address data, or `null`
+ * Sugar instance allowing an [`ADDRESS`](/schema/ADDRESS) or `null`. Equivalent to `NULLABLE(ADDRESS)`.
  *
  * @example NULLABLE_ADDRESS.validate(null); // Returns null
  * @see https://dhoulb.github.io/shelving/schema/AddressSchema/NULLABLE_ADDRESS

--- a/modules/schema/ArraySchema.md
+++ b/modules/schema/ArraySchema.md
@@ -2,7 +2,7 @@
 
 Validates a value into a `readonly` array, validating each element against an `items` schema. Following the robustness principle, a comma-separated string is split into an array, and a missing value falls back to an empty array.
 
-`ARRAY(itemSchema)` is the factory that builds an `ArraySchema` for a given element schema.
+[`ARRAY(itemSchema)`](/schema/ARRAY) is the sugar factory that builds an `ArraySchema` for a given element schema.
 
 ## Usage
 

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -124,7 +124,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 /**
  * Create a schema for a valid array with specified items.
  *
- * *Sugar factory for [`ArraySchema`](/schema/ArraySchema).*
+ * _Sugar factory for [`ArraySchema`](/schema/ArraySchema)._
  *
  * @param items Schema every item in the array must conform to.
  * @returns An `ArraySchema` validating arrays of the given item type.

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -124,7 +124,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 /**
  * Create a schema for a valid array with specified items.
  *
- * _Sugar factory for [`ArraySchema`](/schema/ArraySchema)._
+ * Sugar factory for [`ArraySchema`](/schema/ArraySchema).
  *
  * @param items Schema every item in the array must conform to.
  * @returns An `ArraySchema` validating arrays of the given item type.

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -124,7 +124,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 /**
  * Create a schema for a valid array with specified items.
  *
- * *Factory for `ArraySchema`.*
+ * *Sugar factory for [`ArraySchema`](/schema/ArraySchema).*
  *
  * @param items Schema every item in the array must conform to.
  * @returns An `ArraySchema` validating arrays of the given item type.

--- a/modules/schema/BooleanSchema.md
+++ b/modules/schema/BooleanSchema.md
@@ -2,9 +2,13 @@
 
 Validates a value into a `boolean`. Following the robustness principle, the strings `"no"` and `"false"` coerce to `false`, and any other value is tested for truthiness. A missing value falls back to the schema's `value` default (`false`).
 
-`BOOLEAN` is the ready-made constant for a boolean field.
+[`BOOLEAN`](/schema/BOOLEAN) is the ready-made sugar instance for a boolean field.
 
 ## Usage
+
+### Sugar instances
+
+To save creating a new instance of `BooleanSchema` for trivial uses, you can use the [`BOOLEAN`](/schema/BOOLEAN) sugar instance instead.
 
 ```ts
 import { BOOLEAN } from "shelving/schema";

--- a/modules/schema/BooleanSchema.ts
+++ b/modules/schema/BooleanSchema.ts
@@ -78,7 +78,7 @@ export class BooleanSchema extends Schema<boolean> {
 }
 
 /**
- * Valid boolean.
+ * Sugar instance of [`BooleanSchema`](/schema/BooleanSchema) for a coerced boolean. Equivalent to `new BooleanSchema({})`.
  *
  * @example
  *  BOOLEAN.validate("yes"); // Returns true

--- a/modules/schema/ChoiceSchema.md
+++ b/modules/schema/ChoiceSchema.md
@@ -2,7 +2,7 @@
 
 Validates that a value is one of a known set of options — designed to power a `<select>` field in HTML. The validated type is the union of the option keys.
 
-`CHOICE` builds a `ChoiceSchema` from either an array of strings (keys and labels are the same) or an object (keys are the validated values, object values are display labels).
+[`CHOICE`](/schema/CHOICE) is the sugar factory that builds a `ChoiceSchema` from either an array of strings (keys and labels are the same) or an object (keys are the validated values, object values are display labels).
 
 ## Usage
 

--- a/modules/schema/ChoiceSchema.ts
+++ b/modules/schema/ChoiceSchema.ts
@@ -99,7 +99,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 /**
  * Create a schema for a valid choice from an allowed set of values.
  *
- * *Factory for `ChoiceSchema`.*
+ * *Sugar factory for [`ChoiceSchema`](/schema/ChoiceSchema).*
  *
  * @param options The allowed choices, as a `{ key: title }` dictionary or an array of keys.
  * @returns A `ChoiceSchema` validating the given choices.

--- a/modules/schema/ChoiceSchema.ts
+++ b/modules/schema/ChoiceSchema.ts
@@ -99,7 +99,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 /**
  * Create a schema for a valid choice from an allowed set of values.
  *
- * *Sugar factory for [`ChoiceSchema`](/schema/ChoiceSchema).*
+ * _Sugar factory for [`ChoiceSchema`](/schema/ChoiceSchema)._
  *
  * @param options The allowed choices, as a `{ key: title }` dictionary or an array of keys.
  * @returns A `ChoiceSchema` validating the given choices.

--- a/modules/schema/ChoiceSchema.ts
+++ b/modules/schema/ChoiceSchema.ts
@@ -99,7 +99,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 /**
  * Create a schema for a valid choice from an allowed set of values.
  *
- * _Sugar factory for [`ChoiceSchema`](/schema/ChoiceSchema)._
+ * Sugar factory for [`ChoiceSchema`](/schema/ChoiceSchema).
  *
  * @param options The allowed choices, as a `{ key: title }` dictionary or an array of keys.
  * @returns A `ChoiceSchema` validating the given choices.

--- a/modules/schema/ColorSchema.ts
+++ b/modules/schema/ColorSchema.ts
@@ -60,7 +60,7 @@ export class ColorSchema extends StringSchema {
 }
 
 /**
- * Valid color hex string, e.g. `#00CCFF` (required because empty string is invalid).
+ * Sugar instance of [`ColorSchema`](/schema/ColorSchema) for a required hex color string, e.g. `#00CCFF`. Equivalent to `new ColorSchema({})`.
  *
  * @example COLOR.validate("#00CCFF"); // Returns "#00CCFF"
  * @see https://dhoulb.github.io/shelving/schema/ColorSchema/COLOR
@@ -68,7 +68,7 @@ export class ColorSchema extends StringSchema {
 export const COLOR = new ColorSchema({});
 
 /**
- * Valid color hex string, e.g. `#00CCFF`, or `null`
+ * Sugar instance allowing a [`COLOR`](/schema/COLOR) or `null`. Equivalent to `NULLABLE(COLOR)`.
  *
  * @example NULLABLE_COLOR.validate(null); // Returns null
  * @see https://dhoulb.github.io/shelving/schema/ColorSchema/NULLABLE_COLOR

--- a/modules/schema/CountrySchema.ts
+++ b/modules/schema/CountrySchema.ts
@@ -53,7 +53,7 @@ export class CountrySchema extends ChoiceSchema<Country, PossibleCountry> {
 }
 
 /**
- * Valid country code, e.g. `GB` (required because falsy values are invalid).
+ * Sugar instance of [`CountrySchema`](/schema/CountrySchema) for a required ISO 3166 country code, e.g. `GB`. Equivalent to `new CountrySchema({})`.
  *
  * @example COUNTRY.validate("GB") // "GB"
  * @see https://dhoulb.github.io/shelving/schema/CountrySchema/COUNTRY
@@ -61,7 +61,7 @@ export class CountrySchema extends ChoiceSchema<Country, PossibleCountry> {
 export const COUNTRY = new CountrySchema({});
 
 /**
- * Valid country code, e.g. `GB`, or `null`.
+ * Sugar instance allowing a [`COUNTRY`](/schema/COUNTRY) or `null`. Equivalent to `NULLABLE(COUNTRY)`.
  *
  * @example NULLABLE_COUNTRY.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/CountrySchema/NULLABLE_COUNTRY

--- a/modules/schema/CurrencyAmountSchema.md
+++ b/modules/schema/CurrencyAmountSchema.md
@@ -2,7 +2,7 @@
 
 A `NumberSchema` subclass for monetary amounts. It rounds to the currency's minor units (e.g. two decimal places for `GBP`) and exposes a `format()` method that renders the amount with the correct currency symbol.
 
-`USD_AMOUNT`, `GBP_AMOUNT`, and `EUR_AMOUNT` are ready-made constants; `CURRENCY_AMOUNT(code)` builds one for any currency code.
+[`USD_AMOUNT`](/schema/USD_AMOUNT), [`GBP_AMOUNT`](/schema/GBP_AMOUNT), and [`EUR_AMOUNT`](/schema/EUR_AMOUNT) are ready-made sugar instances; the [`CURRENCY_AMOUNT(code)`](/schema/CURRENCY_AMOUNT) sugar factory builds one for any currency code.
 
 ## Usage
 

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -86,7 +86,7 @@ export class CurrencyAmountSchema extends NumberSchema {
 /**
  * Create a `CurrencyAmountSchema` for a non-negative monetary amount in a currency.
  *
- * *Factory for `CurrencyAmountSchema`.*
+ * *Sugar factory for [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema).*
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `CurrencyAmountSchema` validating amounts in `currency`.
@@ -99,7 +99,7 @@ export function CURRENCY_AMOUNT(currency: CurrencyCode): CurrencyAmountSchema {
 }
 
 /**
- * Valid US dollar amount, e.g. `12.35`.
+ * Sugar instance of [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema) for a US dollar amount. Equivalent to `new CurrencyAmountSchema({ currency: "USD" })`.
  *
  * @example USD_AMOUNT.validate("12.345") // 12.35
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/USD_AMOUNT
@@ -107,7 +107,7 @@ export function CURRENCY_AMOUNT(currency: CurrencyCode): CurrencyAmountSchema {
 export const USD_AMOUNT = new CurrencyAmountSchema({ currency: "USD" });
 
 /**
- * Valid pound sterling amount, e.g. `12.35`.
+ * Sugar instance of [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema) for a pound sterling amount. Equivalent to `new CurrencyAmountSchema({ currency: "GBP" })`.
  *
  * @example GBP_AMOUNT.validate("12.345") // 12.35
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/GBP_AMOUNT
@@ -115,7 +115,7 @@ export const USD_AMOUNT = new CurrencyAmountSchema({ currency: "USD" });
 export const GBP_AMOUNT = new CurrencyAmountSchema({ currency: "GBP" });
 
 /**
- * Valid euro amount, e.g. `12.35`.
+ * Sugar instance of [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema) for a euro amount. Equivalent to `new CurrencyAmountSchema({ currency: "EUR" })`.
  *
  * @example EUR_AMOUNT.validate("12.345") // 12.35
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/EUR_AMOUNT
@@ -125,7 +125,7 @@ export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
 /**
  * Create a `NullableSchema` for an optional monetary amount in a currency, or `null`.
  *
- * *Factory for `NullableSchema`.*
+ * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `NullableSchema` validating amounts in `currency`, or `null`.
@@ -138,7 +138,7 @@ export function NULLABLE_CURRENCY_AMOUNT(currency: CurrencyCode): NullableSchema
 }
 
 /**
- * Valid US dollar amount, e.g. `12.35`, or `null`.
+ * Sugar instance allowing a [`USD_AMOUNT`](/schema/USD_AMOUNT) or `null`. Equivalent to `NULLABLE(USD_AMOUNT)`.
  *
  * @example NULLABLE_USD_AMOUNT.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_USD_AMOUNT
@@ -146,7 +146,7 @@ export function NULLABLE_CURRENCY_AMOUNT(currency: CurrencyCode): NullableSchema
 export const NULLABLE_USD_AMOUNT = NULLABLE(USD_AMOUNT);
 
 /**
- * Valid pound sterling amount, e.g. `12.35`, or `null`.
+ * Sugar instance allowing a [`GBP_AMOUNT`](/schema/GBP_AMOUNT) or `null`. Equivalent to `NULLABLE(GBP_AMOUNT)`.
  *
  * @example NULLABLE_GBP_AMOUNT.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_GBP_AMOUNT
@@ -154,7 +154,7 @@ export const NULLABLE_USD_AMOUNT = NULLABLE(USD_AMOUNT);
 export const NULLABLE_GBP_AMOUNT = NULLABLE(GBP_AMOUNT);
 
 /**
- * Valid euro amount, e.g. `12.35`, or `null`.
+ * Sugar instance allowing an [`EUR_AMOUNT`](/schema/EUR_AMOUNT) or `null`. Equivalent to `NULLABLE(EUR_AMOUNT)`.
  *
  * @example NULLABLE_EUR_AMOUNT.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_EUR_AMOUNT

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -86,7 +86,7 @@ export class CurrencyAmountSchema extends NumberSchema {
 /**
  * Create a `CurrencyAmountSchema` for a non-negative monetary amount in a currency.
  *
- * *Sugar factory for [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema).*
+ * _Sugar factory for [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema)._
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `CurrencyAmountSchema` validating amounts in `currency`.
@@ -125,7 +125,7 @@ export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
 /**
  * Create a `NullableSchema` for an optional monetary amount in a currency, or `null`.
  *
- * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
+ * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `NullableSchema` validating amounts in `currency`, or `null`.

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -86,7 +86,7 @@ export class CurrencyAmountSchema extends NumberSchema {
 /**
  * Create a `CurrencyAmountSchema` for a non-negative monetary amount in a currency.
  *
- * _Sugar factory for [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema)._
+ * Sugar factory for [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema).
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `CurrencyAmountSchema` validating amounts in `currency`.
@@ -125,7 +125,7 @@ export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
 /**
  * Create a `NullableSchema` for an optional monetary amount in a currency, or `null`.
  *
- * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
+ * Sugar factory for [`NullableSchema`](/schema/NullableSchema).
  *
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @returns A `NullableSchema` validating amounts in `currency`, or `null`.

--- a/modules/schema/CurrencyCodeSchema.ts
+++ b/modules/schema/CurrencyCodeSchema.ts
@@ -84,7 +84,7 @@ export class CurrencyCodeSchema extends StringSchema {
 }
 
 /**
- * Valid currency code, e.g. `GBP` (required because falsy values are invalid).
+ * Sugar instance of [`CurrencyCodeSchema`](/schema/CurrencyCodeSchema) for a required ISO 4217 currency code, e.g. `GBP`. Equivalent to `new CurrencyCodeSchema({})`.
  *
  * @example CURRENCY_CODE.validate("gbp") // "GBP"
  * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CURRENCY_CODE
@@ -92,7 +92,7 @@ export class CurrencyCodeSchema extends StringSchema {
 export const CURRENCY_CODE = new CurrencyCodeSchema({});
 
 /**
- * Valid currency code, e.g. `GBP`, or `null`.
+ * Sugar instance allowing a [`CURRENCY_CODE`](/schema/CURRENCY_CODE) or `null`. Equivalent to `NULLABLE(CURRENCY_CODE)`.
  *
  * @example NULLABLE_CURRENCY_CODE.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/NULLABLE_CURRENCY_CODE

--- a/modules/schema/DataSchema.md
+++ b/modules/schema/DataSchema.md
@@ -2,7 +2,7 @@
 
 Validates a plain object whose properties each have their own schema. The term `Data` in Shelving refers to a plain object with known named properties; a `DataSchema` is the validator for one.
 
-When several properties fail, the errors are joined by `\n` with each field name prepended — e.g. `"name: Required\nprice: Minimum 0"`. This file also exports the `DATA`, `ITEM`, and `PARTIAL` factories that build `DataSchema` instances.
+When several properties fail, the errors are joined by `\n` with each field name prepended — e.g. `"name: Required\nprice: Minimum 0"`. This file also exports the [`DATA`](/schema/DATA), [`ITEM`](/schema/ITEM), and [`PARTIAL`](/schema/PARTIAL) sugar factories that build `DataSchema` instances.
 
 ## Usage
 

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -110,7 +110,7 @@ function _getSchemaValue<T extends Data>([, { value }]: Prop<Schemas<T>>): Value
 /**
  * Create a `DataSchema` for a set of properties.
  *
- * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
+ * Sugar factory for [`DataSchema`](/schema/DataSchema).
  *
  * @param props A named schema for each property of the data object.
  * @returns A `DataSchema` validating data with the given props.
@@ -124,7 +124,7 @@ export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
 /**
  * Create a schema for a valid data object with specified properties, or `null`.
  *
- * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
+ * Sugar factory for [`NullableSchema`](/schema/NullableSchema).
  *
  * @param props A named schema for each property of the data object.
  * @returns A `NullableSchema` wrapping a `DataSchema` with the given props.
@@ -138,7 +138,7 @@ export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema
 /**
  * Create a `DataSchema` that validates partially, i.e. every property can be its value or `undefined`.
  *
- * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
+ * Sugar factory for [`DataSchema`](/schema/DataSchema).
  *
  * @param source The props schemas or an existing `DataSchema` to make partial.
  * @returns A `DataSchema` whose every property is optional.
@@ -159,7 +159,7 @@ function _optionalProp([, v]: Prop<Schemas<Data>>): Schema<unknown> {
 /**
  * Create a `DataSchema` that validates a data item, i.e. it has a string or number `.id` identifier property.
  *
- * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
+ * Sugar factory for [`DataSchema`](/schema/DataSchema).
  *
  * @param id Schema for the item's `id` identifier property.
  * @param schemas The props schemas or an existing `DataSchema` for the rest of the item.

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -110,7 +110,7 @@ function _getSchemaValue<T extends Data>([, { value }]: Prop<Schemas<T>>): Value
 /**
  * Create a `DataSchema` for a set of properties.
  *
- * *Factory for `DataSchema`.*
+ * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
  *
  * @param props A named schema for each property of the data object.
  * @returns A `DataSchema` validating data with the given props.
@@ -124,7 +124,7 @@ export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
 /**
  * Create a schema for a valid data object with specified properties, or `null`.
  *
- * *Factory for `NullableSchema`.*
+ * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
  *
  * @param props A named schema for each property of the data object.
  * @returns A `NullableSchema` wrapping a `DataSchema` with the given props.
@@ -138,7 +138,7 @@ export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema
 /**
  * Create a `DataSchema` that validates partially, i.e. every property can be its value or `undefined`.
  *
- * *Factory for `DataSchema`.*
+ * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
  *
  * @param source The props schemas or an existing `DataSchema` to make partial.
  * @returns A `DataSchema` whose every property is optional.
@@ -159,7 +159,7 @@ function _optionalProp([, v]: Prop<Schemas<Data>>): Schema<unknown> {
 /**
  * Create a `DataSchema` that validates a data item, i.e. it has a string or number `.id` identifier property.
  *
- * *Factory for `DataSchema`.*
+ * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
  *
  * @param id Schema for the item's `id` identifier property.
  * @param schemas The props schemas or an existing `DataSchema` for the rest of the item.

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -110,7 +110,7 @@ function _getSchemaValue<T extends Data>([, { value }]: Prop<Schemas<T>>): Value
 /**
  * Create a `DataSchema` for a set of properties.
  *
- * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
+ * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
  *
  * @param props A named schema for each property of the data object.
  * @returns A `DataSchema` validating data with the given props.
@@ -124,7 +124,7 @@ export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
 /**
  * Create a schema for a valid data object with specified properties, or `null`.
  *
- * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
+ * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
  *
  * @param props A named schema for each property of the data object.
  * @returns A `NullableSchema` wrapping a `DataSchema` with the given props.
@@ -138,7 +138,7 @@ export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema
 /**
  * Create a `DataSchema` that validates partially, i.e. every property can be its value or `undefined`.
  *
- * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
+ * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
  *
  * @param source The props schemas or an existing `DataSchema` to make partial.
  * @returns A `DataSchema` whose every property is optional.
@@ -159,7 +159,7 @@ function _optionalProp([, v]: Prop<Schemas<Data>>): Schema<unknown> {
 /**
  * Create a `DataSchema` that validates a data item, i.e. it has a string or number `.id` identifier property.
  *
- * *Sugar factory for [`DataSchema`](/schema/DataSchema).*
+ * _Sugar factory for [`DataSchema`](/schema/DataSchema)._
  *
  * @param id Schema for the item's `id` identifier property.
  * @param schemas The props schemas or an existing `DataSchema` for the rest of the item.

--- a/modules/schema/DateSchema.ts
+++ b/modules/schema/DateSchema.ts
@@ -120,7 +120,7 @@ export class DateSchema extends Schema<string> {
 }
 
 /**
- * Valid date, e.g. `2005-09-12` (required because falsy values are invalid).
+ * Sugar instance of [`DateSchema`](/schema/DateSchema) for a required date. Equivalent to `new DateSchema({})`.
  *
  * @example DATE.validate("2005-09-12") // "2005-09-12"
  * @see https://dhoulb.github.io/shelving/schema/DateSchema/DATE
@@ -128,7 +128,7 @@ export class DateSchema extends Schema<string> {
 export const DATE = new DateSchema({});
 
 /**
- * Valid date, e.g. `2005-09-12`, or `null`.
+ * Sugar instance allowing a [`DATE`](/schema/DATE) or `null`. Equivalent to `NULLABLE(DATE)`.
  *
  * @example NULLABLE_DATE.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/DateSchema/NULLABLE_DATE

--- a/modules/schema/DateTimeSchema.ts
+++ b/modules/schema/DateTimeSchema.ts
@@ -48,7 +48,7 @@ export class DateTimeSchema extends DateSchema {
 }
 
 /**
- * Valid datetime, e.g. `2005-09-12T08:00:00Z` (required because falsy values are invalid).
+ * Sugar instance of [`DateTimeSchema`](/schema/DateTimeSchema) for a required UTC datetime. Equivalent to `new DateTimeSchema({})`.
  *
  * @example DATETIME.validate("2005-09-12T08:00:00Z") // "2005-09-12T08:00:00.000Z"
  * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/DATETIME
@@ -56,7 +56,7 @@ export class DateTimeSchema extends DateSchema {
 export const DATETIME = new DateTimeSchema({});
 
 /**
- * Valid datetime, e.g. `2005-09-12T21:30:00Z`, or `null`.
+ * Sugar instance allowing a [`DATETIME`](/schema/DATETIME) or `null`. Equivalent to `NULLABLE(DATETIME)`.
  *
  * @example NULLABLE_DATETIME.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/NULLABLE_DATETIME

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -99,7 +99,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 /**
  * Create a schema for a valid dictionary object with specified entry values.
  *
- * _Sugar factory for [`DictionarySchema`](/schema/DictionarySchema)._
+ * Sugar factory for [`DictionarySchema`](/schema/DictionarySchema).
  *
  * @param items Schema every entry value in the dictionary must conform to.
  * @returns A `DictionarySchema` validating dictionaries of the given item type.

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -99,7 +99,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 /**
  * Create a schema for a valid dictionary object with specified entry values.
  *
- * *Sugar factory for [`DictionarySchema`](/schema/DictionarySchema).*
+ * _Sugar factory for [`DictionarySchema`](/schema/DictionarySchema)._
  *
  * @param items Schema every entry value in the dictionary must conform to.
  * @returns A `DictionarySchema` validating dictionaries of the given item type.

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -99,7 +99,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 /**
  * Create a schema for a valid dictionary object with specified entry values.
  *
- * *Factory for `DictionarySchema`.*
+ * *Sugar factory for [`DictionarySchema`](/schema/DictionarySchema).*
  *
  * @param items Schema every entry value in the dictionary must conform to.
  * @returns A `DictionarySchema` validating dictionaries of the given item type.

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -68,7 +68,7 @@ export class EmailSchema extends StringSchema {
 }
 
 /**
- * Valid email, e.g. `test@test.com`
+ * Sugar instance of [`EmailSchema`](/schema/EmailSchema) for a valid email address. Equivalent to `new EmailSchema({})`.
  *
  * @example EMAIL.validate("test@test.com"); // Returns "test@test.com"
  * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EMAIL
@@ -76,7 +76,7 @@ export class EmailSchema extends StringSchema {
 export const EMAIL = new EmailSchema({});
 
 /**
- * Valid optional email, e.g. `test@test.com`, or `null`
+ * Sugar instance allowing an [`EMAIL`](/schema/EMAIL) or `null`. Equivalent to `NULLABLE(EMAIL)`.
  *
  * @example NULLABLE_EMAIL.validate(null); // Returns null
  * @see https://dhoulb.github.io/shelving/schema/EmailSchema/NULLABLE_EMAIL

--- a/modules/schema/EntitySchema.ts
+++ b/modules/schema/EntitySchema.ts
@@ -58,7 +58,7 @@ export class EntitySchema<T extends string> extends StringSchema {
 }
 
 /**
- * Valid entity, e.g. `challenge:a1b2c3`
+ * Sugar instance of [`EntitySchema`](/schema/EntitySchema) for an entity string, e.g. `challenge:a1b2c3`. Equivalent to `new EntitySchema({})`.
  *
  * @example ENTITY.validate("challenge:a1b2c3") // "challenge:a1b2c3"
  * @see https://dhoulb.github.io/shelving/schema/EntitySchema/ENTITY
@@ -66,7 +66,7 @@ export class EntitySchema<T extends string> extends StringSchema {
 export const ENTITY = new EntitySchema({});
 
 /**
- * Valid optional entity, e.g. `challenge:a1b2c3`, or `null`
+ * Sugar instance allowing an [`ENTITY`](/schema/ENTITY) or `null`. Equivalent to `NULLABLE(ENTITY)`.
  *
  * @example NULLABLE_ENTITY.validate("") // null
  * @see https://dhoulb.github.io/shelving/schema/EntitySchema/NULLABLE_ENTITY

--- a/modules/schema/FileSchema.ts
+++ b/modules/schema/FileSchema.ts
@@ -59,7 +59,7 @@ export class FileSchema extends StringSchema {
 }
 
 /**
- * Valid file, e.g. `file.txt`
+ * Sugar instance of [`FileSchema`](/schema/FileSchema) for a file name, e.g. `file.txt`. Equivalent to `new FileSchema({})`.
  *
  * @example FILE.validate("file.txt"); // Returns "file.txt"
  * @see https://dhoulb.github.io/shelving/schema/FileSchema/FILE
@@ -67,7 +67,7 @@ export class FileSchema extends StringSchema {
 export const FILE = new FileSchema({});
 
 /**
- * Valid optional file, e.g. `file.txt`, or `null`
+ * Sugar instance allowing a [`FILE`](/schema/FILE) or `null`. Equivalent to `NULLABLE(FILE)`.
  *
  * @example NULLABLE_FILE.validate(null); // Returns null
  * @see https://dhoulb.github.io/shelving/schema/FileSchema/NULLABLE_FILE

--- a/modules/schema/KeySchema.ts
+++ b/modules/schema/KeySchema.ts
@@ -41,7 +41,7 @@ export class KeySchema extends StringSchema {
 }
 
 /**
- * Valid database key.
+ * Sugar instance of [`KeySchema`](/schema/KeySchema) for a database key. Equivalent to `new KeySchema({ title: "ID" })`.
  *
  * @example KEY.validate("a1b2c3") // "a1b2c3"
  * @see https://dhoulb.github.io/shelving/schema/KeySchema/KEY
@@ -49,7 +49,7 @@ export class KeySchema extends StringSchema {
 export const KEY = new KeySchema({ title: "ID" });
 
 /**
- * Valid optional database key, or `null`.
+ * Sugar instance allowing a [`KEY`](/schema/KEY) or `null`. Equivalent to `NULLABLE(KEY)`.
  *
  * @example NULLABLE_KEY.validate("") // null
  * @see https://dhoulb.github.io/shelving/schema/KeySchema/NULLABLE_KEY

--- a/modules/schema/NullableSchema.md
+++ b/modules/schema/NullableSchema.md
@@ -2,7 +2,7 @@
 
 Wraps another schema to allow `null` as a valid value. Following the robustness principle, `undefined` and the empty string `""` also coerce to `null`; any other value is delegated to the wrapped schema.
 
-`NULLABLE(schema)` is the factory that builds a `NullableSchema` around an existing schema.
+[`NULLABLE(schema)`](/schema/NULLABLE) is the sugar factory that builds a `NullableSchema` around an existing schema.
 
 ## Usage
 

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -72,7 +72,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 /**
  * Create a `NullableSchema` that wraps a source schema and also allows `null`.
  *
- * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
+ * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
  *
  * @param source Source schema to wrap.
  * @returns A `NullableSchema` wrapping `source`.

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -72,7 +72,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 /**
  * Create a `NullableSchema` that wraps a source schema and also allows `null`.
  *
- * *Factory for `NullableSchema`.*
+ * *Sugar factory for [`NullableSchema`](/schema/NullableSchema).*
  *
  * @param source Source schema to wrap.
  * @returns A `NullableSchema` wrapping `source`.

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -72,7 +72,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 /**
  * Create a `NullableSchema` that wraps a source schema and also allows `null`.
  *
- * _Sugar factory for [`NullableSchema`](/schema/NullableSchema)._
+ * Sugar factory for [`NullableSchema`](/schema/NullableSchema).
  *
  * @param source Source schema to wrap.
  * @returns A `NullableSchema` wrapping `source`.

--- a/modules/schema/NumberSchema.md
+++ b/modules/schema/NumberSchema.md
@@ -2,11 +2,13 @@
 
 Validates a value into a `number`. Strings that look like numbers are parsed, and a missing value falls back to the schema's `value` default (`0` by default). Construct a `NumberSchema` directly to add constraints like `min`, `max`, and `step`.
 
-`NUMBER` is the ready-made constant for an unconstrained number; `INTEGER` is a `NumberSchema` with `step: 1` constrained to the safe-integer range.
+[`NUMBER`](/schema/NUMBER) is the ready-made sugar instance for an unconstrained number; [`INTEGER`](/schema/INTEGER) is a `NumberSchema` with `step: 1` constrained to the safe-integer range.
 
 ## Usage
 
-### The `NUMBER` constant
+### Sugar instances
+
+To save creating a new instance of `NumberSchema` for trivial uses, you can use the [`NUMBER`](/schema/NUMBER) or [`INTEGER`](/schema/INTEGER) sugar instances instead. The module also ships the constrained integer variants [`POSITIVE_INTEGER`](/schema/POSITIVE_INTEGER), [`NON_NEGATIVE_INTEGER`](/schema/NON_NEGATIVE_INTEGER), [`NEGATIVE_INTEGER`](/schema/NEGATIVE_INTEGER), and [`NON_POSITIVE_INTEGER`](/schema/NON_POSITIVE_INTEGER), the [`TIMESTAMP`](/schema/TIMESTAMP) Unix-timestamp instance, and nullable variants such as [`NULLABLE_NUMBER`](/schema/NULLABLE_NUMBER) and [`NULLABLE_INTEGER`](/schema/NULLABLE_INTEGER).
 
 ```ts
 import { NUMBER } from "shelving/schema";

--- a/modules/schema/NumberSchema.ts
+++ b/modules/schema/NumberSchema.ts
@@ -104,7 +104,7 @@ export class NumberSchema extends Schema<number> {
 }
 
 /**
- * Valid number, e.g. `2048.12345` or `0` zero and a default value of zero.
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for an unconstrained number. Equivalent to `new NumberSchema({ title: "Number" })`.
  *
  * @example
  *  NUMBER.validate("42"); // Returns 42
@@ -114,7 +114,7 @@ export class NumberSchema extends Schema<number> {
 export const NUMBER = new NumberSchema({ title: "Number" });
 
 /**
- * Valid optional number, e.g. `2048.12345` or `0` zero, or `null`.
+ * Sugar instance allowing a [`NUMBER`](/schema/NUMBER) or `null`. Equivalent to `NULLABLE(NUMBER)`.
  *
  * @example
  *  NULLABLE_NUMBER.validate(null); // Returns null
@@ -124,7 +124,7 @@ export const NUMBER = new NumberSchema({ title: "Number" });
 export const NULLABLE_NUMBER = NULLABLE(NUMBER);
 
 /**
- * Valid integer number, e.g. `2048` or `0` zero.
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for an integer. Equivalent to `new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER })`.
  *
  * @example
  *  INTEGER.validate("42.7"); // Returns 43 (rounded to step)
@@ -134,7 +134,7 @@ export const NULLABLE_NUMBER = NULLABLE(NUMBER);
 export const INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER });
 
 /**
- * Valid positive integer number, e.g. `1,2,3` (not including zero).
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for a positive integer (excluding zero). Equivalent to `new NumberSchema({ step: 1, min: 1, max: Number.MAX_SAFE_INTEGER })`.
  *
  * @example
  *  POSITIVE_INTEGER.validate(0); // Throws "Required"
@@ -144,7 +144,7 @@ export const INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER,
 export const POSITIVE_INTEGER = new NumberSchema({ step: 1, min: 1, max: Number.MAX_SAFE_INTEGER });
 
 /**
- * Valid non-negative integer number, e.g. `0,1,2,3` (including zero).
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for a non-negative integer (including zero). Equivalent to `new NumberSchema({ step: 1, min: 0, max: Number.MAX_SAFE_INTEGER })`.
  *
  * @example
  *  NON_NEGATIVE_INTEGER.validate(0); // Returns 0
@@ -154,7 +154,7 @@ export const POSITIVE_INTEGER = new NumberSchema({ step: 1, min: 1, max: Number.
 export const NON_NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: 0, max: Number.MAX_SAFE_INTEGER });
 
 /**
- * Valid negative integer number, e.g. `-1,-2,-3` (not including zero).
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for a negative integer (excluding zero). Equivalent to `new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: -1 })`.
  *
  * @example
  *  NEGATIVE_INTEGER.validate(-3); // Returns -3
@@ -164,7 +164,7 @@ export const NON_NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: 0, max: Num
 export const NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: -1 });
 
 /**
- * Valid non-positive integer number, e.g. `0,-1,-2,-3` (including zero).
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for a non-positive integer (including zero). Equivalent to `new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: 0 })`.
  *
  * @example
  *  NON_POSITIVE_INTEGER.validate(0); // Returns 0
@@ -174,7 +174,7 @@ export const NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE
 export const NON_POSITIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: 0 });
 
 /**
- * Valid optional integer number, e.g. `2048` or `0` zero, or `null`.
+ * Sugar instance allowing an [`INTEGER`](/schema/INTEGER) or `null`. Equivalent to `NULLABLE(INTEGER)`.
  *
  * @example
  *  NULLABLE_INTEGER.validate(null); // Returns null
@@ -184,7 +184,7 @@ export const NON_POSITIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_
 export const NULLABLE_INTEGER = NULLABLE(INTEGER);
 
 /**
- * Valid Unix timestamp (including milliseconds).
+ * Sugar instance of [`NumberSchema`](/schema/NumberSchema) for a Unix timestamp (including milliseconds). Equivalent to `new NumberSchema({ title: "Timestamp", step: 1, min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER })`.
  *
  * @example
  *  TIMESTAMP.validate(1700000000000); // Returns 1700000000000
@@ -199,7 +199,7 @@ export const TIMESTAMP = new NumberSchema({
 });
 
 /**
- * Valid optional Unix timestamp (including milliseconds), or `null`.
+ * Sugar instance — alias of [`NULLABLE_INTEGER`](/schema/NULLABLE_INTEGER). Equivalent to `NULLABLE_INTEGER`.
  *
  * @example
  *  NULLABLE_TIMESTAMP.validate(null); // Returns null

--- a/modules/schema/OptionalSchema.md
+++ b/modules/schema/OptionalSchema.md
@@ -2,7 +2,7 @@
 
 Wraps another schema to allow `undefined` as a valid value. Any value other than `undefined` is delegated to the wrapped schema. It is mainly used for partial data props.
 
-`OPTIONAL(schema)` is the factory that builds an `OptionalSchema` around an existing schema.
+[`OPTIONAL(schema)`](/schema/OPTIONAL) is the sugar factory that builds an `OptionalSchema` around an existing schema.
 
 ## Usage
 

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -73,7 +73,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 /**
  * Create an `OptionalSchema` that wraps a source schema and also allows `undefined`.
  *
- * _Sugar factory for [`OptionalSchema`](/schema/OptionalSchema)._
+ * Sugar factory for [`OptionalSchema`](/schema/OptionalSchema).
  *
  * @param source Source schema to wrap.
  * @returns An `OptionalSchema` wrapping `source`.

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -73,7 +73,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 /**
  * Create an `OptionalSchema` that wraps a source schema and also allows `undefined`.
  *
- * *Sugar factory for [`OptionalSchema`](/schema/OptionalSchema).*
+ * _Sugar factory for [`OptionalSchema`](/schema/OptionalSchema)._
  *
  * @param source Source schema to wrap.
  * @returns An `OptionalSchema` wrapping `source`.

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -73,7 +73,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 /**
  * Create an `OptionalSchema` that wraps a source schema and also allows `undefined`.
  *
- * *Factory for `OptionalSchema`.*
+ * *Sugar factory for [`OptionalSchema`](/schema/OptionalSchema).*
  *
  * @param source Source schema to wrap.
  * @returns An `OptionalSchema` wrapping `source`.

--- a/modules/schema/PasswordSchema.ts
+++ b/modules/schema/PasswordSchema.ts
@@ -44,7 +44,7 @@ export class PasswordSchema extends StringSchema {
 }
 
 /**
- * Password string.
+ * Sugar instance of [`StringSchema`](/schema/StringSchema) for a password string. Equivalent to `new StringSchema({})`.
  *
  * @example PASSWORD.validate("hunter2"); // Returns "hunter2"
  * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PASSWORD

--- a/modules/schema/PhoneSchema.ts
+++ b/modules/schema/PhoneSchema.ts
@@ -62,7 +62,7 @@ export class PhoneSchema extends StringSchema {
 }
 
 /**
- * Valid phone number, e.g. `+441234567890`
+ * Sugar instance of [`PhoneSchema`](/schema/PhoneSchema) for a valid phone number. Equivalent to `new PhoneSchema({})`.
  *
  * @example PHONE.validate("+441234567890"); // Returns "+441234567890"
  * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PHONE
@@ -70,7 +70,7 @@ export class PhoneSchema extends StringSchema {
 export const PHONE = new PhoneSchema({});
 
 /**
- * Valid phone number, e.g. `+441234567890`, or `null`
+ * Sugar instance allowing a [`PHONE`](/schema/PHONE) or `null`. Equivalent to `NULLABLE(PHONE)`.
  *
  * @example NULLABLE_PHONE.validate(null); // Returns null
  * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/NULLABLE_PHONE

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -36,11 +36,11 @@ Every schema carries optional display metadata set at construction time:
 | `value`       | schema-specific | Default used when `validate(undefined)` is called |
 | `format`      | schema-specific | Display formatter for downstream form and UI use  |
 
-### Factory constants
+### Sugar instances and factories
 
-Pre-built constants and factory functions cover the most common cases:
+For convenience the `schema` module offers sugar constants and factories to improve the readability of code that creates complex schemas. Sugar instances are pre-instantiated copies of `Schema` classes — by convention an instantiated schema is named in `ALL_CAPS`, a convention you will find it convenient to use in your own codebase too. Sugar factories are functions like `OPTIONAL()` and `DATA()` that build a configured schema for you.
 
-| Constant / factory      | Validated type       |
+| Sugar instance / factory | Validated type       |
 | ----------------------- | -------------------- |
 | `STRING`                | `string`             |
 | `NUMBER`                | `number`             |

--- a/modules/schema/RequiredSchema.ts
+++ b/modules/schema/RequiredSchema.ts
@@ -36,7 +36,7 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
 /**
  * Create a `RequiredSchema` that wraps a source schema and rejects a falsy result.
  *
- * *Sugar factory for [`RequiredSchema`](/schema/RequiredSchema).*
+ * _Sugar factory for [`RequiredSchema`](/schema/RequiredSchema)._
  *
  * @param source Source schema to wrap.
  * @returns A `RequiredSchema` wrapping `source`.

--- a/modules/schema/RequiredSchema.ts
+++ b/modules/schema/RequiredSchema.ts
@@ -36,7 +36,7 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
 /**
  * Create a `RequiredSchema` that wraps a source schema and rejects a falsy result.
  *
- * _Sugar factory for [`RequiredSchema`](/schema/RequiredSchema)._
+ * Sugar factory for [`RequiredSchema`](/schema/RequiredSchema).
  *
  * @param source Source schema to wrap.
  * @returns A `RequiredSchema` wrapping `source`.

--- a/modules/schema/RequiredSchema.ts
+++ b/modules/schema/RequiredSchema.ts
@@ -36,7 +36,7 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
 /**
  * Create a `RequiredSchema` that wraps a source schema and rejects a falsy result.
  *
- * *Factory for `RequiredSchema`.*
+ * *Sugar factory for [`RequiredSchema`](/schema/RequiredSchema).*
  *
  * @param source Source schema to wrap.
  * @returns A `RequiredSchema` wrapping `source`.

--- a/modules/schema/SlugSchema.ts
+++ b/modules/schema/SlugSchema.ts
@@ -43,9 +43,7 @@ export class SlugSchema extends StringSchema {
 }
 
 /**
- * Valid slug, e.g. `this-is-a-slug`.
- *
- * *Factory for `SlugSchema`.*
+ * Sugar instance of [`SlugSchema`](/schema/SlugSchema) for a valid slug. Equivalent to `new SlugSchema({})`.
  *
  * @example SLUG.validate("This is a Slug!") // "this-is-a-slug"
  * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SLUG
@@ -53,9 +51,7 @@ export class SlugSchema extends StringSchema {
 export const SLUG = new SlugSchema({});
 
 /**
- * Valid slug, e.g. `this-is-a-slug`, or `null`.
- *
- * *Factory for `NullableSchema`.*
+ * Sugar instance allowing a [`SLUG`](/schema/SLUG) or `null`. Equivalent to `NULLABLE(SLUG)`.
  *
  * @example NULLABLE_SLUG.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/SlugSchema/NULLABLE_SLUG

--- a/modules/schema/StringSchema.md
+++ b/modules/schema/StringSchema.md
@@ -2,11 +2,13 @@
 
 Validates a value into a `string`. Numbers are coerced to their string form, and a missing value falls back to the schema's `value` default (an empty string by default). Construct a `StringSchema` directly to add constraints like `min`, `max`, and `match`.
 
-`STRING` is the ready-made constant for an unconstrained string; `REQUIRED_STRING` is a `StringSchema` with `min: 1`, so an empty string fails validation.
+[`STRING`](/schema/STRING) is the ready-made sugar instance for an unconstrained string; [`REQUIRED_STRING`](/schema/REQUIRED_STRING) is a `StringSchema` with `min: 1`, so an empty string fails validation.
 
 ## Usage
 
-### The `STRING` and `REQUIRED_STRING` constants
+### Sugar instances
+
+To save creating a new instance of `StringSchema` for trivial uses, you can use the [`STRING`](/schema/STRING) or [`REQUIRED_STRING`](/schema/REQUIRED_STRING) sugar instances instead. The module also ships [`TITLE`](/schema/TITLE) and [`NAME`](/schema/NAME) (1–100 characters) and their nullable variants [`NULLABLE_TITLE`](/schema/NULLABLE_TITLE) and [`NULLABLE_NAME`](/schema/NULLABLE_NAME).
 
 ```ts
 import { STRING, REQUIRED_STRING } from "shelving/schema";

--- a/modules/schema/StringSchema.ts
+++ b/modules/schema/StringSchema.ts
@@ -148,7 +148,7 @@ export class StringSchema extends Schema<string> {
 }
 
 /**
- * Valid string, e.g. `Hello there!`
+ * Sugar instance of [`StringSchema`](/schema/StringSchema) for an unconstrained string. Equivalent to `new StringSchema({})`.
  *
  * @example
  *  STRING.validate(123); // Returns "123"
@@ -158,7 +158,7 @@ export class StringSchema extends Schema<string> {
 export const STRING = new StringSchema({});
 
 /**
- * Valid string, `Hello there!`, with more than one character.
+ * Sugar instance of [`StringSchema`](/schema/StringSchema) requiring at least one character. Equivalent to `new StringSchema({ min: 1 })`.
  *
  * @example
  *  REQUIRED_STRING.validate(""); // Throws "Required"
@@ -168,7 +168,7 @@ export const STRING = new StringSchema({});
 export const REQUIRED_STRING = new StringSchema({ min: 1 });
 
 /**
- * Title string, e.g. `Title of something` (1–100 characters).
+ * Sugar instance of [`StringSchema`](/schema/StringSchema) for a title of 1–100 characters. Equivalent to `new StringSchema({ one: "title", title: "Title", min: 1, max: 100 })`.
  *
  * @example
  *  TITLE.validate("My Title"); // Returns "My Title"
@@ -178,7 +178,7 @@ export const REQUIRED_STRING = new StringSchema({ min: 1 });
 export const TITLE = new StringSchema({ one: "title", title: "Title", min: 1, max: 100 });
 
 /**
- * Optional title string, e.g. `Title of something` or `null`.
+ * Sugar instance allowing a [`TITLE`](/schema/TITLE) or `null`. Equivalent to `NULLABLE(TITLE)`.
  *
  * @example
  *  NULLABLE_TITLE.validate(null); // Returns null
@@ -188,7 +188,7 @@ export const TITLE = new StringSchema({ one: "title", title: "Title", min: 1, ma
 export const NULLABLE_TITLE = NULLABLE(TITLE);
 
 /**
- * Name string, e.g. `Name of Something` (1–100 characters).
+ * Sugar instance of [`StringSchema`](/schema/StringSchema) for a name of 1–100 characters. Equivalent to `new StringSchema({ one: "name", title: "Name", min: 1, max: 100 })`.
  *
  * @example
  *  NAME.validate("Dave"); // Returns "Dave"
@@ -198,7 +198,7 @@ export const NULLABLE_TITLE = NULLABLE(TITLE);
 export const NAME = new StringSchema({ one: "name", title: "Name", min: 1, max: 100 });
 
 /**
- * Optional name string, e.g. `Name of Something` or `null`.
+ * Sugar instance allowing a [`NAME`](/schema/NAME) or `null`. Equivalent to `NULLABLE(NAME)`.
  *
  * @example
  *  NULLABLE_NAME.validate(null); // Returns null

--- a/modules/schema/TimeSchema.ts
+++ b/modules/schema/TimeSchema.ts
@@ -47,7 +47,7 @@ export class TimeSchema extends DateSchema {
 }
 
 /**
- * Valid time, e.g. `23:59` (required because falsy values are invalid).
+ * Sugar instance of [`TimeSchema`](/schema/TimeSchema) for a required abstract time. Equivalent to `new TimeSchema({})`.
  *
  * @example TIME.validate("23:59") // "23:59:00.000"
  * @see https://dhoulb.github.io/shelving/schema/TimeSchema/TIME
@@ -55,7 +55,7 @@ export class TimeSchema extends DateSchema {
 export const TIME = new TimeSchema({});
 
 /**
- * Valid time, e.g. `23:59`, or `null`.
+ * Sugar instance allowing a [`TIME`](/schema/TIME) or `null`. Equivalent to `NULLABLE(TIME)`.
  *
  * @example NULLABLE_TIME.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/TimeSchema/NULLABLE_TIME

--- a/modules/schema/URISchema.ts
+++ b/modules/schema/URISchema.ts
@@ -96,9 +96,7 @@ export class URISchema extends StringSchema {
 }
 
 /**
- * Valid URI string, e.g. `https://www.google.com`.
- *
- * *Factory for `URISchema`.*
+ * Sugar instance of [`URISchema`](/schema/URISchema) for an absolute URI string. Equivalent to `new URISchema({})`.
  *
  * @example URI_SCHEMA.validate("https://www.google.com") // "https://www.google.com/"
  * @see https://dhoulb.github.io/shelving/schema/URISchema/URI_SCHEMA
@@ -106,9 +104,7 @@ export class URISchema extends StringSchema {
 export const URI_SCHEMA = new URISchema({});
 
 /**
- * Valid URI string, e.g. `https://www.google.com`, or `null`.
- *
- * *Factory for `NullableSchema`.*
+ * Sugar instance allowing a [`URI_SCHEMA`](/schema/URI_SCHEMA) or `null`. Equivalent to `NULLABLE(URI_SCHEMA)`.
  *
  * @example NULLABLE_URI_SCHEMA.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/URISchema/NULLABLE_URI_SCHEMA

--- a/modules/schema/URLSchema.ts
+++ b/modules/schema/URLSchema.ts
@@ -102,9 +102,7 @@ export class URLSchema extends StringSchema {
 }
 
 /**
- * Valid URL string, e.g. `https://www.google.com`.
- *
- * *Factory for `URLSchema`.*
+ * Sugar instance of [`URLSchema`](/schema/URLSchema) for an absolute or relative URL string. Equivalent to `new URLSchema({})`.
  *
  * @example URL_SCHEMA.validate("https://www.google.com") // "https://www.google.com/"
  * @see https://dhoulb.github.io/shelving/schema/URLSchema/URL_SCHEMA
@@ -112,9 +110,7 @@ export class URLSchema extends StringSchema {
 export const URL_SCHEMA = new URLSchema({});
 
 /**
- * Valid URL string, e.g. `https://www.google.com`, or `null`.
- *
- * *Factory for `NullableSchema`.*
+ * Sugar instance allowing a [`URL_SCHEMA`](/schema/URL_SCHEMA) or `null`. Equivalent to `NULLABLE(URL_SCHEMA)`.
  *
  * @example NULLABLE_URL_SCHEMA.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/URLSchema/NULLABLE_URL_SCHEMA

--- a/modules/schema/UUIDSchema.ts
+++ b/modules/schema/UUIDSchema.ts
@@ -44,9 +44,7 @@ export class UUIDSchema extends StringSchema {
 }
 
 /**
- * Any valid UUID (versions 1-5).
- *
- * *Factory for `UUIDSchema`.*
+ * Sugar instance of [`UUIDSchema`](/schema/UUIDSchema) for any valid UUID (versions 1-5). Equivalent to `new UUIDSchema({ title: "ID" })`.
  *
  * @example UUID.validate("F47AC10B-58CC-4372-A567-0E02B2C3D479") // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
  * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUID
@@ -54,9 +52,7 @@ export class UUIDSchema extends StringSchema {
 export const UUID = new UUIDSchema({ title: "ID" });
 
 /**
- * Any valid UUID (versions 1-5), or `null`.
- *
- * *Factory for `NullableSchema`.*
+ * Sugar instance allowing a [`UUID`](/schema/UUID) or `null`. Equivalent to `NULLABLE(UUID)`.
  *
  * @example NULLABLE_UUID.validate(null) // null
  * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/NULLABLE_UUID


### PR DESCRIPTION
## Summary

This PR standardizes the documentation for sugar instances and factories across the schema module, establishing consistent patterns for docblocks and markdown files. It distinguishes between two types of sugar: pre-instantiated constants (sugar instances) and functions that build schemas (sugar factories).

## Key Changes

- **Updated AGENTS.md** with comprehensive guidance on documenting sugar instances and factories:
  - Sugar instances: Pre-instantiated `Schema` classes exported as `ALL_CAPS` constants
  - Sugar factories: Functions that call `new SomeClass(...)` with sensible defaults
  - Specified exact docblock format for each type, including markdown links to class documentation
  - Updated canonical wording from "Factory for" to "Sugar factory for" with proper linking

- **Standardized all sugar instance docblocks** across schema modules to follow the pattern:
  - First line states the class it instantiates (as a docs-site markdown link) and the equivalent constructor call
  - For composed instances (e.g., `NULLABLE_TITLE = NULLABLE(TITLE)`), names the factory call instead
  - Applied to: `NumberSchema`, `StringSchema`, `BooleanSchema`, `CurrencyAmountSchema`, `AddressSchema`, `ColorSchema`, `CountrySchema`, `CurrencyCodeSchema`, `DateSchema`, `DateTimeSchema`, `EmailSchema`, `EntitySchema`, `FileSchema`, `KeySchema`, `PhoneSchema`, `TimeSchema`, `SlugSchema`, `URISchema`, `URLSchema`, `UUIDSchema`, and `PasswordSchema`

- **Standardized all sugar factory docblocks** to use the canonical wording:
  - Changed from `*Factory for \`ClassName\`.*` to `*Sugar factory for [\`ClassName\`](/schema/ClassName).*`
  - Applied to: `DATA`, `NULLABLE_DATA`, `PARTIAL`, `ITEM`, `ARRAY`, `CHOICE`, `DICTIONARY`, `NULLABLE`, `OPTIONAL`, `REQUIRED`, `CURRENCY_AMOUNT`, `NULLABLE_CURRENCY_AMOUNT`

- **Updated markdown documentation files** to reference sugar instances and factories with proper links:
  - `BooleanSchema.md`, `NumberSchema.md`, `StringSchema.md`, `ArraySchema.md`, `ChoiceSchema.md`, `CurrencyAmountSchema.md`, `DataSchema.md`, `DictionarySchema.md`, `NullableSchema.md`, `OptionalSchema.md`
  - Updated `README.md` to clarify the distinction between sugar instances and factories

## Notable Implementation Details

- All sugar instance docblocks now include the exact equivalent constructor or factory call for clarity
- Markdown links use the format `[`ClassName`](/schema/ClassName)` for consistency with the docs site
- Nullable variants of sugar instances reference their wrapped instance (e.g., `NULLABLE(NUMBER)`) rather than repeating the full constructor
- The changes maintain backward compatibility—only documentation is updated, no functional code changes

https://claude.ai/code/session_01E2FJjkE258uYdeZycxvsCE