### PR TITLE
feat: prefix module titles with package name in PackageExtractor

### DIFF
--- a/modules/extract/PackageExtractor.test.ts
+++ b/modules/extract/PackageExtractor.test.ts
@@ -67,6 +67,20 @@ describe("PackageExtractor", () => {
 		}
 	});
 
+	test("prefixes each module title with the package name", async () => {
+		const { root, tree, cleanup } = await _setup(_basicLayout);
+		try {
+			const pkg = await _writePackageJson(root, { "./api": "./api/index.js", "./util/*": "./util/*.js" }, "shelving");
+			const out = await new PackageExtractor({ tree }).extract(pkg);
+			const kids = Array.from(out.props.children as Iterable<TreeElement>);
+			// `name` stays the bare subpath; `title` is prefixed with the package name.
+			expect(kids.map(k => k.props.name).sort()).toEqual(["api", "util/array", "util/string"]);
+			expect(kids.map(k => k.props.title).sort()).toEqual(["shelving/api", "shelving/util/array", "shelving/util/string"]);
+		} finally {
+			await cleanup();
+		}
+	});
+
 	test("expands a wildcard export into one module per matching child", async () => {
 		const { root, tree, cleanup } = await _setup(_basicLayout);
 		try {

--- a/modules/extract/PackageExtractor.ts
+++ b/modules/extract/PackageExtractor.ts
@@ -51,6 +51,7 @@ export interface PackageExtractorOptions {
  * - Static export keys (e.g. `"./api"`, `"./firestore/client"`) become one module each.
  * - Wildcard export keys (e.g. `"./util/*"`) expand against the source tree — one module per matching child file or subdirectory.
  * - Each export's *target* extension (e.g. the `.js` in `"./util/*.js"`) is mapped to source extensions via `extensions`, so built `.js` paths resolve to their `.ts` sources.
+ * - Each module's `title` is prefixed with the package `name` (e.g. `ui` → `shelving/ui`) so listings read as package subpaths.
  * - The `"."` root export is skipped — its content is the root tree element itself.
  * - Throws if a static export key has no matching source element in the tree.
  *
@@ -93,7 +94,9 @@ export class PackageExtractor extends Extractor<Path, TreeElement> {
 	override async extract(packageJson: Path): Promise<TreeElement> {
 		const pkgPath = requirePath(packageJson, this._base, this.extract);
 		const pkg = (await Bun.file(pkgPath).json()) as PackageJson;
-		const exports = pkg.exports ?? {};
+		const tree = this._tree;
+		// Read the package name alongside its exports — the name prefixes each module title (e.g. `ui` → `shelving/ui`).
+		const { name, exports = {} } = pkg;
 
 		const modules: DocumentationElement[] = [];
 		for (const [key, value] of Object.entries(exports)) {
@@ -111,18 +114,22 @@ export class PackageExtractor extends Extractor<Path, TreeElement> {
 			}
 		}
 
-		const tree = this._tree;
+		// Prefix the package name onto each module's title so listings read `shelving/ui` rather than a bare `ui`, making modules glanceable as package subpaths.
+		const children = name
+			? modules.map(module => ({ ...module, props: { ...module.props, title: `${name}/${module.props.title ?? module.props.name}` } }))
+			: modules;
+
 		// Canonical URL `path`s aren't stamped here — they're derived from tree structure when the tree is flattened (`flattenTree()`) in the UI layer.
 		return {
 			type: "tree-element",
-			key: pkg.name ?? tree.key,
+			key: name ?? tree.key,
 			props: {
 				source: tree.props.source,
-				name: pkg.name ?? tree.props.name,
-				title: pkg.name ?? tree.props.title,
+				name: name ?? tree.props.name,
+				title: name ?? tree.props.title,
 				description: pkg.description ?? tree.props.description,
 				content: tree.props.content,
-				children: modules,
+				children,
 			},
 		};
 	}


### PR DESCRIPTION
## Summary

Makes documented modules glanceable as package subpaths by prefixing each module's display `title` with the top-level package `name` — so the docs site shows `shelving/ui` rather than a bare `ui`, making it obvious at a glance which entries are modules.

## Changes

- In `PackageExtractor.extract()`, read the package `name` alongside `exports` in a single destructure of the parsed `package.json`.
- After the module list is built, map each module to a copy whose `title` becomes `` `${name}/${title}` `` (e.g. `ui` → `shelving/ui`, `util/string` → `shelving/util/string`).
- Only the visual `title` changes — each module's `name` (and therefore its slug/`key` and canonical URL path) stays the bare subpath, so routing and search-by-name are unaffected.
- Guarded on `name` existing: a nameless package falls back to the previous behaviour. The same `name` variable now feeds the root element's `key`/`name`/`title` fallbacks, preserving the original semantics.
- Updated the class docblock and added a test asserting names stay bare while titles gain the prefix.

## Testing

`bun run test` is green — lint, types, and 1143 unit tests pass.

> [!NOTE]
> This is a docs-site change; the rendered output can be eyeballed via the `docs.yaml` PR preview at `https://dhoulb.github.io/shelving/pr-<number>/`.

https://claude.ai/code/session_01ByXW2cRtD3sqcEt5ZqxAHL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByXW2cRtD3sqcEt5ZqxAHL)_