### PR TITLE
Add DocumentationHomePage component for site landing page

### DIFF
--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement } from "react";
+import { DocumentationHomePage } from "../modules/ui/docs/DocumentationHomePage.js";
 import { MetaContext } from "../modules/ui/misc/MetaContext.js";
 import { Navigation } from "../modules/ui/router/Navigation.js";
 import { TreeApp } from "../modules/ui/tree/TreeApp.js";
+import { TreeRouterMapping } from "../modules/ui/tree/TreeRouter.js";
 import { createMeta, type PossibleMeta } from "../modules/ui/util/meta.js";
 import type { TreeElement } from "../modules/util/tree.js";
 
@@ -25,7 +27,10 @@ export function App({ tree, meta }: AppProps): ReactElement {
 	return (
 		<MetaContext value={createMeta(meta)}>
 			<Navigation>
-				<TreeApp tree={tree} />
+				{/* Render the root (`/`) with the custom home page; deeper paths keep their default renderers. */}
+				<TreeRouterMapping mapping={{ "tree-element": DocumentationHomePage }}>
+					<TreeApp tree={tree} />
+				</TreeRouterMapping>
 			</Navigation>
 		</MetaContext>
 	);

--- a/modules/ui/block/Panel.module.css
+++ b/modules/ui/block/Panel.module.css
@@ -2,10 +2,10 @@
 
 /*
  * Full-width vertical region that paints the current surface. Panels always have zero block-space
- * (they butt up against each other vertically to create stacked page sections) but they do have
- * vertical `padding-block` — `xxlarge` by default, overridable via PaddingVariants (`.padding-large`,
- * `.padding-none`, etc.). Inline padding is fixed at `--space-normal`; if you want narrower content
- * inside a wide panel, compose a `<Block narrow>` (or `<Block wide>`) inside it.
+ * (they butt up against each other vertically to create stacked page sections). Vertical breathing
+ * room comes from the shared `padding` variant (`.large`, `.xxlarge`, etc. from `style/Padding`);
+ * with no `padding` the block padding is zero and the inner `<Section>` margins provide the spacing.
+ * For narrower content inside a wide panel, compose a `<Block narrow>` (or `<Block wide>`) inside it.
  */
 @layer components {
 	.panel {

--- a/modules/ui/block/Panel.tsx
+++ b/modules/ui/block/Panel.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { type ColorVariants, getColorClass } from "../style/Color.js";
+import { getPaddingClass, type PaddingVariants } from "../style/Padding.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
 import { getTypographyClass, type TypographyVariants } from "../style/Typography.js";
 import { getClass, getModuleClass } from "../util/css.js";
@@ -20,20 +21,20 @@ export type PanelElement = "section" | "header" | "footer" | "nav" | "aside" | "
  *
  * @see https://dhoulb.github.io/shelving/ui/block/Panel/PanelProps
  */
-export interface PanelProps extends ColorVariants, StatusVariants, TypographyVariants, OptionalChildProps {}
+export interface PanelProps extends ColorVariants, PaddingVariants, StatusVariants, TypographyVariants, OptionalChildProps {}
 
 /**
  * Full-width vertical region that paints the current surface colour. Use to break a page into stacked
- * sections. Has zero block-space (Panels butt against each other) but big vertical padding by
- * default — adjust with the `padding` prop (`<Panel padding="large">` etc.).
+ * sections. Has zero block-space (Panels butt against each other); set its vertical breathing room
+ * with the `padding` variant (`<Panel padding="large">`, `<Panel padding="xxlarge">` etc.).
  *
  * Renders as a `<section>` by default; pass `as="header"` etc. for other semantic elements.
  *
  * @kind component
- * @param props Colour, status, and typography variants plus `children`.
+ * @param props Colour, padding, status, and typography variants plus `children`.
  * @returns Rendered full-width panel region.
  * @example <Panel><Block narrow><Title>Welcome</Title></Block></Panel>
- * @example <Panel as="header" color="primary"><Title>Welcome</Title></Panel>
+ * @example <Panel padding="xlarge" color="primary"><Title>Welcome</Title></Panel>
  * @see https://dhoulb.github.io/shelving/ui/block/Panel/Panel
  */
 export function Panel({ children, ...props }: PanelProps): ReactElement {
@@ -43,6 +44,7 @@ export function Panel({ children, ...props }: PanelProps): ReactElement {
 				PANEL_CLASS, //
 				getStatusClass(props),
 				getColorClass(props),
+				getPaddingClass(props),
 				getTypographyClass(props),
 			)}
 		>

--- a/modules/ui/docs/DocumentationHomePage.md
+++ b/modules/ui/docs/DocumentationHomePage.md
@@ -1,0 +1,42 @@
+# DocumentationHomePage
+
+The landing page for a documentation site — a bold coloured hero panel with the package name, sitting above the listing of every module. Swap it in for the root element via [`TreeRouterMapping`](/ui/TreeRouter) so the home route (`/`) renders this instead of the generic [`TreePage`](/ui/TreePage).
+
+**Things to know:**
+
+- The whole page sits inside one `color="red"` [`Block`](/ui/Block), so the hero [`Panel`](/ui/Panel), prose, and child [`DocumentationCard`](/ui/DocumentationCard)s all inherit the red tint and re-derive together.
+- The hero is a `padding="xxlarge"` [`Panel`](/ui/Panel) with the package name centred as a large [`Title`](/ui/Title) (`center`, `size="xxlarge"`).
+- Below the hero it renders any absorbed README prose, then the root's children (the modules) as a stack of cards via [`TreeCards`](/ui/TreeCards).
+- It consumes the same [`TreeElementProps`](/util/tree) as [`TreePage`](/ui/TreePage), so it's a drop-in replacement for the `tree-element` renderer.
+
+## Usage
+
+Wire it in as the renderer for the root `tree-element` so the home route uses it:
+
+```tsx
+import { DocumentationHomePage, TreeApp, TreeRouterMapping } from "shelving/ui";
+
+<TreeRouterMapping mapping={{ "tree-element": DocumentationHomePage }}>
+  <TreeApp tree={tree} />
+</TreeRouterMapping>
+```
+
+Or render a single page manually by spreading the root element's props:
+
+```tsx
+import { DocumentationHomePage } from "shelving/ui";
+
+<DocumentationHomePage {...root.props} />
+```
+
+## Styling
+
+`DocumentationHomePage` has no own CSS hooks — it composes [`Page`](/ui/Page), [`Block`](/ui/Block), [`Panel`](/ui/Panel), [`Title`](/ui/Title), [`Section`](/ui/Section), and [`TreeCards`](/ui/TreeCards), which carry their own themeable surfaces. Retheme through those, or change the hero colour via the `color=` on the wrapping `Block`.
+
+## See also
+
+- [`TreePage`](/ui/TreePage) — the generic `tree-element` renderer this replaces for the home route.
+- [`DocumentationPage`](/ui/DocumentationPage) — the per-symbol detail page that uses the same coloured-panel hero pattern.
+- [`Panel`](/ui/Panel) — the full-width hero band, here with `padding="xxlarge"`.
+- [`TreeCards`](/ui/TreeCards) — the module card listing rendered below the hero.
+- [`TreeApp`](/ui/TreeApp) — wires renderers into a complete site.

--- a/modules/ui/docs/DocumentationHomePage.test.tsx
+++ b/modules/ui/docs/DocumentationHomePage.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DocumentationElement } from "../../util/tree.js";
+import { MetaContext } from "../misc/MetaContext.js";
+import { createMeta } from "../util/meta.js";
+import { DocumentationHomePage } from "./DocumentationHomePage.js";
+
+/** Make a minimal `kind: "module"` child element. */
+function mod(name: string): DocumentationElement {
+	return { type: "tree-documentation", key: name, props: { name, kind: "module" } };
+}
+
+/** Render inside a `MetaContext` — the child cards read the current URL from it. */
+function render(node: ReactNode, url = "./"): string {
+	return renderToStaticMarkup(<MetaContext value={createMeta({ root: "http://x.com/", url })}>{node}</MetaContext>);
+}
+
+describe("DocumentationHomePage", () => {
+	test("renders the title as a hero and lists the modules", () => {
+		const html = render(
+			<DocumentationHomePage name="shelving" title="shelving">
+				{[mod("util"), mod("schema")]}
+			</DocumentationHomePage>,
+		);
+		expect(html).toContain("shelving");
+		expect(html).toContain("util");
+		expect(html).toContain("schema");
+	});
+
+	test("falls back to `name` when no `title` is set", () => {
+		const html = render(<DocumentationHomePage name="shelving">{[mod("util")]}</DocumentationHomePage>);
+		expect(html).toContain("shelving");
+	});
+});

--- a/modules/ui/docs/DocumentationHomePage.tsx
+++ b/modules/ui/docs/DocumentationHomePage.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import type { TreeElementProps } from "../../util/tree.js";
+import { Block } from "../block/Block.js";
+import { Panel } from "../block/Panel.js";
+import { Prose } from "../block/Prose.js";
+import { Section } from "../block/Section.js";
+import { Title } from "../block/Title.js";
+import { Markup } from "../misc/Markup.js";
+import { Page } from "../page/Page.js";
+import { TreeCards } from "../tree/TreeCards.js";
+
+/**
+ * Page renderer for the documentation site's home page — a bold coloured hero panel over the module listing.
+ * - The whole page sits in a single `color="red"` `<Block>`, so the hero panel, prose, and child cards all pick up the red tint.
+ * - The hero is a full-padding `<Panel>` with the package name centred as a large `<Title>`.
+ * - Below the hero it renders any absorbed prose content, then the root's children (the modules) as a stack of cards.
+ *
+ * @kind component
+ * @param props The root tree element props (`title`, `name`, `description`, `content`, `children`).
+ * @returns A `<Page>` with a coloured hero panel followed by the module listing.
+ * @example <DocumentationHomePage {...root.props} />
+ * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationHomePage/DocumentationHomePage
+ */
+export function DocumentationHomePage({ title, name, description, content, children }: TreeElementProps): ReactNode {
+	return (
+		<Page title={title ?? name} description={description}>
+			<Block color="red">
+				<Panel padding="xxlarge">
+					<Title center size="xxlarge">
+						{title ?? name}
+					</Title>
+				</Panel>
+				{content && (
+					<Section wide>
+						<Prose>
+							<Markup>{content}</Markup>
+						</Prose>
+					</Section>
+				)}
+				<Section wide>
+					<TreeCards>{children}</TreeCards>
+				</Section>
+			</Block>
+		</Page>
+	);
+}

--- a/modules/ui/docs/index.ts
+++ b/modules/ui/docs/index.ts
@@ -1,5 +1,6 @@
 export * from "./DocumentationButtons.js";
 export * from "./DocumentationCard.js";
+export * from "./DocumentationHomePage.js";
 export * from "./DocumentationKind.js";
 export * from "./DocumentationPage.js";
 export * from "./DocumentationSignatures.js";


### PR DESCRIPTION
## Summary

Adds a new `DocumentationHomePage` component that serves as a custom landing page renderer for documentation sites. This component replaces the generic `TreePage` for the root route, displaying a bold coloured hero panel with the package name above a listing of all modules.

## Changes

- **New component: `DocumentationHomePage`** — A page renderer that displays:
  - A full-width red hero panel with the package name as a large centred title
  - Optional README prose content below the hero
  - Module listing as a stack of cards via `TreeCards`
  - Accepts the same `TreeElementProps` as `TreePage`, making it a drop-in replacement

- **Enhanced `Panel` component** — Added support for the `padding` variant prop:
  - Now accepts `PaddingVariants` to control vertical breathing room
  - Updated documentation to clarify padding control
  - Allows flexible spacing via `.padding-large`, `.padding-xxlarge`, etc.

- **Updated docs site** — Integrated the new component:
  - Wired `DocumentationHomePage` as the renderer for the root `tree-element` via `TreeRouterMapping`
  - Deeper routes continue using default renderers
  - Added export to the public UI module index

- **Documentation and tests** — Includes:
  - Comprehensive markdown documentation with usage examples
  - Unit tests covering title rendering and fallback to `name` prop
  - JSDoc comments with examples and cross-references

## Implementation Details

The component composes existing UI primitives (`Page`, `Block`, `Panel`, `Title`, `Section`, `TreeCards`) to create a cohesive hero-plus-listing layout. The red `Block` wrapper ensures all child elements inherit the colour theme. The `Panel` enhancement enables flexible padding control, supporting the hero's `padding="xxlarge"` requirement while maintaining backward compatibility.

https://claude.ai/code/session_01ADWv5M9DJgim53Go7uJ8Qz