### PR TITLE
Refactor class exports to use CSS modules and getter functions

### DIFF
--- a/modules/ui/block/Address.tsx
+++ b/modules/ui/block/Address.tsx
@@ -11,19 +11,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import ADDRESS_CSS from "./Address.module.css";
 
-/**
- * CSS class applied to the root `<address>` element of every `Address`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Address/ADDRESS_CLASS
- */
-export const ADDRESS_CLASS = getModuleClass(ADDRESS_CSS, "address");
-
-/**
- * CSS class that styles `<address>` elements when they appear inside `Prose`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Address/ADDRESS_PROSE_CLASS
- */
-export const ADDRESS_PROSE_CLASS = getModuleClass(ADDRESS_CSS, "prose");
+const ADDRESS_CLASS = getModuleClass(ADDRESS_CSS, "address");
 
 /**
  * Props for `Address` — colour, space, and typography variants plus required children.

--- a/modules/ui/block/Block.tsx
+++ b/modules/ui/block/Block.tsx
@@ -8,12 +8,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import BLOCK_CSS from "./Block.module.css";
 
-/**
- * CSS class applied to the root element of every `Block`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Block/BLOCK_CLASS
- */
-export const BLOCK_CLASS = getModuleClass(BLOCK_CSS, "block");
+const BLOCK_CLASS = getModuleClass(BLOCK_CSS, "block");
 
 /**
  * Semantic element names a `Block` may render as via its `as` prop.
@@ -32,6 +27,27 @@ export interface BlockProps extends ColorVariants, SpaceVariants, TypographyVari
 }
 
 /**
+ * Get the combined `className` string for a block from its styling variants.
+ *
+ * Composes the base block class and tint ladder with the colour, space, typography, and width variant helpers, so anything that wants block-level styling can apply it.
+ *
+ * @param variants Colour, space, typography, and width variants.
+ * @returns A space-separated `className` string combining the block class and resolved variant classes.
+ * @example getBlockClass({ space: "large" }) // "block tint …"
+ * @see https://dhoulb.github.io/shelving/ui/block/Block/getBlockClass
+ */
+export function getBlockClass(variants: BlockProps): string {
+	return getClass(
+		BLOCK_CLASS,
+		TINT_CLASS,
+		getColorClass(variants),
+		getSpaceClass(variants),
+		getTypographyClass(variants),
+		getWidthClass(variants),
+	);
+}
+
+/**
  * Plain `<div>` block with block-level spacing.
  * - Pass `as` to render a different semantic element (`section`, `header`, `footer`, `nav`, `aside`, `figure`).
  *
@@ -40,18 +56,5 @@ export interface BlockProps extends ColorVariants, SpaceVariants, TypographyVari
  * @see https://dhoulb.github.io/shelving/ui/block/Block/Block
  */
 export function Block({ as: Component = "div", children, ...props }: BlockProps): ReactElement {
-	return (
-		<Component
-			className={getClass(
-				BLOCK_CLASS,
-				TINT_CLASS,
-				getColorClass(props),
-				getSpaceClass(props),
-				getTypographyClass(props),
-				getWidthClass(props),
-			)}
-		>
-			{children}
-		</Component>
-	);
+	return <Component className={getBlockClass(props)}>{children}</Component>;
 }

--- a/modules/ui/block/Blockquote.tsx
+++ b/modules/ui/block/Blockquote.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import BLOCKQUOTE_CSS from "./Blockquote.module.css";
 
-/**
- * CSS class applied to the root `<blockquote>` element of every `Blockquote`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Blockquote/BLOCKQUOTE_CLASS
- */
-export const BLOCKQUOTE_CLASS = getModuleClass(BLOCKQUOTE_CSS, "blockquote");
-
-/**
- * CSS class that styles `<blockquote>` elements when they appear inside `Prose`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Blockquote/BLOCKQUOTE_PROSE_CLASS
- */
-export const BLOCKQUOTE_PROSE_CLASS = getModuleClass(BLOCKQUOTE_CSS, "prose");
+const BLOCKQUOTE_CLASS = getModuleClass(BLOCKQUOTE_CSS, "blockquote");
 
 /**
  * Props for `Blockquote` — colour, space, and typography variants plus optional children.

--- a/modules/ui/block/Caption.tsx
+++ b/modules/ui/block/Caption.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
 import CAPTION_CSS from "./Caption.module.css";
 
-/**
- * CSS class applied to the root `<figcaption>` element of every `Caption`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Caption/CAPTION_CLASS
- */
-export const CAPTION_CLASS = getModuleClass(CAPTION_CSS, "divider");
-
-/**
- * CSS class that styles `<figcaption>` elements when they appear inside `Prose`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Caption/CAPTION_PROSE_CLASS
- */
-export const CAPTION_PROSE_CLASS = getModuleClass(CAPTION_CSS, "prose");
+const CAPTION_CLASS = getModuleClass(CAPTION_CSS, "divider");
 
 /**
  * Props for `Caption` — colour, space, and typography variants plus optional children.

--- a/modules/ui/block/Definitions.tsx
+++ b/modules/ui/block/Definitions.tsx
@@ -7,19 +7,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import DEFINITIONS_CSS from "./Definitions.module.css";
 
-/**
- * CSS class applied to the root `<dl>` element of every `Definitions`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Definitions/DEFINITIONS_CLASS
- */
-export const DEFINITIONS_CLASS = getModuleClass(DEFINITIONS_CSS, "definitions");
-
-/**
- * CSS class that styles `<dl>` elements when they appear inside `Prose`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Definitions/DEFINITIONS_PROSE_CLASS
- */
-export const DEFINITIONS_PROSE_CLASS = getModuleClass(DEFINITIONS_CSS, "prose");
+const DEFINITIONS_CLASS = getModuleClass(DEFINITIONS_CSS, "definitions");
 
 /**
  * Props for `Definitions` — colour, gap, space, and typography variants plus optional children.

--- a/modules/ui/block/Divider.tsx
+++ b/modules/ui/block/Divider.tsx
@@ -3,19 +3,7 @@ import { getSpaceClass, type SpaceVariants } from "../style/Space.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import DIVIDER_CSS from "./Divider.module.css";
 
-/**
- * CSS class applied to the root `<hr>` element of every `Divider`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Divider/DIVIDER_CLASS
- */
-export const DIVIDER_CLASS = getModuleClass(DIVIDER_CSS, "divider");
-
-/**
- * CSS class that styles `<hr>` elements when they appear inside `Prose`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Divider/DIVIDER_PROSE_CLASS
- */
-export const DIVIDER_PROSE_CLASS = getModuleClass(DIVIDER_CSS, "prose");
+const DIVIDER_CLASS = getModuleClass(DIVIDER_CSS, "divider");
 
 /**
  * Props for `Divider` — space and colour variants.

--- a/modules/ui/block/Heading.md
+++ b/modules/ui/block/Heading.md
@@ -6,7 +6,7 @@ A section heading — renders an `<h2>`. It sits in the middle of the three-leve
 
 - Pick the component that matches the level rather than overriding `level`. Choosing `Title` / `Heading` / `Subheading` keeps the visual size and the document outline in step, which matters for accessibility and the docs-site table of contents.
 - The `level` prop (`1`–`6`) is an escape hatch for the rare case where the outline level must differ from the visual size — avoid it in normal use.
-- Inside `Prose`, an `<h2>` is styled by the same rules (`HEADING_PROSE_CLASS`), so Markdown-rendered headings match component ones.
+- Inside `Prose`, an `<h2>` is styled by the same rules (the shared `.prose` styling), so Markdown-rendered headings match component ones.
 - Accepts `color=` and the typography variants; like all block components it collapses its outer margin when it's the first/last child of its container.
 
 ## Usage

--- a/modules/ui/block/Heading.tsx
+++ b/modules/ui/block/Heading.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import HEADING_CSS from "./Heading.module.css";
 
-/**
- * CSS class applied to the root element of every `Heading`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Heading/HEADING_CLASS
- */
-export const HEADING_CLASS = getModuleClass(HEADING_CSS, "heading");
-
-/**
- * CSS class that styles a `Heading` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Heading/HEADING_PROSE_CLASS
- */
-export const HEADING_PROSE_CLASS = getModuleClass(HEADING_CSS, "prose");
+const HEADING_CLASS = getModuleClass(HEADING_CSS, "heading");
 
 /**
  * Props shared by `Title`, `Heading`, and `Subheading` — colour, space, and typography variants plus a heading-level override.

--- a/modules/ui/block/Image.tsx
+++ b/modules/ui/block/Image.tsx
@@ -4,19 +4,7 @@ import { getWidthClass, type WidthVariants } from "../style/Width.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import styles from "./Image.module.css";
 
-/**
- * CSS class applied to the root element of every `Image`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Image/IMAGE_CLASS
- */
-export const IMAGE_CLASS = getModuleClass(styles, "image");
-
-/**
- * CSS class that styles an `Image` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Image/IMAGE_PROSE_CLASS
- */
-export const IMAGE_PROSE_CLASS = getModuleClass(styles, "prose");
+const IMAGE_CLASS = getModuleClass(styles, "image");
 
 /**
  * Props for `Image` — an `src`, optional `alt` text, plus space and width variants.

--- a/modules/ui/block/Label.tsx
+++ b/modules/ui/block/Label.tsx
@@ -6,12 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import LABEL_CSS from "./Label.module.css";
 import type { SubheadingProps } from "./Subheading.js";
 
-/**
- * CSS class applied to the root element of every `Label`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Label/LABEL_CLASS
- */
-export const LABEL_CLASS = getModuleClass(LABEL_CSS, "label");
+const LABEL_CLASS = getModuleClass(LABEL_CSS, "label");
 
 /**
  * Props for `Label` — identical to `SubheadingProps`.

--- a/modules/ui/block/List.tsx
+++ b/modules/ui/block/List.tsx
@@ -6,26 +6,9 @@ import { getTypographyClass, type TypographyVariants } from "../style/Typography
 import { getClass, getModuleClass } from "../util/css.js";
 import LIST_CSS from "./List.module.css";
 
-/**
- * CSS class applied to an ordered `List` (`<ol>`).
- *
- * @see https://dhoulb.github.io/shelving/ui/block/List/LIST_ORDERED_CLASS
- */
-export const LIST_ORDERED_CLASS = getModuleClass(LIST_CSS, "ordered");
+const LIST_ORDERED_CLASS = getModuleClass(LIST_CSS, "ordered");
 
-/**
- * CSS class applied to an unordered `List` (`<ul>`).
- *
- * @see https://dhoulb.github.io/shelving/ui/block/List/LIST_UNORDERED_CLASS
- */
-export const LIST_UNORDERED_CLASS = getModuleClass(LIST_CSS, "unordered");
-
-/**
- * CSS class that styles a `List` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/List/LIST_PROSE_CLASS
- */
-export const LIST_PROSE_CLASS = getModuleClass(LIST_CSS, "prose");
+const LIST_UNORDERED_CLASS = getModuleClass(LIST_CSS, "unordered");
 
 /**
  * Props for `List` — colour, gap, space, and typography variants plus its list items and an `ordered` toggle.

--- a/modules/ui/block/Paragraph.tsx
+++ b/modules/ui/block/Paragraph.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import PARAGRAPH_CSS from "./Paragraph.module.css";
 
-/**
- * CSS class applied to the root element of every `Paragraph`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/PARAGRAPH_CLASS
- */
-export const PARAGRAPH_CLASS = getModuleClass(PARAGRAPH_CSS, "paragraph");
-
-/**
- * CSS class that styles a `Paragraph` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/PARAGRAPH_PROSE_CLASS
- */
-export const PARAGRAPH_PROSE_CLASS = getModuleClass(PARAGRAPH_CSS, "prose");
+const PARAGRAPH_CLASS = getModuleClass(PARAGRAPH_CSS, "paragraph");
 
 /**
  * Props for `Paragraph` — colour, space, and typography variants.
@@ -26,6 +14,25 @@ export const PARAGRAPH_PROSE_CLASS = getModuleClass(PARAGRAPH_CSS, "prose");
  * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/ParagraphProps
  */
 export interface ParagraphProps extends ColorVariants, SpaceVariants, TypographyVariants, OptionalChildProps {}
+
+/**
+ * Get the combined `className` string for a paragraph from its styling variants.
+ *
+ * Composes the base paragraph class with the colour, space, and typography variant helpers, so anything that wants paragraph styling can apply it.
+ *
+ * @param variants Colour, space, and typography variants.
+ * @returns A space-separated `className` string combining the paragraph class and resolved variant classes.
+ * @example getParagraphClass({ space: "large" }) // "paragraph …"
+ * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/getParagraphClass
+ */
+export function getParagraphClass(variants: ParagraphProps): string {
+	return getClass(
+		PARAGRAPH_CLASS, //
+		getColorClass(variants),
+		getSpaceClass(variants),
+		getTypographyClass(variants),
+	);
+}
 
 /**
  * Paragraph block of body text — rendered as `<p>`.
@@ -37,16 +44,5 @@ export interface ParagraphProps extends ColorVariants, SpaceVariants, Typography
  * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/Paragraph
  */
 export function Paragraph({ children, ...props }: ParagraphProps): ReactElement {
-	return (
-		<p
-			className={getClass(
-				PARAGRAPH_CLASS, //
-				getColorClass(props),
-				getSpaceClass(props),
-				getTypographyClass(props),
-			)}
-		>
-			{children}
-		</p>
-	);
+	return <p className={getParagraphClass(props)}>{children}</p>;
 }

--- a/modules/ui/block/Preformatted.tsx
+++ b/modules/ui/block/Preformatted.tsx
@@ -9,20 +9,6 @@ import type { OptionalChildProps } from "../util/props.js";
 import PREFORMATTED_CSS from "./Preformatted.module.css";
 
 /**
- * CSS class applied to the root element of every `Preformatted` block.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/PREFORMATTED_CLASS
- */
-export const PREFORMATTED_CLASS = getModuleClass(PREFORMATTED_CSS, "preformatted");
-
-/**
- * CSS class that styles a `Preformatted` block when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/PREFORMATTED_PROSE_CLASS
- */
-export const PREFORMATTED_PROSE_CLASS = getModuleClass(PREFORMATTED_CSS, "prose");
-
-/**
  * Props for `Preformatted` — space, colour, typography, width, and padding variants plus a `wrap` toggle.
  *
  * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/PreformattedProps

--- a/modules/ui/block/Prose.tsx
+++ b/modules/ui/block/Prose.tsx
@@ -1,56 +1,57 @@
 import type { ReactElement } from "react";
-import { CODE_PROSE_CLASS } from "../inline/Code.js";
-import { DELETED_PROSE_CLASS } from "../inline/Deleted.js";
-import { EMPHASIS_PROSE_CLASS } from "../inline/Emphasis.js";
-import { INSERTED_PROSE_CLASS } from "../inline/Inserted.js";
-import { LINK_PROSE_CLASS } from "../inline/Link.js";
-import { MARK_PROSE_CLASS } from "../inline/Mark.js";
-import { SMALL_PROSE_CLASS } from "../inline/Small.js";
-import { STRONG_PROSE_CLASS } from "../inline/Strong.js";
-import { SUBSCRIPT_PROSE_CLASS } from "../inline/Subscript.js";
-import { SUPERSCRIPT_PROSE_CLASS } from "../inline/Superscript.js";
+import CODE_CSS from "../inline/Code.module.css";
+import DELETED_CSS from "../inline/Deleted.module.css";
+import EMPHASIS_CSS from "../inline/Emphasis.module.css";
+import INSERTED_CSS from "../inline/Inserted.module.css";
+import LINK_CSS from "../inline/Link.module.css";
+import MARK_CSS from "../inline/Mark.module.css";
+import SMALL_CSS from "../inline/Small.module.css";
+import STRONG_CSS from "../inline/Strong.module.css";
+import SUBSCRIPT_CSS from "../inline/Subscript.module.css";
+import SUPERSCRIPT_CSS from "../inline/Superscript.module.css";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
-import { ADDRESS_PROSE_CLASS } from "./Address.js";
-import { BLOCKQUOTE_PROSE_CLASS } from "./Blockquote.js";
-import { CAPTION_PROSE_CLASS } from "./Caption.js";
-import { DEFINITIONS_PROSE_CLASS } from "./Definitions.js";
-import { DIVIDER_PROSE_CLASS } from "./Divider.js";
-import { HEADING_PROSE_CLASS } from "./Heading.js";
-import { IMAGE_PROSE_CLASS } from "./Image.js";
-import { LIST_PROSE_CLASS } from "./List.js";
-import { PARAGRAPH_PROSE_CLASS } from "./Paragraph.js";
-import { PREFORMATTED_PROSE_CLASS } from "./Preformatted.js";
-import { SECTION_PROSE_CLASS } from "./Section.js";
-import { SUBHEADING_PROSE_CLASS } from "./Subheading.js";
-import { TABLE_PROSE_CLASS } from "./Table.js";
-import { TITLE_PROSE_CLASS } from "./Title.js";
+import ADDRESS_CSS from "./Address.module.css";
+import BLOCKQUOTE_CSS from "./Blockquote.module.css";
+import CAPTION_CSS from "./Caption.module.css";
+import DEFINITIONS_CSS from "./Definitions.module.css";
+import DIVIDER_CSS from "./Divider.module.css";
+import HEADING_CSS from "./Heading.module.css";
+import IMAGE_CSS from "./Image.module.css";
+import LIST_CSS from "./List.module.css";
+import PARAGRAPH_CSS from "./Paragraph.module.css";
+import PREFORMATTED_CSS from "./Preformatted.module.css";
+import SECTION_CSS from "./Section.module.css";
+import SUBHEADING_CSS from "./Subheading.module.css";
+import TABLE_CSS from "./Table.module.css";
+import TITLE_CSS from "./Title.module.css";
 
+// Combine the `.prose` class from every block and inline component's CSS module into a single string.
 const PROSE_STYLES = getClass(
-	PARAGRAPH_PROSE_CLASS,
-	HEADING_PROSE_CLASS,
-	SUBHEADING_PROSE_CLASS,
-	ADDRESS_PROSE_CLASS,
-	BLOCKQUOTE_PROSE_CLASS,
-	SECTION_PROSE_CLASS,
-	CODE_PROSE_CLASS,
-	DEFINITIONS_PROSE_CLASS,
-	DELETED_PROSE_CLASS,
-	EMPHASIS_PROSE_CLASS,
-	IMAGE_PROSE_CLASS,
-	INSERTED_PROSE_CLASS,
-	CAPTION_PROSE_CLASS,
-	LIST_PROSE_CLASS,
-	TITLE_PROSE_CLASS,
-	LINK_PROSE_CLASS,
-	MARK_PROSE_CLASS,
-	PREFORMATTED_PROSE_CLASS,
-	SMALL_PROSE_CLASS,
-	STRONG_PROSE_CLASS,
-	SUBSCRIPT_PROSE_CLASS,
-	SUPERSCRIPT_PROSE_CLASS,
-	TABLE_PROSE_CLASS,
-	DIVIDER_PROSE_CLASS,
+	PARAGRAPH_CSS.prose,
+	HEADING_CSS.prose,
+	SUBHEADING_CSS.prose,
+	ADDRESS_CSS.prose,
+	BLOCKQUOTE_CSS.prose,
+	SECTION_CSS.prose,
+	CODE_CSS.prose,
+	DEFINITIONS_CSS.prose,
+	DELETED_CSS.prose,
+	EMPHASIS_CSS.prose,
+	IMAGE_CSS.prose,
+	INSERTED_CSS.prose,
+	CAPTION_CSS.prose,
+	LIST_CSS.prose,
+	TITLE_CSS.prose,
+	LINK_CSS.prose,
+	MARK_CSS.prose,
+	PREFORMATTED_CSS.prose,
+	SMALL_CSS.prose,
+	STRONG_CSS.prose,
+	SUBSCRIPT_CSS.prose,
+	SUPERSCRIPT_CSS.prose,
+	TABLE_CSS.prose,
+	DIVIDER_CSS.prose,
 );
 
 /**

--- a/modules/ui/block/Section.tsx
+++ b/modules/ui/block/Section.tsx
@@ -7,19 +7,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import SECTION_CSS from "./Section.module.css";
 
-/**
- * CSS class applied to the root element of every `Section` and its semantic siblings.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Section/SECTION_CLASS
- */
-export const SECTION_CLASS = getModuleClass(SECTION_CSS, "section");
-
-/**
- * CSS class that styles a `Section` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Section/SECTION_PROSE_CLASS
- */
-export const SECTION_PROSE_CLASS = getModuleClass(SECTION_CSS, "prose");
+const SECTION_CLASS = getModuleClass(SECTION_CSS, "section");
 
 /**
  * Semantic element names a `Section` may render as via its `as` prop.
@@ -37,23 +25,25 @@ export interface SectionProps extends ColorVariants, SpaceVariants, TypographyVa
 	as?: SectionElement | undefined;
 }
 
+/**
+ * Get the combined `className` string for a section from its styling variants.
+ *
+ * Composes the base section class with the colour, space, typography, and width variant helpers, so anything that wants section-level styling can apply it.
+ *
+ * @param variants Colour, space, typography, and width variants.
+ * @returns A space-separated `className` string combining the section class and resolved variant classes.
+ * @example getSectionClass({ space: "large" }) // "section …"
+ * @see https://dhoulb.github.io/shelving/ui/block/Section/getSectionClass
+ */
+export function getSectionClass(variants: SectionProps): string {
+	return getClass(SECTION_CLASS, getColorClass(variants), getSpaceClass(variants), getTypographyClass(variants), getWidthClass(variants));
+}
+
 function renderSection(
 	defaultComponent: SectionElement,
 	{ as: Component = defaultComponent, children, ...variants }: SectionProps,
 ): ReactElement {
-	return (
-		<Component
-			className={getClass(
-				SECTION_CLASS,
-				getColorClass(variants),
-				getSpaceClass(variants),
-				getTypographyClass(variants),
-				getWidthClass(variants),
-			)}
-		>
-			{children}
-		</Component>
-	);
+	return <Component className={getSectionClass(variants)}>{children}</Component>;
 }
 
 /**

--- a/modules/ui/block/Subheading.tsx
+++ b/modules/ui/block/Subheading.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { HeadingProps } from "./Heading.js";
 import SUBHEADING_CSS from "./Subheading.module.css";
 
-/**
- * CSS class applied to the root element of every `Subheading`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Subheading/SUBHEADING_CLASS
- */
-export const SUBHEADING_CLASS = getModuleClass(SUBHEADING_CSS, "subheading");
-
-/**
- * CSS class that styles a `Subheading` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Subheading/SUBHEADING_PROSE_CLASS
- */
-export const SUBHEADING_PROSE_CLASS = getModuleClass(SUBHEADING_CSS, "prose");
+const SUBHEADING_CLASS = getModuleClass(SUBHEADING_CSS, "subheading");
 
 /**
  * Props for `Subheading` — identical to `HeadingProps`.

--- a/modules/ui/block/Table.tsx
+++ b/modules/ui/block/Table.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import TABLE_CSS from "./Table.module.css";
 
-/**
- * CSS class applied to the root element of every `Table`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Table/TABLE_CLASS
- */
-export const TABLE_CLASS = getModuleClass(TABLE_CSS, "divider");
-
-/**
- * CSS class that styles a `Table` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Table/TABLE_PROSE_CLASS
- */
-export const TABLE_PROSE_CLASS = getModuleClass(TABLE_CSS, "prose");
+const TABLE_CLASS = getModuleClass(TABLE_CSS, "divider");
 
 /**
  * Props for `Table` — colour, space, and typography variants plus `children`.

--- a/modules/ui/block/Title.tsx
+++ b/modules/ui/block/Title.tsx
@@ -6,19 +6,7 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { HeadingProps } from "./Heading.js";
 import TITLE_CSS from "./Title.module.css";
 
-/**
- * CSS class applied to the root element of every `Title`.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Title/TITLE_CLASS
- */
-export const TITLE_CLASS = getModuleClass(TITLE_CSS, "title");
-
-/**
- * CSS class that styles a `Title` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/block/Title/TITLE_PROSE_CLASS
- */
-export const TITLE_PROSE_CLASS = getModuleClass(TITLE_CSS, "prose");
+const TITLE_CLASS = getModuleClass(TITLE_CSS, "title");
 
 /**
  * Props for `Title` — identical to `HeadingProps`.

--- a/modules/ui/docs/DocumentationButtons.md
+++ b/modules/ui/docs/DocumentationButtons.md
@@ -7,7 +7,7 @@ Renders a documented symbol's relational metadata as a `<nav>` column of labelle
 - Each relation reads as `"{label} {Target}"`. The target is a [`TreeButton`](/ui/TreeButton), so it resolves the reference against the flattened tree map from [`TreeProvider`](/ui/TreeProvider): a hit becomes a link, a miss (e.g. a builtin like `Serializable`) renders as a plain non-linking label so the text still reads.
 - Relations come from the raw metadata the extractor records — `extends` and `implements` first, then the broader `member of` (the `class` relation) last.
 - It renders nothing when the symbol has no relations.
-- Block spacing defaults to paragraph spacing (it composes `PARAGRAPH_CLASS`); pass `space` to override. Inner spacing is the flex gap.
+- Block spacing defaults to paragraph spacing (it composes `getParagraphClass`); pass `space` to override. Inner spacing is the flex gap.
 - Exported (plural) from `docs/DocumentationButtons.tsx`.
 
 ## Usage
@@ -28,7 +28,7 @@ Drop a relation by omitting it, or tighten spacing with `space`.
 
 ## Styling
 
-`DocumentationButtons` has no own CSS hooks — it composes `PARAGRAPH_CLASS` for block spacing and the flex utilities for layout, and renders its links as [`TreeButton`](/ui/TreeButton)s. Retheme through those.
+`DocumentationButtons` has no own CSS hooks — it composes `getParagraphClass` for block spacing and the flex utilities for layout, and renders its links as [`TreeButton`](/ui/TreeButton)s. Retheme through those.
 
 ## See also
 

--- a/modules/ui/docs/DocumentationButtons.tsx
+++ b/modules/ui/docs/DocumentationButtons.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import type { DocumentationElementProps } from "../../util/tree.js";
-import { PARAGRAPH_CLASS } from "../block/Paragraph.js";
+import { getParagraphClass } from "../block/Paragraph.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getSpaceClass, type SpaceVariants } from "../style/Space.js";
+import type { SpaceVariants } from "../style/Space.js";
 import { TreeButton } from "../tree/TreeButton.js";
 import { getClass } from "../util/css.js";
 
@@ -32,7 +32,7 @@ function* _relations({
  * Render a symbol's relational metadata as a `<nav>` column of labelled links.
  * - Each relation reads as `"{label} {Target}"` — e.g. `extends AbstractStore`, `implements Serializable`, `member of Store`.
  * - The target is a `<DocumentationButton>`, so it links to the referenced page when it exists in the tree and stays a plain label otherwise.
- * - Block spacing defaults to paragraph spacing (via `PARAGRAPH_CLASS`); pass `space` to override. Inner spacing is the flex gap.
+ * - Block spacing defaults to paragraph spacing (via `getParagraphClass`); pass `space` to override. Inner spacing is the flex gap.
  * - Renders nothing when the symbol has no relations.
  *
  * @kind component
@@ -43,9 +43,8 @@ export function DocumentationButtons({ wrap = true, left = true, gap = "none", .
 	return (
 		<nav
 			className={getClass(
-				PARAGRAPH_CLASS, //
+				getParagraphClass(props), //
 				getFlexClass({ wrap, left, gap, ...props }),
-				getSpaceClass(props),
 			)}
 		>
 			{relations.map(([label, to]) => (

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -3,7 +3,8 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import { Clickable, type ClickableProps } from "./Clickable.js";
-import { BUTTON_INPUT_CLASS, type InputProps, PLACEHOLDER_CLASS } from "./Input.js";
+import { getInputClass, type InputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /**
  * Props for `ButtonInput`, a clickable element styled to match form inputs.
@@ -24,7 +25,10 @@ export interface ButtonInputProps extends InputProps, ClickableProps, FlexVarian
 export function ButtonInput({ title, placeholder, children = title, ...props }: ButtonInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<Clickable {...props} className={getClass(BUTTON_INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<Clickable
+			{...props}
+			className={getClass(getInputClass(), INPUT_CSS.button, getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}
+		>
 			{hasChildren ? children : placeholder}
 		</Clickable>
 	);

--- a/modules/ui/form/CheckboxInput.tsx
+++ b/modules/ui/form/CheckboxInput.tsx
@@ -3,7 +3,8 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
-import { CHECKBOX_CLASS, LABEL_INPUT_CLASS, PLACEHOLDER_CLASS, type ValueInputProps } from "./Input.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /**
  * Props for `CheckboxInput`, a boolean-valued checkbox input.
@@ -35,7 +36,10 @@ export function CheckboxInput({
 }: CheckboxProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={getClass(LABEL_INPUT_CLASS, getFlexClass(variants), hasChildren && PLACEHOLDER_CLASS)} aria-invalid={!!message}>
+		<label
+			className={getClass(getInputClass(), INPUT_CSS.label, getFlexClass(variants), hasChildren && INPUT_CSS.placeholder)}
+			aria-invalid={!!message}
+		>
 			<input
 				name={name}
 				type="checkbox"
@@ -44,7 +48,7 @@ export function CheckboxInput({
 				required={required}
 				disabled={disabled}
 				title={message}
-				className={CHECKBOX_CLASS}
+				className={INPUT_CSS.radio}
 			/>
 			<span>{hasChildren ? children : placeholder}</span>
 		</label>

--- a/modules/ui/form/DateInput.tsx
+++ b/modules/ui/form/DateInput.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { DateInputType } from "../../schema/DateSchema.js";
 import { getDateString, getDateTimeString, getTimeString, type PossibleDate } from "../../util/date.js";
-import { TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /** Convert a `PossibleDate` to a string for a specific date `<input type="etc">` type. */
 const _DATE_TO_STRING: { [K in DateInputType]: (d: PossibleDate | undefined) => string | undefined } = {
@@ -61,7 +63,7 @@ export function DateInput({
 			required={required}
 			defaultValue={dateToString(value)}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(), INPUT_CSS.text)}
 			onChange={onChange}
 			onInput={onChange}
 			title={message}

--- a/modules/ui/form/FileInput.tsx
+++ b/modules/ui/form/FileInput.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { FileTypes } from "../../util/file.js";
-import { INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
 
 /**
  * Props for `FileInput`, an `<input type="file">` that emits the selected `File`.
@@ -44,7 +44,7 @@ export function FileInput({
 			required={required}
 			disabled={disabled}
 			placeholder={placeholder}
-			className={INPUT_CLASS}
+			className={getInputClass()}
 			onChange={onChange}
 			onInput={onChange}
 			multiple={false}

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -5,93 +5,18 @@ import { getClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import INPUT_CSS from "./Input.module.css";
 
-// Classes.
-
 /**
- * `className` for a `<input type="radio">` element.
+ * Get the base `className` shared by every input element.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/RADIO_CLASS
- */
-export const RADIO_CLASS = INPUT_CSS.radio;
-
-/**
- * `className` for a `<input type="checkbox">` element.
+ * Compose the result with the modifier classes from `Input.module.css` (e.g. `INPUT_CSS.text`, `INPUT_CSS.select`, `INPUT_CSS.button`, `INPUT_CSS.label`) for a specific input type.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/CHECKBOX_CLASS
+ * @returns The base input `className` string.
+ * @example getClass(getInputClass(), INPUT_CSS.button) // "input button"
+ * @see https://dhoulb.github.io/shelving/ui/form/Input/getInputClass
  */
-export const CHECKBOX_CLASS = INPUT_CSS.radio;
-
-/**
- * Base `className` shared by all input elements.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/INPUT_CLASS
- */
-export const INPUT_CLASS = INPUT_CSS.input;
-
-/**
- * `className` applied to an input when it's showing placeholder content.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/PLACEHOLDER_CLASS
- */
-export const PLACEHOLDER_CLASS = INPUT_CSS.placeholder;
-
-/**
- * `className` for the empty/placeholder `<option>` of a `<select>`.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/EMPTY_OPTION_CLASS
- */
-export const EMPTY_OPTION_CLASS = INPUT_CSS.empty;
-
-/**
- * `className` for a value-bearing `<option>` of a `<select>`.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/VALUE_OPTION_CLASS
- */
-export const VALUE_OPTION_CLASS = INPUT_CSS.value;
-
-// Precomposed classes.
-
-/**
- * Precomposed `className` for a single-line text `<input>`.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/TEXT_INPUT_CLASS
- */
-export const TEXT_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.text);
-
-/**
- * Precomposed `className` for a multiline `<textarea>`.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/MULTILINE_TEXT_INPUT_CLASS
- */
-export const MULTILINE_TEXT_INPUT_CLASS = getClass(TEXT_INPUT_CLASS, INPUT_CSS.multiline);
-
-/**
- * Precomposed `className` for an input wrapper that hosts `data-slot` icon elements.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/WRAPPER_INPUT_CLASS
- */
-export const WRAPPER_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.wrapper);
-
-/**
- * Precomposed `className` for a `<select>` input.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/SELECT_INPUT_CLASS
- */
-export const SELECT_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.select);
-
-/**
- * Precomposed `className` for a button styled as an input.
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/BUTTON_INPUT_CLASS
- */
-export const BUTTON_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.button);
-
-/**
- * Precomposed `className` for a `<label>` styled as an input (e.g. checkbox/radio wrappers).
- *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/LABEL_INPUT_CLASS
- */
-export const LABEL_INPUT_CLASS = getClass(INPUT_CSS.input, INPUT_CSS.label);
+export function getInputClass(): string {
+	return getClass(INPUT_CSS.input);
+}
 
 /**
  * Base props shared by every form input (name, title, placeholder, required/disabled state, and error message).
@@ -122,12 +47,12 @@ export interface ValueInputProps<O, I = never> extends InputProps {
 }
 
 /** Input that is loading. */
-export const LOADING_INPUT = <div className={getClass(INPUT_CLASS, getFlexClass({}))}>{LOADING}</div>;
+export const LOADING_INPUT = <div className={getClass(getInputClass(), getFlexClass({}))}>{LOADING}</div>;
 
 /**
  * Wraps an input with support for absolutely-positioned `data-slot` icon elements on either side.
  * - This is so you can put an icon before or after an input.
  */
 export function InputWrapper({ children }: ChildProps): ReactElement {
-	return <div className={WRAPPER_INPUT_CLASS}>{children}</div>;
+	return <div className={getClass(getInputClass(), INPUT_CSS.wrapper)}>{children}</div>;
 }

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -17,7 +17,6 @@ export interface InputVariants extends WidthVariants {}
 
 /**
  * Build the shared base `className` for a form input from its styling variants — the base input class plus any `InputVariants`.
- * - Compose the result with the type-modifier classes from `Input.module.css` (`INPUT_CSS.text`, `INPUT_CSS.select`, `INPUT_CSS.button`, `INPUT_CSS.label`, …) for a specific input type; `getInputClass()` never applies them itself.
  *
  * @param props The input's styling variants (width, …).
  * @returns The merged base input `className` string.

--- a/modules/ui/form/NumberInput.tsx
+++ b/modules/ui/form/NumberInput.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import { formatNumber } from "../../util/format.js";
 import { getNumber } from "../../util/number.js";
-import { TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 type NumberFormatter = (num: number) => string;
 
@@ -57,7 +59,7 @@ export function NumberInput({
 			required={required}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(), INPUT_CSS.text)}
 			onChange={onChange}
 			onInput={onChange}
 			onBlur={onBlur}

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -3,7 +3,8 @@ import { notNullish } from "../../util/index.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
-import { INPUT_CLASS, type InputProps, PLACEHOLDER_CLASS } from "./Input.js";
+import { getInputClass, type InputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /**
  * Props for `OutputInput`, a read-only `<output>` styled to match form inputs.
@@ -23,7 +24,7 @@ export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVa
 export function OutputInput({ title, placeholder, children = title, ...props }: OutputInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<output {...props} className={getClass(INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<output {...props} className={getClass(getInputClass(), getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}>
 			{hasChildren ? children : placeholder}
 		</output>
 	);

--- a/modules/ui/form/RadioInput.tsx
+++ b/modules/ui/form/RadioInput.tsx
@@ -3,7 +3,8 @@ import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
-import { LABEL_INPUT_CLASS, PLACEHOLDER_CLASS, RADIO_CLASS, type ValueInputProps } from "./Input.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /**
  * Props for `RadioInput`, a single labelled radio button styled as an input.
@@ -35,9 +36,9 @@ export function RadioInput({
 }: RadioInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={getClass(LABEL_INPUT_CLASS, getFlexClass(props), hasChildren && PLACEHOLDER_CLASS)}>
+		<label className={getClass(getInputClass(), INPUT_CSS.label, getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}>
 			<input
-				className={RADIO_CLASS}
+				className={INPUT_CSS.radio}
 				type="radio"
 				name={name}
 				defaultChecked={value}

--- a/modules/ui/form/SelectInput.tsx
+++ b/modules/ui/form/SelectInput.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement } from "react";
 import type { ChoiceOptions } from "../../schema/ChoiceSchema.js";
 import { getProps } from "../../util/object.js";
-import { EMPTY_OPTION_CLASS, SELECT_INPUT_CLASS, VALUE_OPTION_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 /**
  * Props for `SelectInput`, a dropdown `<select>` bound to a string value.
@@ -38,19 +40,19 @@ export function SelectInput({
 			name={name}
 			defaultValue={value}
 			onChange={e => onValue(e.currentTarget.value || undefined)}
-			className={SELECT_INPUT_CLASS}
+			className={getClass(getInputClass(), INPUT_CSS.select)}
 			title={message}
 			aria-invalid={!!message}
 			disabled={disabled}
 			required={required}
 		>
 			{!required || !value ? (
-				<option value="" className={EMPTY_OPTION_CLASS}>
+				<option value="" className={INPUT_CSS.empty}>
 					{placeholder}
 				</option>
 			) : null}
 			{getProps(options).map(([k, t]) => (
-				<option key={k} value={k} className={VALUE_OPTION_CLASS}>
+				<option key={k} value={k} className={INPUT_CSS.value}>
 					{t}
 				</option>
 			))}

--- a/modules/ui/form/TextInput.tsx
+++ b/modules/ui/form/TextInput.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { StringInputType } from "../../schema/StringSchema.js";
 import { PASSTHROUGH } from "../../util/function.js";
-import { MULTILINE_TEXT_INPUT_CLASS, TEXT_INPUT_CLASS, type ValueInputProps } from "./Input.js";
+import { getClass } from "../util/css.js";
+import { getInputClass, type ValueInputProps } from "./Input.js";
+import INPUT_CSS from "./Input.module.css";
 
 type TextFormatter = (str: string) => string;
 
@@ -66,7 +68,7 @@ export function TextInput({
 				required={required && min > 0}
 				disabled={disabled}
 				placeholder={placeholder || " "}
-				className={MULTILINE_TEXT_INPUT_CLASS}
+				className={getClass(getInputClass(), INPUT_CSS.text, INPUT_CSS.multiline)}
 				onInput={onChange}
 				onChange={onChange}
 				onBlur={onBlur}
@@ -90,7 +92,7 @@ export function TextInput({
 			required={required && min > 0}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={TEXT_INPUT_CLASS}
+			className={getClass(getInputClass(), INPUT_CSS.text)}
 			onInput={onChange}
 			onChange={onChange}
 			onBlur={onBlur}

--- a/modules/ui/inline/Code.tsx
+++ b/modules/ui/inline/Code.tsx
@@ -5,26 +5,9 @@ import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
 import CODE_CSS from "./Code.module.css";
 
-/**
- * CSS class applied to the root element of every `Code`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Code/CODE_CLASS
- */
-export const CODE_CLASS = getModuleClass(CODE_CSS, "code");
+const CODE_CLASS = getModuleClass(CODE_CSS, "code");
 
-/**
- * CSS class that strips the default background and padding when `Code` is rendered `plain`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Code/CODE_PLAIN_CLASS
- */
-export const CODE_PLAIN_CLASS = getModuleClass(CODE_CSS, "plain");
-
-/**
- * CSS class that styles `Code` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Code/CODE_PROSE_CLASS
- */
-export const CODE_PROSE_CLASS = getModuleClass(CODE_CSS, "prose");
+const CODE_PLAIN_CLASS = getModuleClass(CODE_CSS, "plain");
 
 /**
  * Props for `Code` — colour and typography variants, optional `children`, plus a `plain` toggle.

--- a/modules/ui/inline/Deleted.tsx
+++ b/modules/ui/inline/Deleted.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import DELETED_CSS from "./Deleted.module.css";
 
-/**
- * CSS class applied to the root element of every `Deleted`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Deleted/DELETED_CLASS
- */
-export const DELETED_CLASS = getModuleClass(DELETED_CSS, "definitions");
-
-/**
- * CSS class that styles `Deleted` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Deleted/DELETED_PROSE_CLASS
- */
-export const DELETED_PROSE_CLASS = getModuleClass(DELETED_CSS, "prose");
+const DELETED_CLASS = getModuleClass(DELETED_CSS, "definitions");
 
 /**
  * Props for `Deleted` — optional `children`.

--- a/modules/ui/inline/Emphasis.tsx
+++ b/modules/ui/inline/Emphasis.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import EMPHASIS_CSS from "./Emphasis.module.css";
 
-/**
- * CSS class applied to the root element of every `Emphasis`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Emphasis/EMPHASIS_CLASS
- */
-export const EMPHASIS_CLASS = getModuleClass(EMPHASIS_CSS, "emphasis");
-
-/**
- * CSS class that styles `Emphasis` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Emphasis/EMPHASIS_PROSE_CLASS
- */
-export const EMPHASIS_PROSE_CLASS = getModuleClass(EMPHASIS_CSS, "prose");
+const EMPHASIS_CLASS = getModuleClass(EMPHASIS_CSS, "emphasis");
 
 /**
  * Props for `Emphasis` — optional `children`.

--- a/modules/ui/inline/Inserted.tsx
+++ b/modules/ui/inline/Inserted.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import INSERTED_CSS from "./Inserted.module.css";
 
-/**
- * CSS class applied to the root element of every `Inserted`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Inserted/INSERTED_CLASS
- */
-export const INSERTED_CLASS = getModuleClass(INSERTED_CSS, "inserted");
-
-/**
- * CSS class that styles `Inserted` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Inserted/INSERTED_PROSE_CLASS
- */
-export const INSERTED_PROSE_CLASS = getModuleClass(INSERTED_CSS, "prose");
+const INSERTED_CLASS = getModuleClass(INSERTED_CSS, "inserted");
 
 /**
  * Props for `Inserted` — optional `children`.

--- a/modules/ui/inline/Link.tsx
+++ b/modules/ui/inline/Link.tsx
@@ -3,19 +3,7 @@ import { Clickable, type ClickableProps } from "../form/Clickable.js";
 import { getModuleClass } from "../util/css.js";
 import LINK_CSS from "./Link.module.css";
 
-/**
- * CSS class applied to the root element of every `Link`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Link/LINK_CLASS
- */
-export const LINK_CLASS = getModuleClass(LINK_CSS, "link");
-
-/**
- * CSS class that styles a `Link` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Link/LINK_PROSE_CLASS
- */
-export const LINK_PROSE_CLASS = getModuleClass(LINK_CSS, "prose");
+const LINK_CLASS = getModuleClass(LINK_CSS, "link");
 
 /**
  * Props for `Link` — identical to `ClickableProps` (`href` for navigation or `onClick` for actions).

--- a/modules/ui/inline/Mark.tsx
+++ b/modules/ui/inline/Mark.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import MARK_CSS from "./Mark.module.css";
 
-/**
- * CSS class applied to the root element of every `Mark`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Mark/MARK_CLASS
- */
-export const MARK_CLASS = getModuleClass(MARK_CSS, "mark");
-
-/**
- * CSS class that styles `Mark` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Mark/MARK_PROSE_CLASS
- */
-export const MARK_PROSE_CLASS = getModuleClass(MARK_CSS, "prose");
+const MARK_CLASS = getModuleClass(MARK_CSS, "mark");
 
 /**
  * Props for `Mark` — optional `children`.

--- a/modules/ui/inline/Small.tsx
+++ b/modules/ui/inline/Small.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import SMALL_CSS from "./Small.module.css";
 
-/**
- * CSS class applied to the root element of every `Small`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Small/SMALL_CLASS
- */
-export const SMALL_CLASS = getModuleClass(SMALL_CSS, "small");
-
-/**
- * CSS class that styles `Small` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Small/SMALL_PROSE_CLASS
- */
-export const SMALL_PROSE_CLASS = getModuleClass(SMALL_CSS, "prose");
+const SMALL_CLASS = getModuleClass(SMALL_CSS, "small");
 
 /**
  * Props for `Small` — optional `children`.
@@ -33,5 +21,5 @@ export interface SmallProps extends OptionalChildProps {}
  * @see https://dhoulb.github.io/shelving/ui/inline/Small/Small
  */
 export function Small({ children }: SmallProps): ReactElement {
-	return <small className={SMALL_CSS}>{children}</small>;
+	return <small className={SMALL_CLASS}>{children}</small>;
 }

--- a/modules/ui/inline/Strong.tsx
+++ b/modules/ui/inline/Strong.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import STRONG_CSS from "./Strong.module.css";
 
-/**
- * CSS class applied to the root element of every `Strong`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Strong/STRONG_CLASS
- */
-export const STRONG_CLASS = getModuleClass(STRONG_CSS, "strong");
-
-/**
- * CSS class that styles `Strong` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Strong/STRONG_PROSE_CLASS
- */
-export const STRONG_PROSE_CLASS = getModuleClass(STRONG_CSS, "prose");
+const STRONG_CLASS = getModuleClass(STRONG_CSS, "strong");
 
 /**
  * Props for `Strong` — optional `children`.

--- a/modules/ui/inline/Subscript.tsx
+++ b/modules/ui/inline/Subscript.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import SUBSCRIPT_CSS from "./Subscript.module.css";
 
-/**
- * CSS class applied to the root element of every `Subscript`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Subscript/SUBSCRIPT_CLASS
- */
-export const SUBSCRIPT_CLASS = getModuleClass(SUBSCRIPT_CSS, "subscript");
-
-/**
- * CSS class that styles `Subscript` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Subscript/SUBSCRIPT_PROSE_CLASS
- */
-export const SUBSCRIPT_PROSE_CLASS = getModuleClass(SUBSCRIPT_CSS, "prose");
+const SUBSCRIPT_CLASS = getModuleClass(SUBSCRIPT_CSS, "subscript");
 
 /**
  * Props for `Subscript` — optional `children`.

--- a/modules/ui/inline/Superscript.tsx
+++ b/modules/ui/inline/Superscript.tsx
@@ -3,19 +3,7 @@ import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import SUPERSCRIPT_CSS from "./Superscript.module.css";
 
-/**
- * CSS class applied to the root element of every `Superscript`.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Superscript/SUPERSCRIPT_CLASS
- */
-export const SUPERSCRIPT_CLASS = getModuleClass(SUPERSCRIPT_CSS, "superscript");
-
-/**
- * CSS class that styles `Superscript` when it appears inside `Prose` longform content.
- *
- * @see https://dhoulb.github.io/shelving/ui/inline/Superscript/SUPERSCRIPT_PROSE_CLASS
- */
-export const SUPERSCRIPT_PROSE_CLASS = getModuleClass(SUPERSCRIPT_CSS, "prose");
+const SUPERSCRIPT_CLASS = getModuleClass(SUPERSCRIPT_CSS, "superscript");
 
 /**
  * Props for `Superscript` — optional `children`.

--- a/modules/ui/notice/Message.tsx
+++ b/modules/ui/notice/Message.tsx
@@ -1,16 +1,11 @@
-import { PARAGRAPH_CLASS, type ParagraphProps } from "../block/Paragraph.js";
+import { getParagraphClass, type ParagraphProps } from "../block/Paragraph.js";
 import { LOADING } from "../misc/Loading.js";
-import { type ColorVariants, getColorClass } from "../style/Color.js";
+import type { ColorVariants } from "../style/Color.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
 import { getClass } from "../util/css.js";
 import MESSAGE_CSS from "./Message.module.css";
 
-/**
- * Base `className` applied to every `<Message>` paragraph.
- *
- * @see https://dhoulb.github.io/shelving/ui/notice/Message/MESSAGE_CLASS
- */
-export const MESSAGE_CLASS = getClass(MESSAGE_CSS.message);
+const MESSAGE_CLASS = getClass(MESSAGE_CSS.message);
 
 /**
  * Props for `<Message>` — paragraph props plus colour and status styling variants.
@@ -36,10 +31,9 @@ export function Message({ children, ...props }: MessageProps) {
 		<p
 			role={status === "error" || status === "danger" ? "alert" : "status"}
 			className={getClass(
-				PARAGRAPH_CLASS, //
+				getParagraphClass(props), //
 				MESSAGE_CLASS,
 				getStatusClass(props),
-				getColorClass(props),
 			)}
 		>
 			{children}

--- a/modules/ui/notice/Notice.tsx
+++ b/modules/ui/notice/Notice.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
-import { BLOCK_CLASS } from "../block/Block.js";
+import { getBlockClass } from "../block/Block.js";
 import { StatusIcon } from "../misc/StatusIcon.js";
-import { type ColorVariants, getColorClass } from "../style/Color.js";
+import type { ColorVariants } from "../style/Color.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
 import { getClass, getModuleClass } from "../util/css.js";
@@ -41,13 +41,7 @@ export function Notice({
 	return (
 		<aside
 			role={status === "danger" || status === "error" ? "alert" : "status"}
-			className={getClass(
-				BLOCK_CLASS,
-				getModuleClass(NOTICE_CSS, "notice", props),
-				getFlexClass(props),
-				getStatusClass(props),
-				getColorClass(props),
-			)}
+			className={getClass(getBlockClass(props), getModuleClass(NOTICE_CSS, "notice", props), getFlexClass(props), getStatusClass(props))}
 		>
 			{icon !== undefined ? icon : status && <StatusIcon status={status} />}
 			{children}

--- a/modules/ui/style/Scroll.tsx
+++ b/modules/ui/style/Scroll.tsx
@@ -4,19 +4,9 @@ import type { ChildProps } from "../util/index.js";
 import SCROLLABLE_CSS from "./Scroll.module.css";
 import type { WidthVariants } from "./Width.js";
 
-/**
- * CSS class that enables horizontal scrolling on an element.
- *
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/SCROLL_HORIZONTAL_CLASS
- */
-export const SCROLL_HORIZONTAL_CLASS = getModuleClass(SCROLLABLE_CSS, "horizontal");
+const SCROLL_HORIZONTAL_CLASS = getModuleClass(SCROLLABLE_CSS, "horizontal");
 
-/**
- * CSS class that enables vertical scrolling on an element.
- *
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/SCROLL_VERTICAL_CLASS
- */
-export const SCROLL_VERTICAL_CLASS = getModuleClass(SCROLLABLE_CSS, "vertical");
+const SCROLL_VERTICAL_CLASS = getModuleClass(SCROLLABLE_CSS, "vertical");
 
 /**
  * Variant props selecting which scroll axes are enabled on an element.

--- a/modules/ui/tree/TreeBreadcrumbs.tsx
+++ b/modules/ui/tree/TreeBreadcrumbs.tsx
@@ -1,11 +1,11 @@
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import { Fragment, type ReactElement } from "react";
 import { joinPath, splitPath } from "../../util/path.js";
-import { BLOCK_CLASS } from "../block/Block.js";
+import { getBlockClass } from "../block/Block.js";
 import { requireMetaURL } from "../misc/MetaContext.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getSpaceClass, type SpaceVariants } from "../style/Space.js";
-import { getTypographyClass, type TypographyVariants } from "../style/Typography.js";
+import type { SpaceVariants } from "../style/Space.js";
+import type { TypographyVariants } from "../style/Typography.js";
 import { getClass } from "../util/css.js";
 import { TreeButton } from "./TreeButton.js";
 import { useTreeMap } from "./TreeContext.js";
@@ -23,7 +23,7 @@ export interface TreeBreadcrumbsProps extends TypographyVariants, SpaceVariants,
  * - Built from the page's own `path`: each ancestor prefix is looked up in the tree map for its title, and links to its cumulative path.
  * - Prefixes with no entry (e.g. the partial half of a `"util/string"` module name) are skipped, so composite names collapse to a single crumb.
  * - The current item is deliberately omitted — the page `<Title>` already names it.
- * - Block spacing defaults to section spacing (via `BLOCK_CLASS`); pass `space` to override.
+ * - Block spacing defaults to section spacing (via `getBlockClass`); pass `space` to override.
  * - Renders nothing at the tree root (no ancestors) or when there's no `<TreeProvider>` to resolve labels from.
  *
  * @param props Typography, space, and flex variant props.
@@ -40,10 +40,8 @@ export function TreeBreadcrumbs({ tint = "70", left = true, wrap = true, ...vari
 		<nav
 			aria-label="Breadcrumb"
 			className={getClass(
-				BLOCK_CLASS, //
-				getTypographyClass({ tint, ...variants }),
+				getBlockClass({ tint, ...variants }), //
 				getFlexClass({ left, wrap, ...variants }),
-				getSpaceClass(variants),
 			)}
 		>
 			<TreeButton small plain name="/" />

--- a/modules/ui/util/getClass.md
+++ b/modules/ui/util/getClass.md
@@ -32,15 +32,15 @@ getModuleClass(BUTTON_CSS, "button", variants);
 The canonical component pattern combines both:
 
 ```tsx
-import { getClass, getModuleClass } from "shelving/ui";
+import { getClass, getModuleClass, getTypographyClass } from "shelving/ui";
 import BUTTON_CSS from "./Button.module.css";
 
 export function Button({ children, ...variants }: ButtonProps): ReactElement {
   return (
     <button
       className={getClass(
-        BLOCK_CLASS, //
-        getModuleClass(BUTTON_CSS, "button", variants),
+        getModuleClass(BUTTON_CSS, "button", variants), //
+        getTypographyClass(variants),
       )}
     >
       {children}


### PR DESCRIPTION
## Summary

This PR refactors the UI component library to eliminate direct class name exports in favor of importing CSS modules and using getter functions. This improves maintainability by centralizing class definitions in CSS modules and making the API more composable.

## Key Changes

- **Prose.tsx**: Changed from importing individual `*_PROSE_CLASS` constants to importing CSS modules directly, then accessing the `.prose` property from each module
- **Input.tsx**: Replaced 10 exported class constants (`RADIO_CLASS`, `CHECKBOX_CLASS`, `INPUT_CLASS`, etc.) with a single `getInputClass()` function that returns the base input class, allowing callers to compose with modifier classes
- **Block.tsx & Section.tsx**: Added `getBlockClass()` and `getSectionClass()` getter functions to compose base classes with variant helpers, replacing inline class composition in component render methods
- **Paragraph.tsx**: Added `getParagraphClass()` getter function and made `PARAGRAPH_CLASS` private
- **All inline components** (Code, Small, Deleted, Emphasis, Inserted, Link, Mark, Strong, Subscript, Superscript): Made `*_CLASS` and `*_PROSE_CLASS` exports private (no longer exported)
- **All block components** (Address, Blockquote, Caption, Definitions, Divider, Heading, Image, Preformatted, Subheading, Table, Title, List, Label): Made `*_CLASS` and `*_PROSE_CLASS` exports private
- **Scroll.tsx**: Made `SCROLL_HORIZONTAL_CLASS` and `SCROLL_VERTICAL_CLASS` private
- **Consumer updates**: Updated all components that imported these constants to use the new getter functions or import CSS modules directly (Message, Notice, TreeBreadcrumbs, CheckboxInput, SelectInput, ButtonInput, TextInput, RadioInput, DateInput, NumberInput, OutputInput, FileInput, DocumentationButtons)

## Implementation Details

- CSS module imports now use the pattern `import MODULE_CSS from "./Module.module.css"` instead of importing named class constants
- Getter functions follow the pattern `getComponentClass(variants)` and return composed class strings using `getClass()`
- Private class constants are now declared with `const` instead of `export const`, reducing the public API surface
- The refactoring maintains backward compatibility for components that use these utilities internally while simplifying the external API

https://claude.ai/code/session_01UqFU1XwhA6qXzqYth7SHq8