### PR TITLE
refactor: route all CSS-module class lookups through getModuleClass

### DIFF
--- a/modules/ui/block/Card.tsx
+++ b/modules/ui/block/Card.tsx
@@ -36,7 +36,9 @@ export interface CardProps
  * @see https://dhoulb.github.io/shelving/ui/block/Card/Card
  */
 export function Card({ children, href, onClick, title = "Open", ...props }: CardProps): ReactElement {
-	const overlay = (href || onClick) && <Clickable title={title} href={href} onClick={onClick} {...props} className={CARD_CSS.overlay} />;
+	const overlay = (href || onClick) && (
+		<Clickable title={title} href={href} onClick={onClick} {...props} className={getModuleClass(CARD_CSS, "overlay")} />
+	);
 	return (
 		<article
 			className={getClass(

--- a/modules/ui/block/Prose.tsx
+++ b/modules/ui/block/Prose.tsx
@@ -9,7 +9,7 @@ import SMALL_CSS from "../inline/Small.module.css";
 import STRONG_CSS from "../inline/Strong.module.css";
 import SUBSCRIPT_CSS from "../inline/Subscript.module.css";
 import SUPERSCRIPT_CSS from "../inline/Superscript.module.css";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import ADDRESS_CSS from "./Address.module.css";
 import BLOCKQUOTE_CSS from "./Blockquote.module.css";
@@ -28,30 +28,30 @@ import TITLE_CSS from "./Title.module.css";
 
 // Combine the `.prose` class from every block and inline component's CSS module into a single string.
 const PROSE_STYLES = getClass(
-	PARAGRAPH_CSS.prose,
-	HEADING_CSS.prose,
-	SUBHEADING_CSS.prose,
-	ADDRESS_CSS.prose,
-	BLOCKQUOTE_CSS.prose,
-	SECTION_CSS.prose,
-	CODE_CSS.prose,
-	DEFINITIONS_CSS.prose,
-	DELETED_CSS.prose,
-	EMPHASIS_CSS.prose,
-	IMAGE_CSS.prose,
-	INSERTED_CSS.prose,
-	CAPTION_CSS.prose,
-	LIST_CSS.prose,
-	TITLE_CSS.prose,
-	LINK_CSS.prose,
-	MARK_CSS.prose,
-	PREFORMATTED_CSS.prose,
-	SMALL_CSS.prose,
-	STRONG_CSS.prose,
-	SUBSCRIPT_CSS.prose,
-	SUPERSCRIPT_CSS.prose,
-	TABLE_CSS.prose,
-	DIVIDER_CSS.prose,
+	getModuleClass(PARAGRAPH_CSS, "prose"),
+	getModuleClass(HEADING_CSS, "prose"),
+	getModuleClass(SUBHEADING_CSS, "prose"),
+	getModuleClass(ADDRESS_CSS, "prose"),
+	getModuleClass(BLOCKQUOTE_CSS, "prose"),
+	getModuleClass(SECTION_CSS, "prose"),
+	getModuleClass(CODE_CSS, "prose"),
+	getModuleClass(DEFINITIONS_CSS, "prose"),
+	getModuleClass(DELETED_CSS, "prose"),
+	getModuleClass(EMPHASIS_CSS, "prose"),
+	getModuleClass(IMAGE_CSS, "prose"),
+	getModuleClass(INSERTED_CSS, "prose"),
+	getModuleClass(CAPTION_CSS, "prose"),
+	getModuleClass(LIST_CSS, "prose"),
+	getModuleClass(TITLE_CSS, "prose"),
+	getModuleClass(LINK_CSS, "prose"),
+	getModuleClass(MARK_CSS, "prose"),
+	getModuleClass(PREFORMATTED_CSS, "prose"),
+	getModuleClass(SMALL_CSS, "prose"),
+	getModuleClass(STRONG_CSS, "prose"),
+	getModuleClass(SUBSCRIPT_CSS, "prose"),
+	getModuleClass(SUPERSCRIPT_CSS, "prose"),
+	getModuleClass(TABLE_CSS, "prose"),
+	getModuleClass(DIVIDER_CSS, "prose"),
 );
 
 /**

--- a/modules/ui/dialog/Dialog.tsx
+++ b/modules/ui/dialog/Dialog.tsx
@@ -35,9 +35,9 @@ export const Dialog = memo(({ children, onClose, ...props }: DialogProps) => {
 	return (
 		<Suspense fallback={null}>
 			{/** biome-ignore lint/a11y/useKeyWithClickEvents: Dialogs also show a close button. */}
-			<dialog ref={ref} className={styles.dialog} onClick={_closeOnBackdropClick} onClose={onClose} {...props}>
+			<dialog ref={ref} className={getModuleClass(styles, "dialog")} onClick={_closeOnBackdropClick} onClose={onClose} {...props}>
 				{children}
-				<div className={styles.close}>
+				<div className={getModuleClass(styles, "close")}>
 					<DialogCloseButton plain />
 				</div>
 			</dialog>

--- a/modules/ui/dialog/Modal.tsx
+++ b/modules/ui/dialog/Modal.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import styles from "./Modal.module.css";
 
@@ -19,5 +20,5 @@ export interface ModalProps extends OptionalChildProps {}
  * @see https://dhoulb.github.io/shelving/ui/dialog/Modal/Modal
  */
 export function Modal({ children }: ModalProps): ReactElement {
-	return <aside className={styles.modal}>{children}</aside>;
+	return <aside className={getModuleClass(styles, "modal")}>{children}</aside>;
 }

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import { Clickable, type ClickableProps } from "./Clickable.js";
 import { getInputClass, type InputProps, type InputVariants } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
@@ -27,7 +27,12 @@ export function ButtonInput({ title, placeholder, children = title, ...props }: 
 	return (
 		<Clickable
 			{...props}
-			className={getClass(getInputClass(props), INPUT_CSS.button, getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}
+			className={getClass(
+				getInputClass(props),
+				getModuleClass(INPUT_CSS, "button"),
+				getFlexClass(props),
+				hasChildren && getModuleClass(INPUT_CSS, "placeholder"),
+			)}
 		>
 			{hasChildren ? children : placeholder}
 		</Clickable>

--- a/modules/ui/form/CheckboxInput.tsx
+++ b/modules/ui/form/CheckboxInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
@@ -37,7 +37,12 @@ export function CheckboxInput({
 	const hasChildren = notNullish(children);
 	return (
 		<label
-			className={getClass(getInputClass(variants), INPUT_CSS.label, getFlexClass(variants), hasChildren && INPUT_CSS.placeholder)}
+			className={getClass(
+				getInputClass(variants),
+				getModuleClass(INPUT_CSS, "label"),
+				getFlexClass(variants),
+				hasChildren && getModuleClass(INPUT_CSS, "placeholder"),
+			)}
 			aria-invalid={!!message}
 		>
 			<input
@@ -48,7 +53,7 @@ export function CheckboxInput({
 				required={required}
 				disabled={disabled}
 				title={message}
-				className={INPUT_CSS.radio}
+				className={getModuleClass(INPUT_CSS, "radio")}
 			/>
 			<span>{hasChildren ? children : placeholder}</span>
 		</label>

--- a/modules/ui/form/DateInput.tsx
+++ b/modules/ui/form/DateInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { DateInputType } from "../../schema/DateSchema.js";
 import { getDateString, getDateTimeString, getTimeString, type PossibleDate } from "../../util/date.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
 
@@ -64,7 +64,7 @@ export function DateInput({
 			required={required}
 			defaultValue={dateToString(value)}
 			placeholder={placeholder || " "}
-			className={getClass(getInputClass(variants), INPUT_CSS.text)}
+			className={getClass(getInputClass(variants), getModuleClass(INPUT_CSS, "text"))}
 			onChange={onChange}
 			onInput={onChange}
 			title={message}

--- a/modules/ui/form/Field.tsx
+++ b/modules/ui/form/Field.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { Message } from "../notice/Message.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import styles from "./Field.module.css";
 
@@ -27,11 +27,11 @@ export interface FieldProps extends ChildProps {
 export function Field({ title, description, message, half, children }: FieldProps): ReactElement {
 	return (
 		// biome-ignore lint/a11y/noLabelWithoutControl: Generally `children` will contain a field.
-		<label className={getClass(styles.field, half && styles.half)}>
+		<label className={getClass(getModuleClass(styles, "field"), half && getModuleClass(styles, "half"))}>
 			{(title || description) && (
 				<div>
-					{title ? <div className={styles.title}>{title}</div> : null}
-					{description && <div className={styles.description}>{description}</div>}
+					{title ? <div className={getModuleClass(styles, "title")}>{title}</div> : null}
+					{description && <div className={getModuleClass(styles, "description")}>{description}</div>}
 				</div>
 			)}
 			{children}

--- a/modules/ui/form/Form.tsx
+++ b/modules/ui/form/Form.tsx
@@ -6,6 +6,7 @@ import { isAsync } from "../../util/async.js";
 import type { Data, PartialData } from "../../util/data.js";
 import type { ImmutableDictionary } from "../../util/dictionary.js";
 import type { Arguments } from "../../util/function.js";
+import { getModuleClass } from "../util/css.js";
 import { type NoticeCallback, notifySuccess, notifyThrown } from "../util/notice.js";
 import type { OptionalChildProps } from "../util/props.js";
 import styles from "./Form.module.css";
@@ -91,10 +92,10 @@ export function Form({
 				// Close the parent dialog on successful submit.
 				if (result) dialog?.close();
 			}}
-			className={styles.form}
+			className={getModuleClass(styles, "form")}
 			noValidate={true}
 		>
-			<fieldset className={styles.fieldset} disabled={busy}>
+			<fieldset className={getModuleClass(styles, "fieldset")} disabled={busy}>
 				<FormContext value={store}>{children}</FormContext>
 			</fieldset>
 		</form>

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { LOADING } from "../misc/Loading.js";
 import { getFlexClass } from "../style/Flex.js";
 import { getWidthClass, type WidthVariants } from "../style/Width.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import INPUT_CSS from "./Input.module.css";
 
@@ -20,11 +20,11 @@ export interface InputVariants extends WidthVariants {}
  *
  * @param props The input's styling variants (width, …).
  * @returns The merged base input `className` string.
- * @example getClass(getInputClass(props), INPUT_CSS.text) // a text input that also honours width variants
+ * @example getClass(getInputClass(props), getModuleClass(INPUT_CSS, "text")) // a text input that also honours width variants
  * @see https://dhoulb.github.io/shelving/ui/form/Input/getInputClass
  */
 export function getInputClass(props: InputVariants): string {
-	return getClass(INPUT_CSS.input, getWidthClass(props));
+	return getClass(getModuleClass(INPUT_CSS, "input"), getWidthClass(props));
 }
 
 /**
@@ -63,5 +63,5 @@ export const LOADING_INPUT = <div className={getClass(getInputClass({}), getFlex
  * - This is so you can put an icon before or after an input.
  */
 export function InputWrapper({ children }: ChildProps): ReactElement {
-	return <div className={getClass(getInputClass({}), INPUT_CSS.wrapper)}>{children}</div>;
+	return <div className={getClass(getInputClass({}), getModuleClass(INPUT_CSS, "wrapper"))}>{children}</div>;
 }

--- a/modules/ui/form/NumberInput.tsx
+++ b/modules/ui/form/NumberInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import { formatNumber } from "../../util/format.js";
 import { getNumber } from "../../util/number.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
 
@@ -60,7 +60,7 @@ export function NumberInput({
 			required={required}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={getClass(getInputClass(variants), INPUT_CSS.text)}
+			className={getClass(getInputClass(variants), getModuleClass(INPUT_CSS, "text"))}
 			onChange={onChange}
 			onInput={onChange}
 			onBlur={onBlur}

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { notNullish } from "../../util/index.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
 import { getInputClass, type InputProps, type InputVariants } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
@@ -24,7 +24,10 @@ export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVa
 export function OutputInput({ title, placeholder, children = title, ...props }: OutputInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<output {...props} className={getClass(getInputClass(props), getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}>
+		<output
+			{...props}
+			className={getClass(getInputClass(props), getFlexClass(props), hasChildren && getModuleClass(INPUT_CSS, "placeholder"))}
+		>
 			{hasChildren ? children : placeholder}
 		</output>
 	);

--- a/modules/ui/form/Popover.tsx
+++ b/modules/ui/form/Popover.tsx
@@ -5,6 +5,7 @@ import type { ReactElement, ReactNode } from "react";
 
 import { isTruthy } from "../../util/boolean.js";
 import type { Callback } from "../../util/function.js";
+import { getModuleClass } from "../util/css.js";
 import { eventPreventDefault } from "../util/event.js";
 import { eventLoopFocus } from "../util/focus.js";
 import styles from "./Popover.module.css";
@@ -59,7 +60,7 @@ export function Popover({
 }: PopoverProps): ReactElement {
 	return (
 		<div
-			className={styles.wrap}
+			className={getModuleClass(styles, "wrap")}
 			onBlur={e => {
 				if (e.relatedTarget) eventLoopFocus(e);
 				else onClose?.();
@@ -68,7 +69,7 @@ export function Popover({
 		>
 			{trigger}
 			{open ? (
-				<section className={styles.panel} onMouseDown={eventPreventDefault}>
+				<section className={getModuleClass(styles, "panel")} onMouseDown={eventPreventDefault}>
 					{popover}
 				</section>
 			) : null}

--- a/modules/ui/form/Progress.tsx
+++ b/modules/ui/form/Progress.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactElement } from "react";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import styles from "./Progress.module.css";
 
 /**
@@ -28,10 +28,15 @@ export function Progress({ value, success, warning, danger }: ProgressProps): Re
 
 	return (
 		<div
-			className={getClass(styles.track, success && styles.success, warning && styles.warning, danger && styles.danger)}
+			className={getClass(
+				getModuleClass(styles, "track"),
+				success && getModuleClass(styles, "success"),
+				warning && getModuleClass(styles, "warning"),
+				danger && getModuleClass(styles, "danger"),
+			)}
 			style={progressStyle}
 		>
-			<span className={styles.fill} />
+			<span className={getModuleClass(styles, "fill")} />
 		</div>
 	);
 }
@@ -63,11 +68,16 @@ export function SegmentedProgress({ total, current, success, warning, danger }: 
 
 	return (
 		<div
-			className={getClass(styles.segmented, success && styles.success, warning && styles.warning, danger && styles.danger)}
+			className={getClass(
+				getModuleClass(styles, "segmented"),
+				success && getModuleClass(styles, "success"),
+				warning && getModuleClass(styles, "warning"),
+				danger && getModuleClass(styles, "danger"),
+			)}
 			style={progressStyle}
 		>
 			{Array.from({ length: total }, (_, i) => (
-				<span key={i.toString()} className={getClass(styles.item, i <= current && styles.active)} />
+				<span key={i.toString()} className={getClass(getModuleClass(styles, "item"), i <= current && getModuleClass(styles, "active"))} />
 			))}
 		</div>
 	);

--- a/modules/ui/form/RadioInput.tsx
+++ b/modules/ui/form/RadioInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { notNullish } from "../../util/null.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
@@ -36,9 +36,16 @@ export function RadioInput({
 }: RadioInputProps): ReactElement {
 	const hasChildren = notNullish(children);
 	return (
-		<label className={getClass(getInputClass(props), INPUT_CSS.label, getFlexClass(props), hasChildren && INPUT_CSS.placeholder)}>
+		<label
+			className={getClass(
+				getInputClass(props),
+				getModuleClass(INPUT_CSS, "label"),
+				getFlexClass(props),
+				hasChildren && getModuleClass(INPUT_CSS, "placeholder"),
+			)}
+		>
 			<input
-				className={INPUT_CSS.radio}
+				className={getModuleClass(INPUT_CSS, "radio")}
 				type="radio"
 				name={name}
 				defaultChecked={value}

--- a/modules/ui/form/SelectInput.tsx
+++ b/modules/ui/form/SelectInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import type { ChoiceOptions } from "../../schema/ChoiceSchema.js";
 import { getProps } from "../../util/object.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
 
@@ -41,19 +41,19 @@ export function SelectInput({
 			name={name}
 			defaultValue={value}
 			onChange={e => onValue(e.currentTarget.value || undefined)}
-			className={getClass(getInputClass(variants), INPUT_CSS.select)}
+			className={getClass(getInputClass(variants), getModuleClass(INPUT_CSS, "select"))}
 			title={message}
 			aria-invalid={!!message}
 			disabled={disabled}
 			required={required}
 		>
 			{!required || !value ? (
-				<option value="" className={INPUT_CSS.empty}>
+				<option value="" className={getModuleClass(INPUT_CSS, "empty")}>
 					{placeholder}
 				</option>
 			) : null}
 			{getProps(options).map(([k, t]) => (
-				<option key={k} value={k} className={INPUT_CSS.value}>
+				<option key={k} value={k} className={getModuleClass(INPUT_CSS, "value")}>
 					{t}
 				</option>
 			))}

--- a/modules/ui/form/TextInput.tsx
+++ b/modules/ui/form/TextInput.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { StringInputType } from "../../schema/StringSchema.js";
 import { PASSTHROUGH } from "../../util/function.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import { getInputClass, type InputVariants, type ValueInputProps } from "./Input.js";
 import INPUT_CSS from "./Input.module.css";
 
@@ -69,7 +69,7 @@ export function TextInput({
 				required={required && min > 0}
 				disabled={disabled}
 				placeholder={placeholder || " "}
-				className={getClass(getInputClass(variants), INPUT_CSS.text, INPUT_CSS.multiline)}
+				className={getClass(getInputClass(variants), getModuleClass(INPUT_CSS, "text"), getModuleClass(INPUT_CSS, "multiline"))}
 				onInput={onChange}
 				onChange={onChange}
 				onBlur={onBlur}
@@ -93,7 +93,7 @@ export function TextInput({
 			required={required && min > 0}
 			disabled={disabled}
 			placeholder={placeholder || " "}
-			className={getClass(getInputClass(variants), INPUT_CSS.text)}
+			className={getClass(getInputClass(variants), getModuleClass(INPUT_CSS, "text"))}
 			onInput={onChange}
 			onChange={onChange}
 			onBlur={onBlur}

--- a/modules/ui/layout/CenteredLayout.tsx
+++ b/modules/ui/layout/CenteredLayout.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { requireMetaURL } from "../misc/MetaContext.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import CENTERED_LAYOUT_CSS from "./CenteredLayout.module.css";
 import { LAYOUT_CLASS } from "./Layout.js";
@@ -28,8 +28,8 @@ export interface CenteredLayoutProps extends OptionalChildProps {
 export function CenteredLayout({ children, fullWidth = false }: CenteredLayoutProps): ReactElement {
 	const { path } = requireMetaURL();
 	return (
-		<main key={path} className={getClass(CENTERED_LAYOUT_CSS.main, LAYOUT_CLASS)}>
-			<div className={CENTERED_LAYOUT_CSS.mainInner} style={fullWidth ? { maxWidth: "none" } : undefined}>
+		<main key={path} className={getClass(getModuleClass(CENTERED_LAYOUT_CSS, "main"), LAYOUT_CLASS)}>
+			<div className={getModuleClass(CENTERED_LAYOUT_CSS, "mainInner")} style={fullWidth ? { maxWidth: "none" } : undefined}>
 				{children}
 			</div>
 		</main>

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -2,7 +2,7 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
 import { type ReactElement, type ReactNode, useEffect, useState } from "react";
 import { Button } from "../form/Button.js";
 import { requireMetaURL } from "../misc/MetaContext.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/props.js";
 import { LAYOUT_CLASS } from "./Layout.js";
 import SIDEBAR_LAYOUT_CSS from "./SidebarLayout.module.css";
@@ -45,25 +45,34 @@ export function SidebarLayout({ sidebar, children, right = false }: SidebarLayou
 	}, [path]);
 
 	const sidebarEl = (
-		<nav key="sidebar" className={getClass(SIDEBAR_LAYOUT_CSS.sidebar, open && SIDEBAR_LAYOUT_CSS.open)}>
+		<nav
+			key="sidebar"
+			className={getClass(getModuleClass(SIDEBAR_LAYOUT_CSS, "sidebar"), open && getModuleClass(SIDEBAR_LAYOUT_CSS, "open"))}
+		>
 			{sidebar}
 		</nav>
 	);
 	const contentEl = (
-		<div key={path} className={getClass(LAYOUT_CLASS, SIDEBAR_LAYOUT_CSS.content)}>
-			<div className={SIDEBAR_LAYOUT_CSS.toggle}>
+		<div key={path} className={getClass(LAYOUT_CLASS, getModuleClass(SIDEBAR_LAYOUT_CSS, "content"))}>
+			<div className={getModuleClass(SIDEBAR_LAYOUT_CSS, "toggle")}>
 				<Button title={open ? "Close menu" : "Show menu"} onClick={() => setOpen(o => !o)}>
 					{open ? <XMarkIcon /> : <Bars3Icon />}
 				</Button>
 			</div>
-			<div className={SIDEBAR_LAYOUT_CSS.contentInner}>{children}</div>
+			<div className={getModuleClass(SIDEBAR_LAYOUT_CSS, "contentInner")}>{children}</div>
 		</div>
 	);
 	const overlayEl = open && (
-		<button key="overlay" type="button" className={SIDEBAR_LAYOUT_CSS.overlay} aria-label="Close menu" onClick={() => setOpen(false)} />
+		<button
+			key="overlay"
+			type="button"
+			className={getModuleClass(SIDEBAR_LAYOUT_CSS, "overlay")}
+			aria-label="Close menu"
+			onClick={() => setOpen(false)}
+		/>
 	);
 	return (
-		<main className={getClass(SIDEBAR_LAYOUT_CSS.main, LAYOUT_CLASS)}>
+		<main className={getClass(getModuleClass(SIDEBAR_LAYOUT_CSS, "main"), LAYOUT_CLASS)}>
 			{right ? [contentEl, sidebarEl, overlayEl] : [sidebarEl, contentEl, overlayEl]}
 		</main>
 	);

--- a/modules/ui/misc/Loading.tsx
+++ b/modules/ui/misc/Loading.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { getModuleClass } from "../util/css.js";
 import styles from "./Loading.module.css";
 
 declare const _componentProps: unique symbol;
@@ -24,9 +25,15 @@ export interface LoadingProps {
  */
 export function Loading(): ReactElement {
 	return (
-		<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className={styles.spinner} data-slot="icon">
+		<svg
+			aria-hidden="true"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			className={getModuleClass(styles, "spinner")}
+			data-slot="icon"
+		>
 			<title>Loading...</title>
-			<circle className={styles.track} cx="12" cy="12" r="9" pathLength="100" />
+			<circle className={getModuleClass(styles, "track")} cx="12" cy="12" r="9" pathLength="100" />
 			<g>
 				<animateTransform
 					attributeName="transform"
@@ -37,7 +44,7 @@ export function Loading(): ReactElement {
 					dur="0.5s"
 					repeatCount="indefinite"
 				/>
-				<circle className={styles.indicator} cx="12" cy="12" r="9" pathLength="100" />
+				<circle className={getModuleClass(styles, "indicator")} cx="12" cy="12" r="9" pathLength="100" />
 			</g>
 		</svg>
 	);

--- a/modules/ui/notice/Message.tsx
+++ b/modules/ui/notice/Message.tsx
@@ -2,10 +2,10 @@ import { getParagraphClass, type ParagraphProps } from "../block/Paragraph.js";
 import { LOADING } from "../misc/Loading.js";
 import type { ColorVariants } from "../style/Color.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
-import { getClass } from "../util/css.js";
+import { getClass, getModuleClass } from "../util/css.js";
 import MESSAGE_CSS from "./Message.module.css";
 
-const MESSAGE_CLASS = getClass(MESSAGE_CSS.message);
+const MESSAGE_CLASS = getModuleClass(MESSAGE_CSS, "message");
 
 /**
  * Props for `<Message>` — paragraph props plus colour and status styling variants.


### PR DESCRIPTION
## Summary

Makes **every** CSS-module class-name lookup in the UI layer go through the `getModuleClass` helper, rather than mixing the helper with direct property access (`STYLES.foo`).

Direct accesses like:

```tsx
const TABLE_CLASS = TABLE_CSS.divider;
className={CARD_CSS.overlay}
getClass(styles.track, success && styles.success)
```

become:

```tsx
const TABLE_CLASS = getModuleClass(TABLE_CSS, "divider");
className={getModuleClass(CARD_CSS, "overlay")}
getClass(getModuleClass(styles, "track"), success && getModuleClass(styles, "success"))
```

## Why

`getModuleClass` already centralises the CSS-module handling — including the graceful degradation when an environment imports `*.module.css` as a string path rather than a class dictionary (`getModuleClass` returns `undefined` in that case). Direct property access bypasses that single point of handling. Routing all lookups through the helper keeps the behaviour consistent and the intent explicit, with no runtime change for the processed-CSS-module case.

This is a pure refactor — surrounding `getClass(...)` composition and conditional (`cond && …`) structure is preserved, so output class strings are unchanged.

## Scope

21 files across `modules/ui/` (block, dialog, form, layout, misc, notice). No public-API or behavioural changes.

## Verification

- `bun run fix` — formatted/sorted imports
- `bun run test` — lint clean, type check passes, **1140 unit tests pass / 0 fail**


---
_Generated by [Claude Code](https://claude.ai/code/session_011mYZ7k5d3XvNVwrMbVUhrn)_