### PR TITLE
Label and group static class members separately

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -81,6 +81,32 @@ export class Store {
 		]);
 	});
 
+	test("labels static members as `static method` / `static property`", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A colour. */
+export class Color {
+	/** Parse a colour. */
+	static from(possible: unknown): Color | undefined { return undefined; }
+	/** Default colour. */
+	static DEFAULT: string = "#000";
+	/** Format the colour. */
+	toString(): string { return ""; }
+	/** Red channel. */
+	red: number;
+}
+`),
+		);
+		const children = element.props.children as unknown[];
+		const cls = children[0] as { props: { children: unknown[] } };
+		expect(cls.props.children).toMatchObject([
+			{ type: "tree-documentation", props: { kind: "static method", name: "from", title: "from()", class: "Color" } },
+			{ type: "tree-documentation", props: { kind: "static property", name: "DEFAULT", title: "DEFAULT", class: "Color" } },
+			{ type: "tree-documentation", props: { kind: "method", name: "toString", title: "toString()", class: "Color" } },
+			{ type: "tree-documentation", props: { kind: "property", name: "red", title: "red", class: "Color" } },
+		]);
+	});
+
 	test("extracts exported interface", async () => {
 		const element = await extractor.extract(
 			file(`

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -100,10 +100,31 @@ export class Color {
 		const children = element.props.children as unknown[];
 		const cls = children[0] as { props: { children: unknown[] } };
 		expect(cls.props.children).toMatchObject([
-			{ type: "tree-documentation", props: { kind: "static method", name: "from", title: "from()", class: "Color" } },
-			{ type: "tree-documentation", props: { kind: "static property", name: "DEFAULT", title: "DEFAULT", class: "Color" } },
-			{ type: "tree-documentation", props: { kind: "method", name: "toString", title: "toString()", class: "Color" } },
-			{ type: "tree-documentation", props: { kind: "property", name: "red", title: "red", class: "Color" } },
+			{
+				type: "tree-documentation",
+				props: {
+					kind: "static method",
+					name: "from",
+					title: "from()",
+					class: "Color",
+					signatures: ["static from(possible: unknown): Color | undefined"],
+				},
+			},
+			{
+				type: "tree-documentation",
+				props: {
+					kind: "static property",
+					name: "DEFAULT",
+					title: "DEFAULT",
+					class: "Color",
+					signatures: ["static DEFAULT: string"],
+				},
+			},
+			{
+				type: "tree-documentation",
+				props: { kind: "method", name: "toString", title: "toString()", class: "Color", signatures: ["toString(): string"] },
+			},
+			{ type: "tree-documentation", props: { kind: "property", name: "red", title: "red", class: "Color", signatures: ["red: number"] } },
 		]);
 	});
 

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -361,7 +361,7 @@ function _getReturns(
  * - Members declared with the `override` modifier are skipped — the base class already documents them, so a subclass page lists only its newly-introduced API.
  * - Members declared with the `declare` modifier are skipped — they're ambient type-only re-declarations (e.g. narrowing an inherited property's type), not new API.
  * - Getters/setters fold into a single `property` element per name; a getter with no matching setter is `readonly`.
- * - `static` members are labelled `static method` / `static property` so the docs site groups them in their own sections, separate from instance `method` / `property`.
+ * - `static` members are labelled `static method` / `static property` so the docs site groups them in their own sections, separate from instance `method` / `property`, and their rendered signature is prefixed with the `static ` keyword.
  */
 function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, className: string): DocumentationElement[] | undefined {
 	if (!ts.isClassDeclaration(statement) && !ts.isInterfaceDeclaration(statement)) return;
@@ -378,8 +378,10 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 		// Skip `declare` members — ambient type-only re-declarations (e.g. a subclass narrowing an inherited property's type), not new API.
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword)) continue;
 
-		// `static` members are grouped and labelled separately from instance members (`static method` / `static property`).
+		// `static` members are grouped and labelled separately from instance members (`static method` / `static property`),
+		// and carry the `static ` keyword in their rendered signature.
 		const isStatic = modifiers?.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
+		const staticPrefix = isStatic ? "static " : "";
 
 		const memberJSDoc = _getJSDoc(member, source);
 		const content = _buildJSDocContent(memberJSDoc?.description, memberJSDoc?.unhandled);
@@ -388,7 +390,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 		if (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) {
 			const params = member.parameters.map(p => p.getText(source)).join(", ");
 			const ret = member.type ? member.type.getText(source) : "void";
-			const signature = `${name}(${params}): ${ret}`;
+			const signature = `${staticPrefix}${name}(${params}): ${ret}`;
 			const key = name;
 			const existingIndex = members.findIndex(m => m.key === key);
 			const existing = members[existingIndex];
@@ -426,7 +428,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 					kind: isStatic ? "static property" : "property",
 					class: className,
 					readonly,
-					signatures: type ? [`${readonly ? "readonly " : ""}${name}: ${type}`] : undefined,
+					signatures: type ? [`${staticPrefix}${readonly ? "readonly " : ""}${name}: ${type}`] : undefined,
 				},
 			});
 		} else if (ts.isGetAccessor(member) || ts.isSetAccessor(member)) {
@@ -442,7 +444,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 						...existing.props,
 						// A getter + setter pair is writable — drop the read-only flag and the `readonly ` signature prefix.
 						readonly: undefined,
-						signatures: type ? [`${name}: ${type}`] : existing.props.signatures,
+						signatures: type ? [`${staticPrefix}${name}: ${type}`] : existing.props.signatures,
 					},
 				};
 			} else {
@@ -457,7 +459,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 						kind: isStatic ? "static property" : "property",
 						class: className,
 						readonly: ts.isGetAccessor(member) || undefined,
-						signatures: type ? [`${ts.isGetAccessor(member) ? "readonly " : ""}${name}: ${type}`] : undefined,
+						signatures: type ? [`${staticPrefix}${ts.isGetAccessor(member) ? "readonly " : ""}${name}: ${type}`] : undefined,
 					},
 				});
 			}

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -361,6 +361,7 @@ function _getReturns(
  * - Members declared with the `override` modifier are skipped — the base class already documents them, so a subclass page lists only its newly-introduced API.
  * - Members declared with the `declare` modifier are skipped — they're ambient type-only re-declarations (e.g. narrowing an inherited property's type), not new API.
  * - Getters/setters fold into a single `property` element per name; a getter with no matching setter is `readonly`.
+ * - `static` members are labelled `static method` / `static property` so the docs site groups them in their own sections, separate from instance `method` / `property`.
  */
 function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, className: string): DocumentationElement[] | undefined {
 	if (!ts.isClassDeclaration(statement) && !ts.isInterfaceDeclaration(statement)) return;
@@ -376,6 +377,9 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword)) continue;
 		// Skip `declare` members — ambient type-only re-declarations (e.g. a subclass narrowing an inherited property's type), not new API.
 		if (modifiers?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword)) continue;
+
+		// `static` members are grouped and labelled separately from instance members (`static method` / `static property`).
+		const isStatic = modifiers?.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
 
 		const memberJSDoc = _getJSDoc(member, source);
 		const content = _buildJSDocContent(memberJSDoc?.description, memberJSDoc?.unhandled);
@@ -402,7 +406,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 						title: `${name}()`,
 						description,
 						content,
-						kind: "method",
+						kind: isStatic ? "static method" : "method",
 						class: className,
 						signatures: [signature],
 					},
@@ -419,7 +423,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 					title: name,
 					description,
 					content,
-					kind: "property",
+					kind: isStatic ? "static property" : "property",
 					class: className,
 					readonly,
 					signatures: type ? [`${readonly ? "readonly " : ""}${name}: ${type}`] : undefined,
@@ -450,7 +454,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 						title: name,
 						description,
 						content,
-						kind: "property",
+						kind: isStatic ? "static property" : "property",
 						class: className,
 						readonly: ts.isGetAccessor(member) || undefined,
 						signatures: type ? [`${ts.isGetAccessor(member) ? "readonly " : ""}${name}: ${type}`] : undefined,

--- a/modules/ui/docs/DocumentationKind.tsx
+++ b/modules/ui/docs/DocumentationKind.tsx
@@ -8,7 +8,7 @@ import type { UIColor } from "../style/Color.js";
  * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKindProps
  */
 export interface DocumentationKindProps extends TagProps {
-	/** The documentation kind (e.g. `"component"`, `"function"`, `"class"`, `"interface"`, `"type"`, `"constant"`, `"method"`, `"property"`). */
+	/** The documentation kind (e.g. `"component"`, `"function"`, `"class"`, `"interface"`, `"type"`, `"constant"`, `"method"`, `"static method"`, `"property"`, `"static property"`). */
 	readonly kind: string;
 }
 
@@ -23,10 +23,12 @@ const KIND_COLOR: { readonly [K in string]?: UIColor } = {
 	class: "purple",
 	function: "blue",
 	method: "blue",
+	"static method": "blue",
 	interface: "aqua",
 	type: "aqua",
 	constant: "green",
 	property: "yellow",
+	"static property": "yellow",
 };
 
 /**

--- a/modules/ui/docs/DocumentationPage.test.tsx
+++ b/modules/ui/docs/DocumentationPage.test.tsx
@@ -41,4 +41,20 @@ describe("DocumentationPage", () => {
 		expect(html).not.toContain("Functions");
 		expect(html).not.toContain("Interfaces");
 	});
+
+	test("groups static members into their own sections, before instance sections", () => {
+		const html = render(
+			<DocumentationPage path="/Color" name="Color" kind="class">
+				{[doc("from", "static method"), doc("DEFAULT", "static property"), doc("toString", "method"), doc("red", "property")]}
+			</DocumentationPage>,
+			"./Color",
+		);
+		expect(html).toContain("Static methods");
+		expect(html).toContain("Static properties");
+		expect(html).toContain("Methods");
+		expect(html).toContain("Properties");
+		// Static sections render before their instance counterparts (the `Methods` / `Properties` headings use a capital, so they don't match inside `Static methods`).
+		expect(html.indexOf("Static methods")).toBeLessThan(html.indexOf("Methods"));
+		expect(html.indexOf("Static properties")).toBeLessThan(html.indexOf("Properties"));
+	});
 });

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -31,6 +31,8 @@ const KIND_SECTIONS = {
 	interface: "Interfaces",
 	type: "Types",
 	constant: "Constants",
+	"static method": "Static methods",
+	"static property": "Static properties",
 	method: "Methods",
 	property: "Properties",
 };


### PR DESCRIPTION
## Summary
Add support for distinguishing static class members from instance members in documentation. Static methods and properties are now labeled as `"static method"` and `"static property"` respectively, allowing the documentation site to render them in separate sections with the `static` keyword prefix in their signatures.

## Changes
- **TypescriptExtractor.ts**: Updated `_getClassMembers()` to detect static members via the `StaticKeyword` modifier and:
  - Prefix signatures with `"static "` keyword
  - Label static methods as `"static method"` instead of `"method"`
  - Label static properties as `"static property"` instead of `"property"`
  - Updated JSDoc comment to document this behavior

- **DocumentationPage.tsx**: Added section mappings for static members:
  - `"static method"` → "Static methods"
  - `"static property"` → "Static properties"
  - Static sections render before their instance counterparts

- **DocumentationKind.tsx**: Updated kind color mappings to support the new static kinds (using same colors as their instance counterparts)

- **Tests**: 
  - Added comprehensive test in TypescriptExtractor.test.ts validating static method/property extraction and labeling
  - Added test in DocumentationPage.test.tsx verifying static sections render before instance sections

## Implementation Details
Static members are identified by checking for the `StaticKeyword` modifier on class members. The `staticPrefix` variable is used consistently across method signatures, property signatures, and getter/setter signatures to ensure the `static` keyword appears in all rendered documentation.

https://claude.ai/code/session_01NtwjNVJZxSdh5F5hoRLiXj