### PR TITLE
Refactor form inputs to support width variants

### DIFF
--- a/modules/ui/docs/DocumentationKind.tsx
+++ b/modules/ui/docs/DocumentationKind.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from "react";
-import type { ImmutableArray } from "../../util/array.js";
 import { Tag, type TagProps } from "../misc/Tag.js";
 import type { UIColor } from "../style/Color.js";
-import { Row } from "../style/Flex.js";
 
 /**
  * Props for `DocumentationKind` — a `TagProps` plus the documented symbol's `kind`.
@@ -60,48 +58,5 @@ export function DocumentationKind({ kind = "unknown", ...props }: DocumentationK
 		<Tag color={getDocumentationKindColor(kind)} {...props}>
 			{kind}
 		</Tag>
-	);
-}
-
-/**
- * Props for `DocumentationKindChips` — the kinds to offer plus the currently-selected kind.
- *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKindChipsProps
- */
-export interface DocumentationKindChipsProps {
-	/** The kinds to show as chips, in display order. */
-	readonly kinds: ImmutableArray<string>;
-	/** The currently-selected kind, or `undefined` when none is selected. */
-	readonly value?: string | undefined;
-	/** Called with the clicked kind, or `undefined` when the active chip is clicked again to clear it. */
-	readonly onValue?: ((kind: string | undefined) => void) | undefined;
-}
-
-/**
- * Row of clickable kind-filter chips — clicking a chip selects that kind, clicking the active chip clears it.
- * - Exclusive: at most one kind is selected at a time. The selected chip is shown bold.
- * - Renders `null` when there are no `kinds`.
- *
- * @kind component
- * @param props The `kinds` to offer, the selected `value`, and an `onValue` callback.
- * @returns A `<Row>` of colour-coded `<Tag>` chips, or `null` when there are no kinds.
- * @example <DocumentationKindChips kinds={["function", "class"]} value={kind} onValue={setKind} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKindChips
- */
-export function DocumentationKindChips({ kinds, value, onValue }: DocumentationKindChipsProps): ReactElement | null {
-	if (!kinds.length) return null;
-	return (
-		<Row left wrap>
-			{kinds.map(kind => (
-				<Tag
-					key={kind}
-					color={getDocumentationKindColor(kind)}
-					weight={kind === value ? "strong" : undefined}
-					onClick={() => onValue?.(kind === value ? undefined : kind)}
-				>
-					{kind}
-				</Tag>
-			))}
-		</Row>
 	);
 }

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -1,8 +1,6 @@
-import { Fragment, type ReactNode, useMemo, useState } from "react";
+import { Fragment, type ReactNode } from "react";
 import { walkElements } from "../../util/element.js";
-import type { Query } from "../../util/query.js";
 import type { DocumentationElementProps, TreeElement, TreeElements } from "../../util/tree.js";
-import { searchTree } from "../../util/tree.js";
 import { Block } from "../block/Block.js";
 import { Definitions } from "../block/Definitions.js";
 import { Heading } from "../block/Heading.js";
@@ -12,7 +10,6 @@ import { Preformatted } from "../block/Preformatted.js";
 import { Prose } from "../block/Prose.js";
 import { Header, Section } from "../block/Section.js";
 import { Title } from "../block/Title.js";
-import { TextInput } from "../form/TextInput.js";
 import { Code } from "../inline/Code.js";
 import { Markup } from "../misc/Markup.js";
 import { Page } from "../page/Page.js";
@@ -20,7 +17,7 @@ import { Row } from "../style/Flex.js";
 import { TreeBreadcrumbs } from "../tree/TreeBreadcrumbs.js";
 import { TreeCards } from "../tree/TreeCards.js";
 import { DocumentationButtons } from "./DocumentationButtons.js";
-import { DocumentationKind, DocumentationKindChips, getDocumentationKindColor } from "./DocumentationKind.js";
+import { DocumentationKind, getDocumentationKindColor } from "./DocumentationKind.js";
 import { DocumentationSignatures } from "./DocumentationSignatures.js";
 
 const DEFAULT_TYPE = "unknown";
@@ -53,52 +50,21 @@ function _renderSections(elements: readonly TreeElement[]): ReactNode {
 }
 
 /**
- * Interactive children listing for a documentation page — a filter input, kind chips, and grouped cards.
+ * Children listing for a documentation page — this page's child symbols grouped into kind-based card sections.
  *
- * - Filters this page's own children as you type (ranked via `searchTree`, capped at 20); the kind chips narrow to a single `kind`.
- * - With an empty filter and no chip selected, shows the normal grouped listing of `children`.
- * - Renders nothing when the page has no children (e.g. a leaf symbol) — no point showing an empty filter.
+ * - Renders nothing when the page has no children (e.g. a leaf symbol).
+ * - Cross-tree search and kind filtering live on the index page (`TreeIndexPage`), not here.
  *
  * @param props The page's child elements.
- * @returns The filter controls plus the grouped card sections, or `null` when there are no children.
+ * @returns The grouped card sections, or `null` when there are no children.
  */
 function DocumentationChildren({ elements }: { readonly elements?: TreeElements }): ReactNode {
-	const [query, setQuery] = useState("");
-	const [chip, setChip] = useState<string | undefined>(undefined);
+	const childElements = Array.from(walkElements<TreeElement>(elements));
 
-	const childElements = useMemo(() => Array.from(walkElements<TreeElement>(elements)), [elements]);
-
-	// Kinds present in this page's children, in section order, for the chip row.
-	const kinds = useMemo(
-		() => Object.keys(KIND_SECTIONS).filter(k => childElements.some(el => (el.props as DocumentationElementProps).kind === k)),
-		[childElements],
-	);
-
-	// No children → nothing to list or filter.
+	// No children → nothing to list.
 	if (!childElements.length) return null;
 
-	const trimmed = query.trim();
-	const active = !!trimmed || !!chip;
-
-	// Inactive → normal grouped listing. Active → filter this page's children, grouped the same way.
-	let listing: ReactNode;
-	if (!active) {
-		listing = _renderSections(childElements);
-	} else {
-		const scope: TreeElement = { type: "tree-element", key: "", props: { name: "", children: elements } };
-		const filter = chip ? ({ kind: chip } as Query) : undefined;
-		listing = _renderSections(searchTree(scope, trimmed, { limit: 20, filter }));
-	}
-
-	return (
-		<>
-			<Section wide>
-				<TextInput name="filter" title="Filter" placeholder="Filter…" value={query} onValue={v => setQuery(v ?? "")} />
-				<DocumentationKindChips kinds={kinds} value={chip} onValue={setChip} />
-			</Section>
-			{listing}
-		</>
-	);
+	return _renderSections(childElements);
 }
 
 /**

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -3,14 +3,14 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import { Clickable, type ClickableProps } from "./Clickable.js";
-import { BUTTON_INPUT_CLASS, type InputProps, PLACEHOLDER_CLASS } from "./Input.js";
+import { BUTTON_CLASS, getInputClass, type InputProps, type InputVariants, PLACEHOLDER_CLASS } from "./Input.js";
 
 /**
  * Props for `ButtonInput`, a clickable element styled to match form inputs.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/ButtonInput/ButtonInputProps
  */
-export interface ButtonInputProps extends InputProps, ClickableProps, FlexVariants {}
+export interface ButtonInputProps extends InputProps, ClickableProps, FlexVariants, InputVariants {}
 
 /**
  * Return either a `<button>` or an `<a href="">` styled as an input, based on whether an `onClick` or `href` prop is provided.
@@ -24,7 +24,7 @@ export interface ButtonInputProps extends InputProps, ClickableProps, FlexVarian
 export function ButtonInput({ title, placeholder, children = title, ...props }: ButtonInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<Clickable {...props} className={getClass(BUTTON_INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<Clickable {...props} className={getClass(getInputClass(props), BUTTON_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
 			{hasChildren ? children : placeholder}
 		</Clickable>
 	);

--- a/modules/ui/form/CheckboxInput.tsx
+++ b/modules/ui/form/CheckboxInput.tsx
@@ -3,14 +3,14 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
-import { CHECKBOX_CLASS, LABEL_INPUT_CLASS, PLACEHOLDER_CLASS, type ValueInputProps } from "./Input.js";
+import { CHECKBOX_CLASS, getInputClass, type InputVariants, LABEL_CLASS, PLACEHOLDER_CLASS, type ValueInputProps } from "./Input.js";
 
 /**
  * Props for `CheckboxInput`, a boolean-valued checkbox input.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/CheckboxInput/CheckboxProps
  */
-export interface CheckboxProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants {}
+export interface CheckboxProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants, InputVariants {}
 
 /**
  * Checkbox input bound to a `boolean` value, rendered as a labelled `<input type="checkbox">`.
@@ -35,7 +35,10 @@ export function CheckboxInput({
 }: CheckboxProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={getClass(LABEL_INPUT_CLASS, getFlexClass(variants), hasChildren && PLACEHOLDER_CLASS)} aria-invalid={!!message}>
+		<label
+			className={getClass(getInputClass(variants), LABEL_CLASS, getFlexClass(variants), hasChildren && PLACEHOLDER_CLASS)}
+			aria-invalid={!!message}
+		>
 			<input
 				name={name}
 				type="checkbox"

--- a/modules/ui/form/DateInput.tsx
+++ b/modules/ui/form/DateInput.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { DateInputType } from "../../schema/DateSchema.js";
 import { getDateString, getDateTimeString, getTimeString, type PossibleDate } from "../../util/date.js";
-import { TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type InputVariants, TEXT_CLASS, type ValueInputProps } from "./Input.js";
 
 /** Convert a `PossibleDate` to a string for a specific date `<input type="etc">` type. */
 const _DATE_TO_STRING: { [K in DateInputType]: (d: PossibleDate | undefined) => string | undefined } = {
@@ -15,7 +16,7 @@ const _DATE_TO_STRING: { [K in DateInputType]: (d: PossibleDate | undefined) => 
  *
  * @see https://dhoulb.github.io/shelving/ui/form/DateInput/DateInputProps
  */
-export interface DateInputProps extends ValueInputProps<string, PossibleDate> {
+export interface DateInputProps extends ValueInputProps<string, PossibleDate>, InputVariants {
 	min?: PossibleDate | undefined;
 	max?: PossibleDate | undefined;
 	input?: DateInputType | undefined;
@@ -44,6 +45,7 @@ export function DateInput({
 	max,
 	input = "date",
 	step,
+	...variants
 }: DateInputProps): ReactElement {
 	const onChange = (e: SyntheticEvent<HTMLInputElement>) => {
 		onValue?.(e.currentTarget.value ?? undefined);
@@ -61,7 +63,7 @@ export function DateInput({
 			required={required}
 			defaultValue={dateToString(value)}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(variants), TEXT_CLASS)}
 			onChange={onChange}
 			onInput={onChange}
 			title={message}

--- a/modules/ui/form/FileInput.tsx
+++ b/modules/ui/form/FileInput.tsx
@@ -1,13 +1,13 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { FileTypes } from "../../util/file.js";
-import { INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 
 /**
  * Props for `FileInput`, an `<input type="file">` that emits the selected `File`.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/FileInput/FileInputProps
  */
-export interface FileInputProps extends ValueInputProps<string | File> {
+export interface FileInputProps extends ValueInputProps<string | File>, InputVariants {
 	types?: FileTypes | undefined;
 }
 
@@ -30,6 +30,7 @@ export function FileInput({
 	// value,
 	onValue,
 	types = {},
+	...variants
 }: FileInputProps): ReactElement {
 	const onChange = (e: SyntheticEvent<HTMLInputElement>) => {
 		const files = e.currentTarget.files;
@@ -44,7 +45,7 @@ export function FileInput({
 			required={required}
 			disabled={disabled}
 			placeholder={placeholder}
-			className={INPUT_CLASS}
+			className={getInputClass(variants)}
 			onChange={onChange}
 			onInput={onChange}
 			multiple={false}

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { LOADING } from "../misc/Loading.js";
 import { getFlexClass } from "../style/Flex.js";
+import { getWidthClass, type WidthVariants } from "../style/Width.js";
 import { getClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import INPUT_CSS from "./Input.module.css";
@@ -49,6 +50,50 @@ export const EMPTY_OPTION_CLASS = INPUT_CSS.empty;
  */
 export const VALUE_OPTION_CLASS = INPUT_CSS.value;
 
+// Type modifier classes — layered on top of `getInputClass()` by each input component (never applied by `getInputClass()` itself).
+
+/**
+ * `className` modifier for a single- or multi-line text `<input>`/`<textarea>`.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/TEXT_CLASS
+ */
+export const TEXT_CLASS = INPUT_CSS.text;
+
+/**
+ * `className` modifier for a multiline `<textarea>` (combine with `TEXT_CLASS`).
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/MULTILINE_CLASS
+ */
+export const MULTILINE_CLASS = INPUT_CSS.multiline;
+
+/**
+ * `className` modifier for a `<select>` input.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/SELECT_CLASS
+ */
+export const SELECT_CLASS = INPUT_CSS.select;
+
+/**
+ * `className` modifier for a button styled as an input.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/BUTTON_CLASS
+ */
+export const BUTTON_CLASS = INPUT_CSS.button;
+
+/**
+ * `className` modifier for a `<label>` styled as an input (e.g. checkbox/radio wrappers).
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/LABEL_CLASS
+ */
+export const LABEL_CLASS = INPUT_CSS.label;
+
+/**
+ * `className` modifier for an input wrapper that hosts `data-slot` icon elements.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/WRAPPER_CLASS
+ */
+export const WRAPPER_CLASS = INPUT_CSS.wrapper;
+
 // Precomposed classes.
 
 /**
@@ -56,42 +101,66 @@ export const VALUE_OPTION_CLASS = INPUT_CSS.value;
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/TEXT_INPUT_CLASS
  */
-export const TEXT_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.text);
+export const TEXT_INPUT_CLASS = getClass(INPUT_CLASS, TEXT_CLASS);
 
 /**
  * Precomposed `className` for a multiline `<textarea>`.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/MULTILINE_TEXT_INPUT_CLASS
  */
-export const MULTILINE_TEXT_INPUT_CLASS = getClass(TEXT_INPUT_CLASS, INPUT_CSS.multiline);
+export const MULTILINE_TEXT_INPUT_CLASS = getClass(TEXT_INPUT_CLASS, MULTILINE_CLASS);
 
 /**
  * Precomposed `className` for an input wrapper that hosts `data-slot` icon elements.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/WRAPPER_INPUT_CLASS
  */
-export const WRAPPER_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.wrapper);
+export const WRAPPER_INPUT_CLASS = getClass(INPUT_CLASS, WRAPPER_CLASS);
 
 /**
  * Precomposed `className` for a `<select>` input.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/SELECT_INPUT_CLASS
  */
-export const SELECT_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.select);
+export const SELECT_INPUT_CLASS = getClass(INPUT_CLASS, SELECT_CLASS);
 
 /**
  * Precomposed `className` for a button styled as an input.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/BUTTON_INPUT_CLASS
  */
-export const BUTTON_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.button);
+export const BUTTON_INPUT_CLASS = getClass(INPUT_CLASS, BUTTON_CLASS);
 
 /**
  * Precomposed `className` for a `<label>` styled as an input (e.g. checkbox/radio wrappers).
  *
  * @see https://dhoulb.github.io/shelving/ui/form/Input/LABEL_INPUT_CLASS
  */
-export const LABEL_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.label);
+export const LABEL_INPUT_CLASS = getClass(INPUT_CLASS, LABEL_CLASS);
+
+// Shared input styling.
+
+/**
+ * Styling variants shared by every form input — currently the width variants (`narrow`, `wide`, `full`, `fit`).
+ * - Extends `WidthVariants` so any input can be sized (e.g. `<CheckboxInput fit>` to shrink to its content).
+ * - Designed to grow: new cross-cutting input styling props (e.g. spacing) should be added here so every input picks them up consistently.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/InputVariants
+ */
+export interface InputVariants extends WidthVariants {}
+
+/**
+ * Build the shared `className` for a form input from its styling variants — the base `INPUT_CLASS` plus any `InputVariants`.
+ * - Deliberately does *not* apply the type modifier classes (`TEXT_CLASS`, `SELECT_CLASS`, `BUTTON_CLASS`, etc.); each input layers its own modifier on top of this.
+ *
+ * @param props The input's styling variants (width, …).
+ * @returns The merged base input `className` string.
+ * @example getClass(getInputClass(props), TEXT_CLASS) // a text input that also honours width variants
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/getInputClass
+ */
+export function getInputClass(props: InputVariants): string {
+	return getClass(INPUT_CLASS, getWidthClass(props));
+}
 
 /**
  * Base props shared by every form input (name, title, placeholder, required/disabled state, and error message).

--- a/modules/ui/form/NumberInput.tsx
+++ b/modules/ui/form/NumberInput.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import { formatNumber } from "../../util/format.js";
 import { getNumber } from "../../util/number.js";
-import { TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type InputVariants, TEXT_CLASS, type ValueInputProps } from "./Input.js";
 
 type NumberFormatter = (num: number) => string;
 
@@ -10,7 +11,7 @@ type NumberFormatter = (num: number) => string;
  *
  * @see https://dhoulb.github.io/shelving/ui/form/NumberInput/NumberInputProps
  */
-export interface NumberInputProps extends ValueInputProps<number> {
+export interface NumberInputProps extends ValueInputProps<number>, InputVariants {
 	min?: number | undefined;
 	max?: number | undefined;
 	/** Optional formatter — when provided the input switches to `type="text"` and reformats the value on blur. */
@@ -38,6 +39,7 @@ export function NumberInput({
 	// min = Number.NEGATIVE_INFINITY,
 	// max = Number.POSITIVE_INFINITY,
 	formatter = formatNumber,
+	...variants
 }: NumberInputProps): ReactElement {
 	const onChange = ({ currentTarget }: SyntheticEvent<HTMLInputElement>) => {
 		onValue?.(getNumber(currentTarget.value) ?? undefined);
@@ -57,7 +59,7 @@ export function NumberInput({
 			required={required}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(variants), TEXT_CLASS)}
 			onChange={onChange}
 			onInput={onChange}
 			onBlur={onBlur}

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -3,14 +3,14 @@ import { notNullish } from "../../util/index.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
-import { INPUT_CLASS, type InputProps, PLACEHOLDER_CLASS } from "./Input.js";
+import { getInputClass, type InputProps, type InputVariants, PLACEHOLDER_CLASS } from "./Input.js";
 
 /**
  * Props for `OutputInput`, a read-only `<output>` styled to match form inputs.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/OutputInput/OutputInputProps
  */
-export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVariants {}
+export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVariants, InputVariants {}
 
 /**
  * Show static read-only content styled as an input, falling back to `placeholder` when empty.
@@ -23,7 +23,7 @@ export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVa
 export function OutputInput({ title, placeholder, children = title, ...props }: OutputInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<output {...props} className={getClass(INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<output {...props} className={getClass(getInputClass(props), getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
 			{hasChildren ? children : placeholder}
 		</output>
 	);

--- a/modules/ui/form/RadioInput.tsx
+++ b/modules/ui/form/RadioInput.tsx
@@ -3,14 +3,14 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
-import { LABEL_INPUT_CLASS, PLACEHOLDER_CLASS, RADIO_CLASS, type ValueInputProps } from "./Input.js";
+import { getInputClass, type InputVariants, LABEL_CLASS, PLACEHOLDER_CLASS, RADIO_CLASS, type ValueInputProps } from "./Input.js";
 
 /**
  * Props for `RadioInput`, a single labelled radio button styled as an input.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/RadioInput/RadioInputProps
  */
-export interface RadioInputProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants {}
+export interface RadioInputProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants, InputVariants {}
 
 /**
  * Single `<input type="radio">` wrapped in a `<label>` styled as an `<Input>`.
@@ -35,7 +35,7 @@ export function RadioInput({
 }: RadioInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={getClass(LABEL_INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<label className={getClass(getInputClass(props), LABEL_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
 			<input
 				className={RADIO_CLASS}
 				type="radio"

--- a/modules/ui/form/SelectInput.tsx
+++ b/modules/ui/form/SelectInput.tsx
@@ -1,14 +1,15 @@
 import type { ReactElement } from "react";
 import type { ChoiceOptions } from "../../schema/ChoiceSchema.js";
 import { getProps } from "../../util/object.js";
-import { EMPTY_OPTION_CLASS, SELECT_INPUT_CLASS, VALUE_OPTION_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { EMPTY_OPTION_CLASS, getInputClass, type InputVariants, SELECT_CLASS, VALUE_OPTION_CLASS, type ValueInputProps } from "./Input.js";
 
 /**
  * Props for `SelectInput`, a dropdown `<select>` bound to a string value.
  *
  * @see https://dhoulb.github.io/shelving/ui/form/SelectInput/SelectProps
  */
-export interface SelectProps<T extends string> extends ValueInputProps<T> {
+export interface SelectProps<T extends string> extends ValueInputProps<T>, InputVariants {
 	/** The options for the select. */
 	options: ChoiceOptions<T>;
 }
@@ -32,13 +33,14 @@ export function SelectInput({
 	value = "",
 	onValue,
 	options,
+	...variants
 }: SelectProps<string>): ReactElement {
 	return (
 		<select
 			name={name}
 			defaultValue={value}
 			onChange={e => onValue(e.currentTarget.value || undefined)}
-			className={SELECT_INPUT_CLASS}
+			className={getClass(getInputClass(variants), SELECT_CLASS)}
 			title={message}
 			aria-invalid={!!message}
 			disabled={disabled}

--- a/modules/ui/form/TextInput.tsx
+++ b/modules/ui/form/TextInput.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { StringInputType } from "../../schema/StringSchema.js";
 import { PASSTHROUGH } from "../../util/function.js";
-import { MULTILINE_TEXT_INPUT_CLASS, TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type InputVariants, MULTILINE_CLASS, TEXT_CLASS, type ValueInputProps } from "./Input.js";
 
 type TextFormatter = (str: string) => string;
 
@@ -10,7 +11,7 @@ type TextFormatter = (str: string) => string;
  *
  * @see https://dhoulb.github.io/shelving/ui/form/TextInput/TextInputProps
  */
-export interface TextInputProps extends ValueInputProps<string> {
+export interface TextInputProps extends ValueInputProps<string>, InputVariants {
 	rows?: number | undefined;
 	multiline?: boolean;
 	input?: StringInputType;
@@ -44,6 +45,7 @@ export function TextInput({
 	max = Number.POSITIVE_INFINITY,
 	rows = 1,
 	formatter = PASSTHROUGH,
+	...variants
 }: TextInputProps): ReactElement {
 	const onBlur = ({ currentTarget }: SyntheticEvent<HTMLInputElement | HTMLTextAreaElement>) => {
 		currentTarget.value = formatter(currentTarget.value);
@@ -66,7 +68,7 @@ export function TextInput({
 				required={required && min > 0}
 				disabled={disabled}
 				placeholder={placeholder || " "}
-				className={MULTILINE_TEXT_INPUT_CLASS}
+				className={getClass(getInputClass(variants), TEXT_CLASS, MULTILINE_CLASS)}
 				onInput={onChange}
 				onChange={onChange}
 				onBlur={onBlur}
@@ -90,7 +92,7 @@ export function TextInput({
 			required={required && min > 0}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(variants), TEXT_CLASS)}
 			onInput={onChange}
 			onChange={onChange}
 			onBlur={onBlur}

--- a/modules/ui/style/Width.tsx
+++ b/modules/ui/style/Width.tsx
@@ -13,6 +13,8 @@ export interface WidthVariants {
 	wide?: boolean | undefined;
 	/** Take the full available width — removes any default max-width constraint. */
 	full?: boolean | undefined;
+	/** Shrink to fit the content's intrinsic width (`fit-content`). */
+	fit?: boolean | undefined;
 }
 
 /**

--- a/modules/ui/tree/TreeIndexPage.tsx
+++ b/modules/ui/tree/TreeIndexPage.tsx
@@ -1,13 +1,16 @@
 import { type ReactNode, useMemo, useState } from "react";
+import { type ImmutableArray, toggleArrayItem } from "../../util/array.js";
 import type { AbsolutePath } from "../../util/path.js";
 import type { Query } from "../../util/query.js";
 import type { DocumentationElementProps } from "../../util/tree.js";
 import { searchTree } from "../../util/tree.js";
 import { Header, Section } from "../block/Section.js";
 import { Title } from "../block/Title.js";
-import { DocumentationKindChips } from "../docs/DocumentationKind.js";
+import { DocumentationKind } from "../docs/DocumentationKind.js";
+import { CheckboxInput } from "../form/CheckboxInput.js";
 import { TextInput } from "../form/TextInput.js";
 import { Page } from "../page/Page.js";
+import { Row } from "../style/Flex.js";
 import { TreeCards } from "./TreeCards.js";
 import { useTreeMap } from "./TreeContext.js";
 
@@ -29,23 +32,24 @@ const INDEX_LIMIT = 100;
 /**
  * Page listing every element in the system in one flat, searchable view.
  *
- * - A `<TextInput>` filters as you type; a row of kind chips narrows by `kind` via `searchTree`'s `filter`.
+ * - A `<TextInput>` filters as you type; a row of kind checkboxes narrows by `kind` via `searchTree`'s `filter`.
+ * - The kind checkboxes are multi-select — ticking several narrows to a `kind IN […]` filter; ticking none shows every kind.
  * - An empty query lists everything (capped at 100); a non-empty query ranks with `searchTree` and caps at 20.
  * - Reads the whole tree from the surrounding `<TreeProvider>` (the flattened map's root), so it works on every page.
  * - Wired as a `<TreeApp>` fallback route at `TREE_INDEX_PATH` (`/all`) — it's not a node in the tree.
  *
  * @kind component
- * @returns A `<Page>` with a search input, kind chips, and a flat card listing of results.
+ * @returns A `<Page>` with a search input, kind checkboxes, and a flat card listing of results.
  * @example <Router routes={{ [TREE_INDEX_PATH]: TreeIndexPage }} />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeIndexPage/TreeIndexPage
  */
 export function TreeIndexPage(): ReactNode {
 	const [query, setQuery] = useState("");
-	const [chip, setChip] = useState<string | undefined>(undefined);
+	const [selected, setSelected] = useState<ImmutableArray<string>>([]);
 
 	const root = useTreeMap().get("/");
 
-	// Kinds actually present anywhere in the tree, in display order, for the chip row.
+	// Kinds actually present anywhere in the tree, in display order, for the checkbox row.
 	const kinds = useMemo(() => {
 		if (!root) return [];
 		const all = searchTree(root, "", { limit: Number.POSITIVE_INFINITY });
@@ -53,7 +57,8 @@ export function TreeIndexPage(): ReactNode {
 	}, [root]);
 
 	const trimmed = query.trim();
-	const filter = chip ? ({ kind: chip } as Query) : undefined;
+	// Multiple kinds can be ticked at once — an array value decodes to a `kind IN […]` filter.
+	const filter = selected.length ? ({ kind: selected } as Query) : undefined;
 	// Each element's `key` is its unique canonical path (stamped by `flattenTree()`), so this flat cross-tree listing reconciles correctly.
 	const cards = root ? searchTree(root, trimmed, { limit: trimmed ? 20 : INDEX_LIMIT, filter }) : [];
 
@@ -64,7 +69,21 @@ export function TreeIndexPage(): ReactNode {
 			</Header>
 			<Section wide>
 				<TextInput name="search" title="Search" placeholder="Search…" value={query} onValue={v => setQuery(v ?? "")} />
-				<DocumentationKindChips kinds={kinds} value={chip} onValue={setChip} />
+				{!!kinds.length && (
+					<Row left wrap>
+						{kinds.map(kind => (
+							<CheckboxInput
+								key={kind}
+								name={kind}
+								fit
+								value={selected.includes(kind)}
+								onValue={() => setSelected(s => toggleArrayItem(s, kind))}
+							>
+								<DocumentationKind kind={kind} />
+							</CheckboxInput>
+						))}
+					</Row>
+				)}
 			</Section>
 			<Section wide>
 				<TreeCards>{cards}</TreeCards>


### PR DESCRIPTION
## Summary

Refactored the form input system to support width variants (`narrow`, `wide`, `full`, `fit`) consistently across all input types. Extracted shared input styling logic into a new `getInputClass()` function and `InputVariants` interface that all inputs now extend.

## Key Changes

- **Input.tsx**: 
  - Added `InputVariants` interface extending `WidthVariants` for shared styling across all inputs
  - Created `getInputClass()` function to build base input className from variants (width, etc.)
  - Extracted individual type modifier classes (`TEXT_CLASS`, `SELECT_CLASS`, `BUTTON_CLASS`, `LABEL_CLASS`, `MULTILINE_CLASS`, `WRAPPER_CLASS`) as separate exports
  - Updated precomposed classes to use `getInputClass()` instead of hardcoded `INPUT_CLASS`

- **All input components** (TextInput, NumberInput, DateInput, SelectInput, FileInput, CheckboxInput, RadioInput, ButtonInput, OutputInput):
  - Extended their props interfaces with `InputVariants` to support width variants
  - Updated className construction to use `getInputClass(variants)` instead of hardcoded precomposed classes
  - Spread `...variants` to pass width props through to the base input styling

- **Width.tsx**:
  - Added `fit` variant to `WidthVariants` for `fit-content` sizing

- **Documentation pages**:
  - Removed search/filter UI from `DocumentationPage` (moved to index page)
  - Removed `DocumentationKindChips` component from `DocumentationKind.tsx`
  - Updated `TreeIndexPage` to use multi-select checkboxes instead of single-select chips for kind filtering
  - Simplified `DocumentationChildren` to only render grouped listings without filtering

## Implementation Details

The refactoring follows a layered approach:
- `getInputClass()` applies base input styling + width variants (never applies type modifiers)
- Each input component layers its own type modifier on top: `getClass(getInputClass(variants), TYPE_CLASS)`
- This allows any input to be sized consistently while maintaining type-specific styling
- The design is extensible for future cross-cutting input styling (e.g., spacing variants)

https://claude.ai/code/session_01P6b9GrXB1E7Ekc43pzLRLh