### PR TITLE
Fix @example tag parsing to handle multi-line blocks

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -602,6 +602,28 @@ export function add(a: number, b: number): number { return a + b; }
 		expect(children[0]?.props.examples).toEqual([{ description: "add(1, 2)" }, { description: "add(3, 4)" }]);
 	});
 
+	test("parses multi-line @example blocks without leaking the docblock `*` prefix", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Make an endpoint.
+ * @example
+ * const getUser = new Endpoint("GET", "/users/{id}", USER_PAYLOAD, USER_RESULT);
+ * const user = await provider.call(getUser, { id: "abc" });
+ * @see https://example.com/
+ */
+export function make(): void {}
+`),
+		);
+		const children = element.props.children as { props: { examples?: unknown } }[];
+		expect(children[0]?.props.examples).toEqual([
+			{
+				description:
+					'const getUser = new Endpoint("GET", "/users/{id}", USER_PAYLOAD, USER_RESULT);\nconst user = await provider.call(getUser, { id: "abc" });',
+			},
+		]);
+	});
+
 	test("appends unhandled @rule blocks to content", async () => {
 		const element = await extractor.extract(
 			file(`

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -627,15 +627,38 @@ function _parseJSDocThrows(text: string): DocumentationThrow[] {
 	return results;
 }
 
-/** Parse `@example` tags from a JSDoc comment. */
+/**
+ * Parse `@example` tags from a JSDoc comment.
+ * - Strips the `/** ... *​/` delimiters and per-line `*` continuation markers first, so example bodies never include a leading `*`.
+ * - Each `@example` block extends from its tag line (content may start on the same line) up to the next `@tag` or the end of the docblock, so multi-line examples are captured in full.
+ */
 function _parseJSDocExamples(text: string): DocumentationExample[] {
+	const body = text
+		.replace(/^\/\*\*\s*/, "")
+		.replace(/\s*\*\/$/, "")
+		.split("\n")
+		.map(l => l.replace(/^\s*\*\s?/, ""))
+		.join("\n");
+
 	const results: DocumentationExample[] = [];
-	// `@example` followed by the rest of the line.
-	const regexp = /@examples?\s+(.+)/g;
-	let match: RegExpExecArray | null;
-	while ((match = regexp.exec(text))) {
-		const description = match[1]?.trim();
-		if (description) results.push({ description });
+	let currentLines: string[] | undefined;
+	const flush = () => {
+		if (currentLines) {
+			const description = currentLines.join("\n").trim();
+			if (description) results.push({ description });
+		}
+		currentLines = undefined;
+	};
+	for (const line of body.split("\n")) {
+		const match = line.match(/^@(\w+)\s*(.*)$/);
+		if (match) {
+			flush();
+			// Start collecting a new example block; keep any content that followed the tag on the same line.
+			if (match[1] === "example" || match[1] === "examples") currentLines = match[2] ? [match[2]] : [];
+		} else if (currentLines) {
+			currentLines.push(line);
+		}
 	}
+	flush();
 	return results;
 }


### PR DESCRIPTION
## Summary
Improved the `@example` JSDoc tag parser to correctly handle multi-line example blocks while properly stripping JSDoc formatting characters.

## Key Changes
- **Refactored `_parseJSDocExamples()`** to parse the entire JSDoc body first, stripping the `/** ... */` delimiters and per-line `*` continuation markers before processing tags
- **Changed parsing strategy** from regex-based single-line matching to line-by-line iteration that collects all content between `@example` tags and the next `@tag` or end of docblock
- **Preserves multi-line content** by joining collected lines with newlines, allowing examples to span multiple lines without losing formatting
- **Added test case** verifying that multi-line `@example` blocks are parsed correctly without including the docblock `*` prefix characters

## Implementation Details
The new implementation:
1. Normalizes the input by removing JSDoc delimiters and per-line `*` markers upfront
2. Iterates through lines looking for tag markers (`@tagname`)
3. When an `@example` or `@examples` tag is found, starts collecting subsequent lines
4. Stops collecting when another tag is encountered or the docblock ends
5. Trims and stores the accumulated content as a single example description

This approach correctly handles examples that span multiple lines while maintaining clean output without JSDoc formatting artifacts.

https://claude.ai/code/session_0188Najt4nGohi5EdcfQQZTW