### PR TITLE
Qualify member titles with class name in documentation

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -75,9 +75,9 @@ export class Store {
 		expect(cls.props.children).toMatchObject([
 			{
 				type: "tree-documentation",
-				props: { kind: "property", name: "value", title: "value", class: "Store", signatures: ["value: string"] },
+				props: { kind: "property", name: "value", title: "Store.value", class: "Store", signatures: ["value: string"] },
 			},
-			{ type: "tree-documentation", props: { kind: "method", name: "set", title: "set()", class: "Store" } },
+			{ type: "tree-documentation", props: { kind: "method", name: "set", title: "Store.set()", class: "Store" } },
 		]);
 	});
 
@@ -168,7 +168,7 @@ export function first<T>(arr: T[]): T | undefined {
 		expect(element.key).toBe("array.ts");
 	});
 
-	test("sets title with () for functions and methods, bare name for other kinds", async () => {
+	test("sets title with () for functions, Class.name() for methods, Class.name for properties, bare name for other kinds", async () => {
 		const element = await extractor.extract(
 			file(`
 /** A function. */
@@ -196,8 +196,8 @@ export class Widget {
 					name: "Widget",
 					title: "Widget",
 					children: [
-						{ props: { kind: "property", name: "size", title: "size" } },
-						{ props: { kind: "method", name: "resize", title: "resize()" } },
+						{ props: { kind: "property", name: "size", title: "Widget.size" } },
+						{ props: { kind: "method", name: "resize", title: "Widget.resize()" } },
 					],
 				},
 			},
@@ -265,7 +265,7 @@ export class MemoryStore extends AbstractStore {
 		const cls = (element.props.children as { props: { children: { props: Record<string, unknown> }[] } }[])[0];
 		// Only the directly-implemented `value` survives — `get()` and `size` carry `override` and are documented on the base class.
 		expect(cls?.props.children).toMatchObject([
-			{ props: { kind: "property", name: "value", title: "value", class: "MemoryStore", readonly: true } },
+			{ props: { kind: "property", name: "value", title: "MemoryStore.value", class: "MemoryStore", readonly: true } },
 		]);
 		expect(cls?.props.children).toHaveLength(1);
 	});
@@ -289,13 +289,13 @@ export class Store {
 				props: {
 					kind: "property",
 					name: "size",
-					title: "size",
+					title: "Store.size",
 					class: "Store",
 					readonly: true,
 					signatures: ["readonly size: number"],
 				},
 			},
-			{ props: { kind: "property", name: "name", title: "name", class: "Store", signatures: ["name: string"] } },
+			{ props: { kind: "property", name: "name", title: "Store.name", class: "Store", signatures: ["name: string"] } },
 		]);
 		// The getter+setter pair must NOT be flagged readonly.
 		expect((cls?.props.children[1]?.props as { readonly?: boolean }).readonly).toBeUndefined();
@@ -337,7 +337,7 @@ export class BooleanSchema extends Schema {
 		);
 		const cls = (element.props.children as { props: { children: { props: Record<string, unknown> }[] } }[])[0];
 		// The `declare` field is omitted; only the genuinely-new `check()` survives.
-		expect(cls?.props.children).toMatchObject([{ props: { kind: "method", name: "check", title: "check()" } }]);
+		expect(cls?.props.children).toMatchObject([{ props: { kind: "method", name: "check", title: "BooleanSchema.check()" } }]);
 		expect(cls?.props.children).toHaveLength(1);
 	});
 

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -21,7 +21,7 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - A `@kind` tag in a symbol's JSDoc overrides the inferred kind — e.g. `@kind component` relabels a React component (otherwise a `function`) so the docs site groups and colours it as a component. The override also drops the trailing `()` from the title, since a non-function kind reads as a bare name.
  * - Top-of-file JSDoc comment becomes the file's `content`.
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on the file and every `tree-documentation` child.
- * - Sets `title` on every `tree-documentation` child — `name()` for functions and methods, bare `name` for other kinds. Parent class context comes from the `class` prop ("member of …" affordance), never the title.
+ * - Sets `title` on every `tree-documentation` child — `name()` for functions, `Class.name()` for methods, `Class.name` for properties, bare `name` for other kinds.
  * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`.
  * - Members declared with the `override` or `declare` modifier are skipped — the base class already documents overrides, and `declare` members are ambient type-only re-declarations rather than new API.
  * - Keys are the raw declared `name` (case-preserving) so case-distinct exports like `Collection` and `COLLECTION` stay separate.
@@ -357,7 +357,7 @@ function _getReturns(
 
 /**
  * Extract class or interface members as child elements.
- * - `className` is stamped onto every member as its `class` prop (the source of the qualified flat key and the "member of …" affordance); the title stays the bare member `name` / `name()`.
+ * - `className` is stamped onto every member as its `class` prop (the source of the qualified flat key and the "member of …" affordance) and is prebaked into the member `title` (`Class.name` / `Class.name()`).
  * - Members declared with the `override` modifier are skipped — the base class already documents them, so a subclass page lists only its newly-introduced API.
  * - Members declared with the `declare` modifier are skipped — they're ambient type-only re-declarations (e.g. narrowing an inherited property's type), not new API.
  * - Getters/setters fold into a single `property` element per name; a getter with no matching setter is `readonly`.
@@ -399,7 +399,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 					key,
 					props: {
 						name,
-						title: `${name}()`,
+						title: `${className}.${name}()`,
 						description,
 						content,
 						kind: "method",
@@ -416,7 +416,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 				key: name,
 				props: {
 					name,
-					title: name,
+					title: `${className}.${name}`,
 					description,
 					content,
 					kind: "property",
@@ -447,7 +447,7 @@ function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, classN
 					key,
 					props: {
 						name,
-						title: name,
+						title: `${className}.${name}`,
 						description,
 						content,
 						kind: "property",


### PR DESCRIPTION
## Summary
Updated the TypeScript documentation extractor to include class names in the `title` field of class members, improving clarity in documentation output.

## Changes
- **Method titles**: Changed from `name()` to `ClassName.name()` for class methods
- **Property titles**: Changed from bare `name` to `ClassName.name` for class properties
- **Documentation**: Updated JSDoc comments to reflect the new title format convention
- **Test expectations**: Updated all test assertions to expect the new qualified title format across multiple test cases

## Implementation Details
The changes were made in `_getClassMembers()` function where member elements are created:
- Method title construction now includes `${className}.${name}()`
- Property title construction now includes `${className}.${name}`
- This provides better context in documentation by showing the full qualified name of each member, making it clearer which class a member belongs to without relying solely on the separate `class` prop

https://claude.ai/code/session_016PyU9VahrWYxnTobe9npsx