### PR TITLE
docs: link and style token cross-references across READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,6 +459,8 @@ So a linked reference reads ``[`<Section>`](/ui/Section)``, ``[`formatDate()`](/
 
 **Generics belong in the link text.** When a token is referenced with its generic parameters, keep the whole thing inside one backtick-quoted link — ``[`Schema<T>`](/schema/Schema)``, ``[`ItemStore<I, T>`](/db/ItemStore)`` — not the bare name linked with the generics trailing in a second code span (``[`Schema`](/schema/Schema)`<T>``), which renders as two separate, awkwardly-split chips. The path still targets the bare token; only the displayed name carries the generics.
 
+**Member access belongs in the link text too.** A qualified reference like `PostgreSQLMigrator.migrate()` is a single link whose text holds the whole chain — ``[`PostgreSQLMigrator.migrate()`](/db/PostgreSQLMigrator)`` — not a class link with the `.method()` trailing in a second span. Target the **class** page in most cases (the member often has no page of its own); only link the member page directly when the reference is to the bare member (``[`.validate()`](/schema/BooleanSchema/validate)``). Never split one styled reference across two adjacent code spans.
+
 ### UI component pages and CSS-variable documentation
 
 Each reusable UI component's sibling `.md` (e.g. `modules/ui/block/Card.md`) follows the same shape as other per-symbol pages — a `# Name` heading, a short purpose paragraph, a "Things to know" bullet list, runnable `tsx` usage examples — plus a **Styling** section that documents the component's themeable surface. The CSS custom properties are written inline in the `.module.css` (`var(--card-background, …)`), so there's no declaration site for an extractor to read; the Styling table is the documented source of truth and must be kept in sync by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,37 @@ Checklist:
 - **Per-class / per-function usage examples** live in a sibling `MyClass.md` / `myFunction.md` next to the source file. `DirectoryExtractor` merges that markdown onto the symbol's own page (`MarkupExtractor` outranks `TypescriptExtractor`), so detailed usage belongs there rather than in the module README. `modules/util/template.md` is the precedent. This applies to UI components too — each reusable component gets a sibling `.md` (`Card.md` next to `Card.tsx`) with usage examples and a **Styling** section (see below)
 - Trust source and tests over README if they conflict — but fix the README rather than leaving it wrong
 
+### Cross-references and token display
+
+Whenever a README, per-symbol `.md` page, or docblock names another module or token — a class, function, constant, type, method, property, or component — link it to its canonical docs-site page. Use a backtick-quoted name as the link text and a site-root-relative path as the target:
+
+```
+[`BooleanSchema`](/schema/BooleanSchema)
+```
+
+i.e. ``[`nameOfToken`](/canonical/path)``. This is mandatory for **"See also" lists** and for **inline references** to classes / functions / methods / properties / components alike — not just link lists. Link the first mention in a passage; don't re-link the same token on every line.
+
+**Canonical paths** mirror the docs-site router (the path the page actually resolves at — note this is *not* the same as the longer `@see` page URL):
+
+- A top-level module is `/<module>` — `/schema`, `/db`, `/store`, `/ui`.
+- A token is `/<module>/<Token>` — `/schema/BooleanSchema`, `/db/Collection`, `/store/Store`.
+- A member is `/<module>/<Token>/<member>` — `/schema/BooleanSchema/validate`, `/store/Store/value`.
+- The `util` module is published per-file, so its tokens are `/util/<file>/<Token>` — `/util/array/getArray`, `/util/format/formatDate`, `/util/object/withProp`.
+
+**Only link to paths that resolve to a real page.** The docs tree is flat per top-level module: there are no submodule pages (`/db/collection`, `/api/provider`, `/markup/rule`, `/ui/tree`), and no bare `/firestore` or `/util` page. Link a submodule or module concept to its nearest real page instead — `/db`, `/api`, `/markup`, `/firestore/client`, or the specific `/util/<file>`.
+
+**Token display style.** Format a token name so its kind reads from the text, then put the styled name inside the link:
+
+| Kind | Style | Example |
+|---|---|---|
+| Function | trailing parens | `formatDate()` |
+| Method | leading dot + trailing parens | `.validate()` |
+| Property | leading dot | `.value` |
+| Component | angle brackets | `<Section>` |
+| Class / interface / type / constant | bare name | `BooleanSchema`, `STRING` |
+
+So a linked reference reads ``[`<Section>`](/ui/Section)``, ``[`formatDate()`](/util/format/formatDate)``, ``[`.validate()`](/schema/BooleanSchema/validate)``, or ``[`.value`](/store/Store/value)``. Apply the same styling to unlinked mentions (e.g. a builtin or external symbol with no page) so the kind is still obvious.
+
 ### UI component pages and CSS-variable documentation
 
 Each reusable UI component's sibling `.md` (e.g. `modules/ui/block/Card.md`) follows the same shape as other per-symbol pages — a `# Name` heading, a short purpose paragraph, a "Things to know" bullet list, runnable `tsx` usage examples — plus a **Styling** section that documents the component's themeable surface. The CSS custom properties are written inline in the `.module.css` (`var(--card-background, …)`), so there's no declaration site for an extractor to read; the Styling table is the documented source of truth and must be kept in sync by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,6 +457,8 @@ i.e. ``[`nameOfToken`](/canonical/path)``. This is mandatory for **"See also" li
 
 So a linked reference reads ``[`<Section>`](/ui/Section)``, ``[`formatDate()`](/util/format/formatDate)``, ``[`.validate()`](/schema/BooleanSchema/validate)``, or ``[`.value`](/store/Store/value)``. Apply the same styling to unlinked mentions (e.g. a builtin or external symbol with no page) so the kind is still obvious.
 
+**Generics belong in the link text.** When a token is referenced with its generic parameters, keep the whole thing inside one backtick-quoted link — ``[`Schema<T>`](/schema/Schema)``, ``[`ItemStore<I, T>`](/db/ItemStore)`` — not the bare name linked with the generics trailing in a second code span (``[`Schema`](/schema/Schema)`<T>``), which renders as two separate, awkwardly-split chips. The path still targets the bare token; only the displayed name carries the generics.
+
 ### UI component pages and CSS-variable documentation
 
 Each reusable UI component's sibling `.md` (e.g. `modules/ui/block/Card.md`) follows the same shape as other per-symbol pages — a `# Name` heading, a short purpose paragraph, a "Things to know" bullet list, runnable `tsx` usage examples — plus a **Styling** section that documents the component's themeable surface. The CSS custom properties are written inline in the `.module.css` (`var(--card-background, …)`), so there's no declaration site for an extractor to read; the Styling table is the documented source of truth and must be kept in sync by hand.

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,6 +1,6 @@
 # Shelving
 
-Shelving is a TypeScript toolkit for working with typed data. At its core it is a schema validation library — every schema has a `validate()` method that returns a typed value or throws a human-readable error. On top of that it provides a database provider abstraction, an API provider abstraction, observable state stores, React integration, and a large set of typed utility functions.
+Shelving is a TypeScript toolkit for working with typed data. At its core it is a schema validation library — every schema has a [`.validate()`](/schema/Schema/validate) method that returns a typed value or throws a human-readable error. On top of that it provides a database provider abstraction, an API provider abstraction, observable state stores, React integration, and a large set of typed utility functions.
 
 > Note: Shelving is in active development and does not yet follow semver.
 

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -1,14 +1,14 @@
 # api
 
-Typed, provider-based framework for HTTP API access. Define your routes as `Endpoint` definitions, then call them through a composable provider stack — the same pattern the [`db`](/db) module uses for databases.
+Typed, provider-based framework for HTTP API access. Define your routes as [`Endpoint`](/api/Endpoint) definitions, then call them through a composable provider stack — the same pattern the [`db`](/db) module uses for databases.
 
 ## Concepts
 
 ### Endpoint
 
-An `Endpoint` is a declarative, typed description of a single API route. It captures the HTTP method, the URL path (with optional `{placeholder}` segments), a [schema](/schema) for the request payload, and a schema for the response. Think of it the way [`Collection`](/db) describes a database table — a shared definition both client and server reference.
+An [`Endpoint`](/api/Endpoint) is a declarative, typed description of a single API route. It captures the HTTP method, the URL path (with optional `{placeholder}` segments), a [`schema`](/schema) for the request payload, and a schema for the response. Think of it the way [`Collection`](/db/Collection) describes a database table — a shared definition both client and server reference.
 
-Factory functions (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`) create endpoints concisely:
+Factory functions ([`GET()`](/api/GET), [`POST()`](/api/POST), [`PUT()`](/api/PUT), [`PATCH()`](/api/PATCH), [`DELETE()`](/api/DELETE), [`HEAD()`](/api/HEAD)) create endpoints concisely:
 
 ```ts
 import { GET, POST } from "shelving/api"
@@ -22,18 +22,18 @@ For `GET` and `HEAD` requests, payload fields that don't fill a `{placeholder}` 
 
 ### Providers
 
-An `APIProvider` is the abstract interface for executing calls against endpoints. `ClientAPIProvider` is the concrete implementation that uses the global `fetch` API. Wrap it with `ThroughAPIProvider` subclasses to layer in behaviour without rewriting transport logic:
+An [`APIProvider`](/api/APIProvider) is the abstract interface for executing calls against endpoints. [`ClientAPIProvider`](/api/ClientAPIProvider) is the concrete implementation that uses the global `fetch` API. Wrap it with [`ThroughAPIProvider`](/api/ThroughAPIProvider) subclasses to layer in behaviour without rewriting transport logic:
 
 | Provider | Purpose |
 |---|---|
-| `ClientAPIProvider` | Concrete base — sends requests over the network with `fetch()` |
-| `ThroughAPIProvider` | Pass-through base for wrapping another provider |
-| `ValidationAPIProvider` | Validates payload and result against endpoint schemas |
-| `DebugAPIProvider` | Logs fetch attempts, results, and errors to the console |
-| `JSONAPIProvider` | Forces JSON request bodies and JSON response parsing |
-| `MockAPIProvider` | Records calls without sending network requests |
-| `MockEndpointAPIProvider` | Dispatches calls through handler objects (useful for unit tests) |
-| `XMLAPIProvider` | Forces XML request bodies and returns raw text responses |
+| [`ClientAPIProvider`](/api/ClientAPIProvider) | Concrete base — sends requests over the network with `fetch()` |
+| [`ThroughAPIProvider`](/api/ThroughAPIProvider) | Pass-through base for wrapping another provider |
+| [`ValidationAPIProvider`](/api/ValidationAPIProvider) | Validates payload and result against endpoint schemas |
+| [`DebugAPIProvider`](/api/DebugAPIProvider) | Logs fetch attempts, results, and errors to the console |
+| [`JSONAPIProvider`](/api/JSONAPIProvider) | Forces JSON request bodies and JSON response parsing |
+| [`MockAPIProvider`](/api/MockAPIProvider) | Records calls without sending network requests |
+| [`MockEndpointAPIProvider`](/api/MockEndpointAPIProvider) | Dispatches calls through handler objects (useful for unit tests) |
+| [`XMLAPIProvider`](/api/XMLAPIProvider) | Forces XML request bodies and returns raw text responses |
 
 Extend `ThroughAPIProvider` to add custom behaviour such as auth headers:
 
@@ -52,7 +52,7 @@ class AuthAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 
 ### Caching
 
-`APICache` manages `EndpointCache` objects, one per endpoint. Each `EndpointCache` manages `EndpointStore` objects, one per unique payload — keyed by the rendered URL. For `GET`/`HEAD` requests, query params are part of the key so `?role=admin` and `?role=editor` are stored separately. `EndpointStore` fetches automatically on first read and de-duplicates in-flight requests.
+[`APICache`](/api/APICache) manages [`EndpointCache`](/api/EndpointCache) objects, one per endpoint. Each `EndpointCache` manages [`EndpointStore`](/api/EndpointStore) objects, one per unique payload — keyed by the rendered URL. For `GET`/`HEAD` requests, query params are part of the key so `?role=admin` and `?role=editor` are stored separately. `EndpointStore` fetches automatically on first read and de-duplicates in-flight requests.
 
 The cache is primarily useful as the backbone of the [React integration](#react-integration). Use it directly only when you need a reactive layer outside React.
 
@@ -105,7 +105,7 @@ const user = await api.call(getUser, { id: "u_123" })
 
 ## React integration
 
-The [`react`](/react) module's `createAPIContext()` is the primary way to use a provider in a React app. It creates a context backed by an `APICache` and exposes a typed `useAPI()` hook that returns reactive `EndpointStore` instances and suspends automatically while loading.
+The [`react`](/react) module's [`createAPIContext()`](/react/createAPIContext) is the primary way to use a provider in a React app. It creates a context backed by an [`APICache`](/api/APICache) and exposes a typed [`.useAPI()`](/react/APIContext/useAPI) hook that returns reactive [`EndpointStore`](/api/EndpointStore) instances and suspends automatically while loading.
 
 ```ts
 import { createAPIContext } from "shelving/react"
@@ -121,5 +121,5 @@ See the [`react`](/react) module for full usage.
 
 - [`schema`](/schema) — schemas for endpoint payload and result validation
 - [`db`](/db) — the parallel database provider module
-- [`store`](/store) — `Store` base class that `EndpointStore` extends
-- [`react`](/react) — `createAPIContext()` for React integration
+- [`store`](/store) — [`Store`](/store/Store) base class that [`EndpointStore`](/api/EndpointStore) extends
+- [`react`](/react) — [`createAPIContext()`](/react/createAPIContext) for React integration

--- a/modules/api/cache/README.md
+++ b/modules/api/cache/README.md
@@ -1,6 +1,6 @@
 # Cache
 
-Reactive caching layer for API calls. `APICache` manages one `EndpointCache` per endpoint; each `EndpointCache` manages one `EndpointStore` per unique rendered URL. This three-level structure lets you cache, invalidate, and refresh at any granularity — all endpoints, a single endpoint, or a specific payload.
+Reactive caching layer for API calls. [`APICache`](/api/APICache) manages one [`EndpointCache`](/api/EndpointCache) per endpoint; each `EndpointCache` manages one [`EndpointStore`](/api/EndpointStore) per unique rendered URL. This three-level structure lets you cache, invalidate, and refresh at any granularity — all endpoints, a single endpoint, or a specific payload.
 
 ## Concepts
 
@@ -16,16 +16,16 @@ APICache
 
 ### Cache keys
 
-`EndpointCache.get(payload)` renders the full URL (including `?query` params for `GET`/`HEAD`) and uses that as the map key. Two payloads that produce the same URL share a store.
+[`.get(payload)`](/api/EndpointCache/get) renders the full URL (including `?query` params for `GET`/`HEAD`) and uses that as the map key. Two payloads that produce the same URL share a store.
 
 ### `call()` vs `refresh()`
 
-- `call(payload, maxAge)` — returns a cached value if it is younger than `maxAge`. Awaits any in-flight fetch. Good for on-demand reads.
-- `refresh(payload, maxAge?)` — triggers a re-fetch unless the value is already younger than `maxAge`. Does not await.
+- [`.call(payload, maxAge)`](/api/EndpointCache/call) — returns a cached value if it is younger than `maxAge`. Awaits any in-flight fetch. Good for on-demand reads.
+- [`.refresh(payload, maxAge?)`](/api/EndpointCache/refresh) — triggers a re-fetch unless the value is already younger than `maxAge`. Does not await.
 
 ## Usage
 
-Direct use of `APICache` or `EndpointCache` is rarely necessary outside of `CachedAPIProvider`. They power the [React integration](#see-also) via `createAPIContext()`.
+Direct use of [`APICache`](/api/APICache) or [`EndpointCache`](/api/EndpointCache) is rarely necessary outside of [`CachedAPIProvider`](/api/CachedAPIProvider). They power the [React integration](#see-also) via [`createAPIContext()`](/react/createAPIContext).
 
 ```ts
 import { APICache } from "shelving/api"
@@ -57,7 +57,7 @@ Cache instances implement `AsyncDisposable` — `await using cache = new APICach
 
 ## See also
 
-- [api/store](/api/store) — `EndpointStore`, the reactive leaf node
-- [api/provider](/api/provider) — `CachedAPIProvider` wraps a provider with an `APICache`
-- [store](/store) — `FetchStore` base class
-- [react](/react) — `createAPIContext()` uses `APICache` under the hood
+- [`api/store`](/api) — [`EndpointStore`](/api/EndpointStore), the reactive leaf node
+- [`api/provider`](/api) — [`CachedAPIProvider`](/api/CachedAPIProvider) wraps a provider with an `APICache`
+- [`store`](/store) — [`FetchStore`](/store/FetchStore) base class
+- [`react`](/react) — [`createAPIContext()`](/react/createAPIContext) uses `APICache` under the hood

--- a/modules/api/endpoint/README.md
+++ b/modules/api/endpoint/README.md
@@ -1,6 +1,6 @@
 # Endpoints
 
-Declarative, typed descriptions of API routes. An `Endpoint` captures an HTTP method, a path (with optional `{placeholder}` segments), a payload schema, and a result schema. Define endpoints once; use them on both client and server.
+Declarative, typed descriptions of API routes. An [`Endpoint`](/api/Endpoint) captures an HTTP method, a path (with optional `{placeholder}` segments), a payload schema, and a result schema. Define endpoints once; use them on both client and server.
 
 ## Concepts
 
@@ -10,12 +10,12 @@ Declarative, typed descriptions of API routes. An `Endpoint` captures an HTTP me
 
 | Factory | HTTP method |
 |---|---|
-| `GET(path, payload, result)` | GET |
-| `POST(path, payload, result)` | POST |
-| `PUT(path, payload, result)` | PUT |
-| `PATCH(path, payload, result)` | PATCH |
-| `DELETE(path, payload, result)` | DELETE |
-| `HEAD(path, payload, result)` | HEAD |
+| [`GET(path, payload, result)`](/api/GET) | GET |
+| [`POST(path, payload, result)`](/api/POST) | POST |
+| [`PUT(path, payload, result)`](/api/PUT) | PUT |
+| [`PATCH(path, payload, result)`](/api/PATCH) | PATCH |
+| [`DELETE(path, payload, result)`](/api/DELETE) | DELETE |
+| [`HEAD(path, payload, result)`](/api/HEAD) | HEAD |
 
 All three arguments are optional. Omit `payload` or `result` to get `undefined` typed fields.
 
@@ -39,7 +39,7 @@ const deleteUser = DELETE("/users/{id}", DATA({ id: STRING }))
 
 ### Server-side handler wiring
 
-`endpoint.handler(callback)` pairs an endpoint with an implementation. Pass the resulting `EndpointHandler` objects to `handleEndpoints()`, which matches an incoming `Request` against the list, validates the payload, invokes the callback, and returns a `Response`.
+[`.handler(callback)`](/api/Endpoint/handler) pairs an endpoint with an implementation. Pass the resulting [`EndpointHandler`](/api/EndpointHandler) objects to [`handleEndpoints()`](/api/handleEndpoints), which matches an incoming `Request` against the list, validates the payload, invokes the callback, and returns a `Response`.
 
 ```ts
 import { handleEndpoints } from "shelving/api"
@@ -57,7 +57,7 @@ export default {
 }
 ```
 
-`handleEndpoints` strips the base URL path prefix before matching, so it works behind a sub-path mount. It throws `NotFoundError` if no handler matches and `MethodNotAllowedError` for unsupported methods.
+`handleEndpoints` strips the base URL path prefix before matching, so it works behind a sub-path mount. It throws [`NotFoundError`](/error/NotFoundError) if no handler matches and [`MethodNotAllowedError`](/error/MethodNotAllowedError) for unsupported methods.
 
 ### Callback signature
 
@@ -70,6 +70,6 @@ Return `R` to let `handleEndpoints` validate and serialise the result, or return
 
 ## See also
 
-- [api](/api) — parent module overview
-- [api/provider](/api/provider) — provider stack that calls endpoints client-side
-- [schema](/schema) — `Schema<T>` used for payload and result
+- [`api`](/api) — parent module overview
+- [`api`](/api) — provider stack that calls endpoints client-side
+- [`schema`](/schema) — `Schema<T>` used for payload and result

--- a/modules/api/provider/README.md
+++ b/modules/api/provider/README.md
@@ -6,20 +6,20 @@ The transport layer for API calls. A provider builds requests, sends them, and p
 
 ### Provider hierarchy
 
-`APIProvider` is the abstract base class. `ClientAPIProvider` is the concrete network implementation. All wrapper providers extend `ThroughAPIProvider`, which delegates every method to a `source` provider.
+[`APIProvider`](/api/APIProvider) is the abstract base class. [`ClientAPIProvider`](/api/ClientAPIProvider) is the concrete network implementation. All wrapper providers extend [`ThroughAPIProvider`](/api/ThroughAPIProvider), which delegates every method to a `source` provider.
 
 | Provider | Role |
 |---|---|
-| `ClientAPIProvider` | Sends requests over the network with `fetch()`. Accepts `{ url, options, timeout }`. |
-| `ThroughAPIProvider` | Pass-through base — extend this to intercept only the methods you need. |
-| `ValidationAPIProvider` | Validates payload before request creation and result after response parsing. |
-| `LoggingAPIProvider` | Logs requests, responses, and errors using configurable callbacks (production-safe). |
-| `DebugAPIProvider` | Verbose console output including full request/response bodies — development only. |
-| `JSONAPIProvider` | A `ClientAPIProvider` that forces JSON request bodies and always parses responses as JSON. |
-| `XMLAPIProvider` | A `ClientAPIProvider` that sends XML request bodies and returns raw text responses. |
-| `MockAPIProvider` | Intercepts fetches through a `RequestHandler`; records all calls. No network requests. |
-| `MockEndpointAPIProvider` | Routes mock fetches through a real `EndpointHandler` array — test client and server together. |
-| `CachedAPIProvider` | Serves calls through an `APICache` and exposes `invalidate` / `refresh` helpers. |
+| [`ClientAPIProvider`](/api/ClientAPIProvider) | Sends requests over the network with `fetch()`. Accepts `{ url, options, timeout }`. |
+| [`ThroughAPIProvider`](/api/ThroughAPIProvider) | Pass-through base — extend this to intercept only the methods you need. |
+| [`ValidationAPIProvider`](/api/ValidationAPIProvider) | Validates payload before request creation and result after response parsing. |
+| [`LoggingAPIProvider`](/api/LoggingAPIProvider) | Logs requests, responses, and errors using configurable callbacks (production-safe). |
+| [`DebugAPIProvider`](/api/DebugAPIProvider) | Verbose console output including full request/response bodies — development only. |
+| [`JSONAPIProvider`](/api/JSONAPIProvider) | A `ClientAPIProvider` that forces JSON request bodies and always parses responses as JSON. |
+| [`XMLAPIProvider`](/api/XMLAPIProvider) | A `ClientAPIProvider` that sends XML request bodies and returns raw text responses. |
+| [`MockAPIProvider`](/api/MockAPIProvider) | Intercepts fetches through a `RequestHandler`; records all calls. No network requests. |
+| [`MockEndpointAPIProvider`](/api/MockEndpointAPIProvider) | Routes mock fetches through a real [`EndpointHandler`](/api/EndpointHandler) array — test client and server together. |
+| [`CachedAPIProvider`](/api/CachedAPIProvider) | Serves calls through an [`APICache`](/api/APICache) and exposes `invalidate` / `refresh` helpers. |
 
 Each provider has its own page with focused usage examples.
 
@@ -43,8 +43,8 @@ const user = await provider.call(getUser, { id: "u_123" })
 
 ## See also
 
-- [api](/api) — parent module overview
-- [api/endpoint](/api/endpoint) — endpoint definitions and handler wiring
-- [api/cache](/api/cache) — `APICache` and `EndpointCache` used internally
-- [schema](/schema) — `Schema<T>` used by `ValidationAPIProvider`
-- [react](/react) — `createAPIContext()` for React integration
+- [`api`](/api) — parent module overview
+- [`api`](/api) — endpoint definitions and handler wiring
+- [`api`](/api) — [`APICache`](/api/APICache) and [`EndpointCache`](/api/EndpointCache) used internally
+- [`schema`](/schema) — `Schema<T>` used by [`ValidationAPIProvider`](/api/ValidationAPIProvider)
+- [`react`](/react) — [`createAPIContext()`](/react/createAPIContext) for React integration

--- a/modules/api/store/README.md
+++ b/modules/api/store/README.md
@@ -1,22 +1,22 @@
 # Endpoint store
 
-Reactive per-request state for a single API call. `EndpointStore` holds the current result for one endpoint+payload pair and fetches automatically on first read.
+Reactive per-request state for a single API call. [`EndpointStore`](/api/EndpointStore) holds the current result for one endpoint+payload pair and fetches automatically on first read.
 
 ## Concepts
 
 ### EndpointStore
 
-`EndpointStore<P, R>` extends `PayloadFetchStore` from the [`store`](/store) module. It binds an `Endpoint`, a payload value, and an `APIProvider` together. When `.value` or `.loading` is first read, it triggers a fetch automatically. Concurrent reads de-duplicate the in-flight request — only one network call goes out regardless of how many subscribers read the value.
+`EndpointStore<P, R>` extends [`PayloadFetchStore`](/store/PayloadFetchStore) from the [`store`](/store) module. It binds an [`Endpoint`](/api/Endpoint), a payload value, and an [`APIProvider`](/api/APIProvider) together. When [`.value`](/store/Store/value) or [`.loading`](/store/Store/loading) is first read, it triggers a fetch automatically. Concurrent reads de-duplicate the in-flight request — only one network call goes out regardless of how many subscribers read the value.
 
 The store's reactive contract follows the rest of the shelving store layer:
 
-- `.value` — throws a `Promise` while loading (suspense-compatible), throws `.reason` on failure, returns `R` when ready.
-- `.loading` — `true` while a fetch is in progress; reading it also triggers the initial fetch.
-- `.invalidate()` — marks the value stale; the next read starts a fresh fetch.
-- `.refresh(maxAge?)` — triggers a re-fetch unless the cached value is younger than `maxAge` milliseconds.
+- [`.value`](/store/Store/value) — throws a `Promise` while loading (suspense-compatible), throws [`.reason`](/store/Store/reason) on failure, returns `R` when ready.
+- [`.loading`](/store/Store/loading) — `true` while a fetch is in progress; reading it also triggers the initial fetch.
+- [`.invalidate()`](/store/FetchStore/invalidate) — marks the value stale; the next read starts a fresh fetch.
+- [`.refresh(maxAge?)`](/store/FetchStore/refresh) — triggers a re-fetch unless the cached value is younger than `maxAge` milliseconds.
 - Implements `AsyncIterable<R>` — `for await...of` emits each new value as it arrives.
 
-Payload changes are tracked via the inner `payload` store. Updating `store.payload.value` cancels any in-flight fetch and starts a new one.
+Payload changes are tracked via the inner [`.payload`](/store/PayloadFetchStore/payload) store. Updating `store.payload.value` cancels any in-flight fetch and starts a new one.
 
 ### Where EndpointStore lives in the stack
 
@@ -28,7 +28,7 @@ APICache
         └── EndpointStore  (one per unique rendered URL / payload)
 ```
 
-In normal use you don't create `EndpointStore` directly. [`EndpointCache`](/api/cache) creates and keys them by rendered URL. The [`react`](/react) module's `createAPIContext()` exposes them through hooks.
+In normal use you don't create `EndpointStore` directly. [`EndpointCache`](/api/EndpointCache) creates and keys them by rendered URL. The [`react`](/react) module's [`createAPIContext()`](/react/createAPIContext) exposes them through hooks.
 
 ## Usage
 
@@ -59,7 +59,7 @@ await store.refresh()
 
 ## See also
 
-- [api/cache](/api/cache) — `EndpointCache` and `APICache` manage stores keyed by payload
-- [api/provider](/api/provider) — providers that `EndpointStore` delegates fetching to
-- [store](/store) — `FetchStore` and `PayloadFetchStore` base classes
-- [react](/react) — `createAPIContext()` exposes stores as React hooks
+- [`api`](/api) — [`EndpointCache`](/api/EndpointCache) and [`APICache`](/api/APICache) manage stores keyed by payload
+- [`api`](/api) — providers that [`EndpointStore`](/api/EndpointStore) delegates fetching to
+- [`store`](/store) — [`FetchStore`](/store/FetchStore) and [`PayloadFetchStore`](/store/PayloadFetchStore) base classes
+- [`react`](/react) — [`createAPIContext()`](/react/createAPIContext) exposes stores as React hooks

--- a/modules/bun/README.md
+++ b/modules/bun/README.md
@@ -39,4 +39,4 @@ await migrator.migrate(USERS);
 
 `new SQL(...)` accepts the same connection options as the Bun PostgreSQL client — see the [Bun SQL docs](https://bun.sh/docs/api/sql) for the full list of options including TLS and connection pooling. You can also pass a connection string as the first argument.
 
-Tables must exist before the provider can read or write. [`PostgreSQLMigrator`](/db/PostgreSQLMigrator)`.migrate()` inspects the live schema and issues the minimum `CREATE TABLE` or `ALTER TABLE` statements needed to match your collection definitions.
+Tables must exist before the provider can read or write. [`PostgreSQLMigrator.migrate()`](/db/PostgreSQLMigrator) inspects the live schema and issues the minimum `CREATE TABLE` or `ALTER TABLE` statements needed to match your collection definitions.

--- a/modules/bun/README.md
+++ b/modules/bun/README.md
@@ -1,12 +1,12 @@
 # bun
 
-[DBProvider](/db) implementation for PostgreSQL using Bun's built-in `Bun.sql` API. No external database driver is required.
+[`DBProvider`](/db/DBProvider) implementation for PostgreSQL using Bun's built-in `Bun.sql` API. No external database driver is required.
 
-`BunPostgreSQLProvider` extends the shared `PostgreSQLProvider`, which handles SQL generation, filtering, sorting, pagination, JSONB nested key access, and partial updates. The Bun-specific layer provides the tagged-template SQL execution and wraps identifier quoting through Bun's native SQL engine for additional safety.
+[`BunPostgreSQLProvider`](/bun/BunPostgreSQLProvider) extends the shared [`PostgreSQLProvider`](/db/PostgreSQLProvider), which handles SQL generation, filtering, sorting, pagination, JSONB nested key access, and partial updates. The Bun-specific layer provides the tagged-template SQL execution and wraps identifier quoting through Bun's native SQL engine for additional safety.
 
 **Bun only.** This module uses `Bun.sql` and `SQL` from `bun`, which are not available in Node.js or other runtimes.
 
-There is no realtime support — `getItemSequence()` and `getQuerySequence()` throw `UnimplementedError`.
+There is no realtime support — [`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) throw [`UnimplementedError`](/error/UnimplementedError).
 
 ## PostgreSQL (`BunPostgreSQLProvider`)
 
@@ -39,4 +39,4 @@ await migrator.migrate(USERS);
 
 `new SQL(...)` accepts the same connection options as the Bun PostgreSQL client — see the [Bun SQL docs](https://bun.sh/docs/api/sql) for the full list of options including TLS and connection pooling. You can also pass a connection string as the first argument.
 
-Tables must exist before the provider can read or write. `PostgreSQLMigrator.migrate()` inspects the live schema and issues the minimum `CREATE TABLE` or `ALTER TABLE` statements needed to match your collection definitions.
+Tables must exist before the provider can read or write. [`PostgreSQLMigrator`](/db/PostgreSQLMigrator)`.migrate()` inspects the live schema and issues the minimum `CREATE TABLE` or `ALTER TABLE` statements needed to match your collection definitions.

--- a/modules/cloudflare/README.md
+++ b/modules/cloudflare/README.md
@@ -1,20 +1,20 @@
 # cloudflare
 
-[DBProvider](/db) implementations for Cloudflare Workers. Two backends are available: Workers KV for simple key-value storage and D1 for relational SQL.
+[`DBProvider`](/db/DBProvider) implementations for Cloudflare Workers. Two backends are available: Workers KV for simple key-value storage and D1 for relational SQL.
 
 Both providers accept a binding object injected by the Cloudflare Workers runtime. Declare the binding in `wrangler.toml` and access it through the `env` parameter of your Worker's `fetch` handler.
 
-## KV (`CloudflareKVProvider`)
+## KV ([`CloudflareKVProvider`](/cloudflare/CloudflareKVProvider))
 
 Workers KV is a globally distributed key-value store. It is the right choice when you need fast single-item reads and writes by ID across Cloudflare's edge network, and do not need to query or filter across items.
 
-Items are stored as JSON under keys formatted as `collection:id`. `addItem()` generates a UUID v4 identifier automatically.
+Items are stored as JSON under keys formatted as `collection:id`. [`.addItem()`](/db/DBProvider/addItem) generates a UUID v4 identifier automatically.
 
 **Limitations:**
 
-- No queries — `getQuery()`, `setQuery()`, `deleteQuery()`, and `countQuery()` throw `UnimplementedError`.
-- No partial updates — `updateItem()` and `updateQuery()` throw `UnimplementedError`.
-- No realtime — `getItemSequence()` and `getQuerySequence()` throw `UnimplementedError`.
+- No queries — [`.getQuery()`](/db/DBProvider/getQuery), [`.setQuery()`](/db/DBProvider/setQuery), [`.deleteQuery()`](/db/DBProvider/deleteQuery), and [`.countQuery()`](/db/DBProvider/countQuery) throw [`UnimplementedError`](/error/UnimplementedError).
+- No partial updates — [`.updateItem()`](/db/DBProvider/updateItem) and [`.updateQuery()`](/db/DBProvider/updateQuery) throw `UnimplementedError`.
+- No realtime — [`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) throw `UnimplementedError`.
 - Eventual consistency — reads may briefly return stale data after a write.
 
 **Install:**
@@ -40,13 +40,13 @@ export default {
 };
 ```
 
-## D1 (`CloudflareD1Provider`)
+## D1 ([`CloudflareD1Provider`](/cloudflare/CloudflareD1Provider))
 
 D1 is Cloudflare's edge SQLite database. It supports collection queries with filtering, sorting, and pagination. Use it when you need structured data and the ability to query across items.
 
-`CloudflareD1Provider` extends the shared `SQLiteProvider`, so it inherits standard SQL-based CRUD and query behaviour. There is no realtime support — `getItemSequence()` and `getQuerySequence()` throw `UnimplementedError`.
+`CloudflareD1Provider` extends the shared [`SQLiteProvider`](/db/SQLiteProvider), so it inherits standard SQL-based CRUD and query behaviour. There is no realtime support — [`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) throw [`UnimplementedError`](/error/UnimplementedError).
 
-Tables must exist before the provider can read or write. Use `SQLiteMigrator` from `shelving/db` to create and migrate tables from your collection definitions.
+Tables must exist before the provider can read or write. Use [`SQLiteMigrator`](/db/SQLiteMigrator) from `shelving/db` to create and migrate tables from your collection definitions.
 
 ```wrangler.toml
 [[d1_databases]]

--- a/modules/db/README.md
+++ b/modules/db/README.md
@@ -1,12 +1,12 @@
 # db
 
-Typed database provider abstraction. Define your schema once as a [`Collection`](/db/collection), then swap providers (in-memory, SQLite, Firestore, Cloudflare D1, …) without changing any call sites. Providers are composable wrappers — add validation, logging, or caching by stacking them in a chain.
+Typed database provider abstraction. Define your schema once as a [`Collection`](/db/Collection), then swap providers (in-memory, SQLite, Firestore, Cloudflare D1, …) without changing any call sites. Providers are composable wrappers — add validation, logging, or caching by stacking them in a chain.
 
 ## Concepts
 
 ### Collection
 
-A `Collection` is a declarative description of a database table or collection. It extends [`DataSchema`](/schema) and carries three things: a string `name`, an `id` schema (the identifier type), and a data schema (the shape of each record).
+A [`Collection`](/db/Collection) is a declarative description of a database table or collection. It extends [`DataSchema`](/schema/DataSchema) and carries three things: a string `name`, an `id` schema (the identifier type), and a data schema (the shape of each record).
 
 ```ts
 import { COLLECTION } from "shelving/db"
@@ -23,16 +23,16 @@ const POSTS = COLLECTION("posts", STRING, {
 
 ### DBProvider
 
-`DBProvider` is the abstract base class every backend implements. Its surface covers:
+[`DBProvider`](/db/DBProvider) is the abstract base class every backend implements. Its surface covers:
 
 | Category | Methods |
 |---|---|
-| Single item | `getItem`, `requireItem`, `addItem`, `setItem`, `updateItem`, `deleteItem` |
-| Single item (realtime) | `getItemSequence` |
-| Queries | `getQuery`, `countQuery`, `setQuery`, `updateQuery`, `deleteQuery`, `getFirst`, `requireFirst` |
-| Query (realtime) | `getQuerySequence` |
+| Single item | [`.getItem()`](/db/DBProvider/getItem), [`.requireItem()`](/db/DBProvider/requireItem), [`.addItem()`](/db/DBProvider/addItem), [`.setItem()`](/db/DBProvider/setItem), [`.updateItem()`](/db/DBProvider/updateItem), [`.deleteItem()`](/db/DBProvider/deleteItem) |
+| Single item (realtime) | [`.getItemSequence()`](/db/DBProvider/getItemSequence) |
+| Queries | [`.getQuery()`](/db/DBProvider/getQuery), [`.countQuery()`](/db/DBProvider/countQuery), [`.setQuery()`](/db/DBProvider/setQuery), [`.updateQuery()`](/db/DBProvider/updateQuery), [`.deleteQuery()`](/db/DBProvider/deleteQuery), [`.getFirst()`](/db/DBProvider/getFirst), [`.requireFirst()`](/db/DBProvider/requireFirst) |
+| Query (realtime) | [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) |
 
-`getItemSequence` and `getQuerySequence` return `AsyncIterable` — iterate them with `for await...of` to receive realtime updates as data changes.
+`.getItemSequence()` and `.getQuerySequence()` return `AsyncIterable` — iterate them with `for await...of` to receive realtime updates as data changes.
 
 ### Query syntax
 
@@ -51,17 +51,17 @@ Query objects use encoded key names alongside plain field names:
 
 Providers are layered wrappers. Each takes a `source` and delegates to it, intercepting only what it needs.
 
-- **`MemoryDBProvider`** — fully in-memory, ideal for testing and as a lightweight standalone store.
-- **`ValidationDBProvider`** — validates data in and out using the collection's schema. Throws `ValueError` on bad data from the backend.
-- **`CacheDBProvider`** — keeps a `MemoryDBProvider` mirror in sync with a remote source so reads are synchronous after the first fetch. Primarily useful with the [React integration](#react-integration).
-- **`ThroughDBProvider`** — identity wrapper; extend this to intercept only specific methods (e.g. `DebugDBProvider`).
-- **`SQLiteProvider`** / **`PostgreSQLProvider`** — SQL-backed abstract providers. Concrete subclasses bind them to a specific driver.
+- **[`MemoryDBProvider`](/db/MemoryDBProvider)** — fully in-memory, ideal for testing and as a lightweight standalone store.
+- **[`ValidationDBProvider`](/db/ValidationDBProvider)** — validates data in and out using the collection's schema. Throws [`ValueError`](/error/ValueError) on bad data from the backend.
+- **[`CacheDBProvider`](/db/CacheDBProvider)** — keeps a `MemoryDBProvider` mirror in sync with a remote source so reads are synchronous after the first fetch. Primarily useful with the [React integration](#react-integration).
+- **[`ThroughDBProvider`](/db/ThroughDBProvider)** — identity wrapper; extend this to intercept only specific methods (e.g. [`DebugDBProvider`](/db/DebugDBProvider)).
+- **[`SQLiteProvider`](/db/SQLiteProvider)** / **[`PostgreSQLProvider`](/db/PostgreSQLProvider)** — SQL-backed abstract providers. Concrete subclasses bind them to a specific driver.
 
-Cloud providers live in the [`cloudflare`](/cloudflare) and [`firestore`](/firestore) sibling modules.
+Cloud providers live in the [`cloudflare`](/cloudflare) and [`firestore`](/firestore/client) sibling modules.
 
 ### Migrations
 
-`DBMigrator` is an abstract base for schema migrations. SQL-backed providers ship `SQLiteMigrator` and `PostgreSQLMigrator`, which implement `migrate(...collections)` to create or alter tables to match the current collection schemas.
+[`DBMigrator`](/db/DBMigrator) is an abstract base for schema migrations. SQL-backed providers ship [`SQLiteMigrator`](/db/SQLiteMigrator) and [`PostgreSQLMigrator`](/db/PostgreSQLMigrator), which implement [`.migrate()`](/db/DBMigrator/migrate) to create or alter tables to match the current collection schemas.
 
 ## Usage
 
@@ -117,7 +117,7 @@ for await (const post of provider.getItemSequence(POSTS, id)) {
 
 ## React integration
 
-The [`react`](/react) module's `createDBContext()` is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — `useItem()` and `useQuery()` — that return reactive `Store` instances and suspend automatically while loading.
+The [`react`](/react) module's [`createDBContext()`](/react/createDBContext) is the primary way to use a provider in a React app. It creates a context that wraps a provider (typically with a `CacheDBProvider` in the chain) and exposes typed hooks — [`.useItem()`](/react/DBContext/useItem) and [`.useQuery()`](/react/DBContext/useQuery) — that return reactive [`Store`](/store/Store) instances and suspend automatically while loading.
 
 ```ts
 import { createDBContext } from "shelving/react"
@@ -131,8 +131,8 @@ See the [`react`](/react) module for full usage.
 
 ## See also
 
-- [`schema`](/schema) — `DataSchema` that `Collection` extends
-- [`store`](/store) — `Store` base class used by `ItemStore` and `QueryStore`
-- [`react`](/react) — `createDBContext()` for React integration
+- [`schema`](/schema) — [`DataSchema`](/schema/DataSchema) that [`Collection`](/db/Collection) extends
+- [`store`](/store) — [`Store`](/store/Store) base class used by [`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore)
+- [`react`](/react) — [`createDBContext()`](/react/createDBContext) for React integration
 - [`cloudflare`](/cloudflare) — Cloudflare KV and D1 providers
-- [`firestore`](/firestore) — Firestore providers
+- [`firestore`](/firestore/client) — Firestore providers

--- a/modules/db/cache/README.md
+++ b/modules/db/cache/README.md
@@ -1,24 +1,24 @@
 # Cache
 
-`DBCache` and `CollectionCache` are the store-management layer that sits between a `DBProvider` and the reactive `ItemStore` / `QueryStore` instances used by UI code. They ensure that only one store exists per (collection, id) or (collection, query) pair and expose a `refresh` API to pull fresh data on demand.
+[`DBCache`](/db/DBCache) and [`CollectionCache`](/db/CollectionCache) are the store-management layer that sits between a [`DBProvider`](/db/DBProvider) and the reactive [`ItemStore`](/db/ItemStore) / [`QueryStore`](/db/QueryStore) instances used by UI code. They ensure that only one store exists per (collection, id) or (collection, query) pair and expose a `refresh` API to pull fresh data on demand.
 
 ## Concepts
 
 ### DBCache
 
-`DBCache` is a registry of `CollectionCache` objects, one per `Collection`. Call `cache.getItem(collection, id)` or `cache.getQuery(collection, query)` to retrieve or lazily create a store. Calling the same method twice with the same arguments returns the exact same store instance.
+`DBCache` is a registry of `CollectionCache` objects, one per [`Collection`](/db/Collection). Call [`.getItem()`](/db/DBCache/getItem) or [`.getQuery()`](/db/DBCache/getQuery) to retrieve or lazily create a store. Calling the same method twice with the same arguments returns the exact same store instance.
 
-If the provider chain contains a `CacheDBProvider`, `DBCache` finds it automatically via `getSource` and reuses its `MemoryDBProvider` mirror. Stores are then seeded with the current in-memory snapshot and subscribe to live updates from it — so the first render is synchronous when data is already cached.
+If the provider chain contains a [`CacheDBProvider`](/db/CacheDBProvider), `DBCache` finds it automatically via `getSource` and reuses its [`MemoryDBProvider`](/db/MemoryDBProvider) mirror. Stores are then seeded with the current in-memory snapshot and subscribe to live updates from it — so the first render is synchronous when data is already cached.
 
 ### CollectionCache
 
 `CollectionCache` manages stores for a single collection. It is used internally by `DBCache` but is also available directly when you need per-collection refresh control.
 
-- `getItem(id)` — returns an `ItemStore` for the id, creating it if needed.
-- `getQuery(query)` — returns a `QueryStore` for the query, keyed by `JSON.stringify(query)`.
-- `refreshItem(id, maxAge?)` / `refreshItems(maxAge?)` — re-fetch one or all item stores.
-- `refreshQuery(query, maxAge?)` / `refreshQueries(maxAge?)` — re-fetch one or all query stores.
-- `refreshAll(maxAge?)` — re-fetch everything in this collection at once.
+- [`.getItem()`](/db/CollectionCache/getItem) — returns an `ItemStore` for the id, creating it if needed.
+- [`.getQuery()`](/db/CollectionCache/getQuery) — returns a `QueryStore` for the query, keyed by `JSON.stringify(query)`.
+- [`.refreshItem()`](/db/CollectionCache/refreshItem) / [`.refreshItems()`](/db/CollectionCache/refreshItems) — re-fetch one or all item stores.
+- [`.refreshQuery()`](/db/CollectionCache/refreshQuery) / [`.refreshQueries()`](/db/CollectionCache/refreshQueries) — re-fetch one or all query stores.
+- [`.refreshAll()`](/db/CollectionCache/refreshAll) — re-fetch everything in this collection at once.
 
 Both `DBCache` and `CollectionCache` implement `AsyncDisposable`. Disposing them disposes every store they hold.
 
@@ -69,6 +69,6 @@ await using cache = new DBCache(provider);
 
 ## See also
 
-- [db/store](/db/store) — `ItemStore` and `QueryStore` that `CollectionCache` creates and manages
-- [db/provider](/db/provider) — `CacheDBProvider` whose memory layer `DBCache` reuses
-- [react](/react) — `createDBContext()` builds a `DBCache` internally for React hooks
+- [`db`](/db) — [`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore) that `CollectionCache` creates and manages
+- [`db`](/db) — [`CacheDBProvider`](/db/CacheDBProvider) whose memory layer `DBCache` reuses
+- [`react`](/react) — [`createDBContext()`](/react/createDBContext) builds a `DBCache` internally for React hooks

--- a/modules/db/collection/README.md
+++ b/modules/db/collection/README.md
@@ -1,6 +1,6 @@
 # Collection
 
-`Collection` is the typed definition of a database table. It combines a name, an identifier schema, and a data schema into a single object that every provider method uses as its source of truth for types and validation.
+[`Collection`](/db/Collection) is the typed definition of a database table. It combines a name, an identifier schema, and a data schema into a single object that every provider method uses as its source of truth for types and validation.
 
 By convention, instantiated collections are constants and use `UPPERCASE`.
 
@@ -11,14 +11,14 @@ By convention, instantiated collections are constants and use `UPPERCASE`.
 A `Collection<N, I, T>` carries three things:
 
 - `name` — the string key used as the table or collection name in the database.
-- `id` — a `Schema<I>` that validates the identifier type. Use `INTEGER` for auto-increment integer IDs, `STRING` for UUIDs, or any other schema.
-- The data schema — the shape of each record, defined as a plain object of named schemas. `Collection` extends `DataSchema`, so it validates data directly via `.validate(data)`.
+- `id` — a [`Schema`](/schema/Schema)`<I>` that validates the identifier type. Use [`INTEGER`](/schema/INTEGER) for auto-increment integer IDs, [`STRING`](/schema/STRING) for UUIDs, or any other schema.
+- The data schema — the shape of each record, defined as a plain object of named schemas. `Collection` extends [`DataSchema`](/schema/DataSchema), so it validates data directly via [`.validate()`](/schema/Schema/validate).
 
 It also exposes `collection.item`, a combined `DataSchema<{ id: I } & T>` used by providers to validate complete items returned from the backend.
 
 ### The `ID` constant
 
-`ID` is the default integer identifier schema (step 1, safe integer range). Import it when you want an explicit integer ID or when extending a collection.
+[`ID`](/db/ID) is the default integer identifier schema (step 1, safe integer range). Import it when you want an explicit integer ID or when extending a collection.
 
 ### Utility types
 
@@ -26,12 +26,12 @@ The module exports helper types to extract typed parts from a `Collection` varia
 
 | Type | Extracts |
 |---|---|
-| `CollectionName<C>` | The string literal name |
-| `CollectionIdentifier<C>` | The identifier type `I` |
-| `CollectionData<C>` | The data type `T` |
-| `CollectionItem<C>` | `Item<I, T>` |
-| `OptionalCollectionItem<C>` | `Item<I, T> \| undefined` |
-| `CollectionItems<C>` | `readonly Item<I, T>[]` |
+| [`CollectionName`](/db/CollectionName)`<C>` | The string literal name |
+| [`CollectionIdentifier`](/db/CollectionIdentifier)`<C>` | The identifier type `I` |
+| [`CollectionData`](/db/CollectionData)`<C>` | The data type `T` |
+| [`CollectionItem`](/db/CollectionItem)`<C>` | [`Item`](/util/item/Item)`<I, T>` |
+| [`OptionalCollectionItem`](/db/OptionalCollectionItem)`<C>` | `Item<I, T> \| undefined` |
+| [`CollectionItems`](/db/CollectionItems)`<C>` | `readonly Item<I, T>[]` |
 
 ## Usage
 
@@ -78,7 +78,7 @@ type PostItem = CollectionItem<typeof POSTS>;  // { id: string; title: string; b
 
 ## See also
 
-- [db](/db) — provider methods all accept a `Collection` as their first argument
-- [schema](/schema) — `DataSchema` that `Collection` extends; `ITEM` that builds `collection.item`
-- [db/provider](/db/provider) — `DBProvider` and the built-in provider implementations
-- [db/migrate](/db/migrate) — `SQLiteMigrator` and `PostgreSQLMigrator` use collection schemas to create and alter tables
+- [`db`](/db) — provider methods all accept a `Collection` as their first argument
+- [`schema`](/schema) — [`DataSchema`](/schema/DataSchema) that `Collection` extends; [`ITEM()`](/schema/ITEM) that builds `collection.item`
+- [`db`](/db) — [`DBProvider`](/db/DBProvider) and the built-in provider implementations
+- [`db`](/db) — [`SQLiteMigrator`](/db/SQLiteMigrator) and [`PostgreSQLMigrator`](/db/PostgreSQLMigrator) use collection schemas to create and alter tables

--- a/modules/db/collection/README.md
+++ b/modules/db/collection/README.md
@@ -11,7 +11,7 @@ By convention, instantiated collections are constants and use `UPPERCASE`.
 A `Collection<N, I, T>` carries three things:
 
 - `name` — the string key used as the table or collection name in the database.
-- `id` — a [`Schema`](/schema/Schema)`<I>` that validates the identifier type. Use [`INTEGER`](/schema/INTEGER) for auto-increment integer IDs, [`STRING`](/schema/STRING) for UUIDs, or any other schema.
+- `id` — a [`Schema<I>`](/schema/Schema) that validates the identifier type. Use [`INTEGER`](/schema/INTEGER) for auto-increment integer IDs, [`STRING`](/schema/STRING) for UUIDs, or any other schema.
 - The data schema — the shape of each record, defined as a plain object of named schemas. `Collection` extends [`DataSchema`](/schema/DataSchema), so it validates data directly via [`.validate()`](/schema/Schema/validate).
 
 It also exposes `collection.item`, a combined `DataSchema<{ id: I } & T>` used by providers to validate complete items returned from the backend.
@@ -26,12 +26,12 @@ The module exports helper types to extract typed parts from a `Collection` varia
 
 | Type | Extracts |
 |---|---|
-| [`CollectionName`](/db/CollectionName)`<C>` | The string literal name |
-| [`CollectionIdentifier`](/db/CollectionIdentifier)`<C>` | The identifier type `I` |
-| [`CollectionData`](/db/CollectionData)`<C>` | The data type `T` |
-| [`CollectionItem`](/db/CollectionItem)`<C>` | [`Item`](/util/item/Item)`<I, T>` |
-| [`OptionalCollectionItem`](/db/OptionalCollectionItem)`<C>` | `Item<I, T> \| undefined` |
-| [`CollectionItems`](/db/CollectionItems)`<C>` | `readonly Item<I, T>[]` |
+| [`CollectionName<C>`](/db/CollectionName) | The string literal name |
+| [`CollectionIdentifier<C>`](/db/CollectionIdentifier) | The identifier type `I` |
+| [`CollectionData<C>`](/db/CollectionData) | The data type `T` |
+| [`CollectionItem<C>`](/db/CollectionItem) | [`Item<I, T>`](/util/item/Item) |
+| [`OptionalCollectionItem<C>`](/db/OptionalCollectionItem) | `Item<I, T> \| undefined` |
+| [`CollectionItems<C>`](/db/CollectionItems) | `readonly Item<I, T>[]` |
 
 ## Usage
 

--- a/modules/db/migrate/README.md
+++ b/modules/db/migrate/README.md
@@ -1,16 +1,16 @@
 # Migrations
 
-Schema migration for SQL-backed database providers. `DBMigrator` and its subclasses compare a provider's live table schema against your `Collection` definitions and emit the SQL statements needed to bring them in sync — creating missing tables and adding or dropping generated columns.
+Schema migration for SQL-backed database providers. [`DBMigrator`](/db/DBMigrator) and its subclasses compare a provider's live table schema against your [`Collection`](/db/Collection) definitions and emit the SQL statements needed to bring them in sync — creating missing tables and adding or dropping generated columns.
 
 ## Concepts
 
 ### DBMigrator
 
-`DBMigrator` is the abstract base class. It holds a reference to the provider and declares one method: `migrate(...collections)`. Concrete subclasses implement `migrate` to inspect the live schema and run the required SQL.
+`DBMigrator` is the abstract base class. It holds a reference to the provider and declares one method: [`.migrate()`](/db/DBMigrator/migrate). Concrete subclasses implement `migrate` to inspect the live schema and run the required SQL.
 
 ### SQLMigrator
 
-`SQLMigrator` extends `DBMigrator` with the shared SQL diffing logic. It:
+[`SQLMigrator`](/db/SQLMigrator) extends `DBMigrator` with the shared SQL diffing logic. It:
 
 - Calls `getTables()` to list existing tables.
 - For each collection, calls `getTable(name)` to read the current column definitions.
@@ -44,7 +44,7 @@ await migrator.migrate(POSTS, COMMENTS);
 
 ### Inspect migrations without running them
 
-`getMigrations(...collections)` returns the SQL strings without executing them. Useful for previewing or logging:
+[`.getMigrations()`](/db/SQLMigrator/getMigrations) returns the SQL strings without executing them. Useful for previewing or logging:
 
 ```ts
 const sql = await migrator.getMigrations(POSTS, COMMENTS);
@@ -71,7 +71,7 @@ const PRODUCTS = COLLECTION("products", STRING, {
 
 ## See also
 
-- [db/collection](/db/collection) — `Collection` / `COLLECTION` definitions that migrators consume
-- [db/provider](/db/provider) — `SQLiteProvider` and `PostgreSQLProvider` that migrators run against
-- [cloudflare](/cloudflare) — D1 provider and migrator usage in Cloudflare Workers
-- [bun](/bun) — Bun PostgreSQL provider for use with `PostgreSQLMigrator`
+- [`db`](/db) — [`Collection`](/db/Collection) / [`COLLECTION()`](/db/COLLECTION) definitions that migrators consume
+- [`db`](/db) — [`SQLiteProvider`](/db/SQLiteProvider) and [`PostgreSQLProvider`](/db/PostgreSQLProvider) that migrators run against
+- [`cloudflare`](/cloudflare) — D1 provider and migrator usage in Cloudflare Workers
+- [`bun`](/bun) — Bun PostgreSQL provider for use with [`PostgreSQLMigrator`](/db/PostgreSQLMigrator)

--- a/modules/db/provider/README.md
+++ b/modules/db/provider/README.md
@@ -1,16 +1,16 @@
 # Providers
 
-This directory contains `DBProvider` — the abstract base every backend implements — and all the built-in provider implementations. Providers are composable: wrap a backend in any combination of `ValidationDBProvider`, `CacheDBProvider`, or `DebugDBProvider` to add behaviour without touching call sites.
+This directory contains [`DBProvider`](/db/DBProvider) — the abstract base every backend implements — and all the built-in provider implementations. Providers are composable: wrap a backend in any combination of [`ValidationDBProvider`](/db/ValidationDBProvider), [`CacheDBProvider`](/db/CacheDBProvider), or [`DebugDBProvider`](/db/DebugDBProvider) to add behaviour without touching call sites.
 
 ## Concepts
 
 ### DBProvider
 
-`DBProvider` is the abstract base class. Concrete backends implement its abstract methods; the base class provides default implementations for `requireItem`, `countQuery`, `getFirst`, and `requireFirst` built on top of them.
+`DBProvider` is the abstract base class. Concrete backends implement its abstract methods; the base class provides default implementations for [`.requireItem()`](/db/DBProvider/requireItem), [`.countQuery()`](/db/DBProvider/countQuery), [`.getFirst()`](/db/DBProvider/getFirst), and [`.requireFirst()`](/db/DBProvider/requireFirst) built on top of them.
 
 `DBProvider` implements `AsyncDisposable`. Use `await using provider = …` or `await provider[Symbol.asyncDispose]()` to release underlying connections.
 
-SQLite realtime sequences (`getItemSequence`, `getQuerySequence`) are not supported by `SQLProvider` — they throw `UnimplementedError`. Realtime is available from `MemoryDBProvider` and cloud providers.
+SQLite realtime sequences ([`.getItemSequence()`](/db/DBProvider/getItemSequence), [`.getQuerySequence()`](/db/DBProvider/getQuerySequence)) are not supported by [`SQLProvider`](/db/SQLProvider) — they throw [`UnimplementedError`](/error/UnimplementedError). Realtime is available from [`MemoryDBProvider`](/db/MemoryDBProvider) and cloud providers.
 
 ### Provider chain
 
@@ -19,15 +19,15 @@ Stack providers to compose behaviour. Each wrapping provider delegates to its `s
 | Provider | Role |
 |---|---|
 | `MemoryDBProvider` | In-memory store — fast, no persistence. Use for tests and as the cache layer. |
-| `ValidationDBProvider` | Validates data written to and read from the source against the collection schema. Throws `ValueError` on bad backend data. |
+| `ValidationDBProvider` | Validates data written to and read from the source against the collection schema. Throws [`ValueError`](/error/ValueError) on bad backend data. |
 | `CacheDBProvider` | Keeps a `MemoryDBProvider` mirror in sync with a remote source so reads arrive synchronously after the first fetch. |
-| `ThroughDBProvider` | Identity passthrough. Extend this to override only specific methods. |
+| [`ThroughDBProvider`](/db/ThroughDBProvider) | Identity passthrough. Extend this to override only specific methods. |
 | `DebugDBProvider` | Logs all operations to the console (ANSI-formatted). Extends `ThroughDBProvider`. |
-| `ChangesDBProvider` | Accumulates a `.changes` log of every write. Useful for audit trails and testing. Extends `ThroughDBProvider`. |
-| `MockDBProvider` | Extends `MemoryDBProvider` and records every call in `.calls`. Use in tests to assert operations. |
+| [`ChangesDBProvider`](/db/ChangesDBProvider) | Accumulates a [`.changes`](/db/ChangesDBProvider/changes) log of every write. Useful for audit trails and testing. Extends `ThroughDBProvider`. |
+| [`MockDBProvider`](/db/MockDBProvider) | Extends `MemoryDBProvider` and records every call in [`.calls`](/db/MockDBProvider/calls). Use in tests to assert operations. |
 | `SQLProvider` | Abstract SQL base — concrete subclasses bind it to a driver. |
-| `SQLiteProvider` | Abstract SQL backend targeting SQLite / D1 with JSON1 support for nested keys and array operations. |
-| `PostgreSQLProvider` | Abstract SQL backend targeting PostgreSQL with JSONB support. |
+| [`SQLiteProvider`](/db/SQLiteProvider) | Abstract SQL backend targeting SQLite / D1 with JSON1 support for nested keys and array operations. |
+| [`PostgreSQLProvider`](/db/PostgreSQLProvider) | Abstract SQL backend targeting PostgreSQL with JSONB support. |
 
 ## Usage
 
@@ -49,9 +49,9 @@ const provider = new CacheDBProvider(
 
 ## See also
 
-- [db](/db) — overview and full usage examples
-- [db/collection](/db/collection) — `Collection` / `COLLECTION` definition
-- [db/cache](/db/cache) — `DBCache` and `CollectionCache` for reactive store management
-- [db/migrate](/db/migrate) — `SQLiteMigrator` / `PostgreSQLMigrator` for schema migration
-- [cloudflare](/cloudflare) — Cloudflare KV and D1 provider implementations
-- [firestore](/firestore) — Firestore provider implementation
+- [`db`](/db) — overview and full usage examples
+- [`db`](/db) — [`Collection`](/db/Collection) / [`COLLECTION()`](/db/COLLECTION) definition
+- [`db`](/db) — [`DBCache`](/db/DBCache) and [`CollectionCache`](/db/CollectionCache) for reactive store management
+- [`db`](/db) — [`SQLiteMigrator`](/db/SQLiteMigrator) / [`PostgreSQLMigrator`](/db/PostgreSQLMigrator) for schema migration
+- [`cloudflare`](/cloudflare) — Cloudflare KV and D1 provider implementations
+- [`firestore`](/firestore/client) — Firestore provider implementation

--- a/modules/db/store/README.md
+++ b/modules/db/store/README.md
@@ -1,37 +1,37 @@
 # Stores
 
-`ItemStore` and `QueryStore` are reactive, database-backed stores. Each one holds the current value of a single item or query result and re-fetches from the provider when asked. They integrate with React Suspense — reading `.value` while loading throws a `Promise` that Suspense catches.
+[`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore) are reactive, database-backed stores. Each one holds the current value of a single item or query result and re-fetches from the provider when asked. They integrate with React Suspense — reading `.value` while loading throws a `Promise` that Suspense catches.
 
-Both extend `FetchStore` from the [`store`](/store) module, which manages the loading / error / ready lifecycle and the `refresh(maxAge?)` method.
+Both extend [`FetchStore`](/store/FetchStore) from the [`store`](/store) module, which manages the loading / error / ready lifecycle and the `refresh(maxAge?)` method.
 
 ## Concepts
 
 ### ItemStore
 
-`ItemStore<I, T>` holds `OptionalItem<I, T>` — the current item, or `undefined` if it does not exist. It calls `provider.getItem(collection, id)` on the first fetch and whenever `refresh()` is called.
+`ItemStore<I, T>` holds [`OptionalItem`](/util/item/OptionalItem)`<I, T>` — the current item, or `undefined` if it does not exist. It calls [`.getItem()`](/db/DBProvider/getItem) on the first fetch and whenever `refresh()` is called.
 
-- `.item` — returns the item or throws `RequiredError` if absent. Safe to use once the store is loaded and you know the item exists.
-- `.item = data` — write helper that sets `.value` to `getItem(id, data)` directly (bypasses the provider; useful for optimistic updates).
+- [`.item`](/db/ItemStore/item) — returns the item or throws [`RequiredError`](/error/RequiredError) if absent. Safe to use once the store is loaded and you know the item exists.
+- `.item = data` — write helper that sets `.value` to [`getItem()`](/util/item/getItem) directly (bypasses the provider; useful for optimistic updates).
 
-When a `MemoryDBProvider` is supplied (via `DBCache` reusing the `CacheDBProvider` mirror), the store seeds its initial value from the in-memory snapshot and subscribes to live changes via `memory.getItemSequence`. This makes the first render synchronous if the data is already cached.
+When a [`MemoryDBProvider`](/db/MemoryDBProvider) is supplied (via [`DBCache`](/db/DBCache) reusing the [`CacheDBProvider`](/db/CacheDBProvider) mirror), the store seeds its initial value from the in-memory snapshot and subscribes to live changes via [`.getItemSequence()`](/db/DBProvider/getItemSequence). This makes the first render synchronous if the data is already cached.
 
 ### QueryStore
 
-`QueryStore<I, T>` holds `Items<I, T>` — a readonly array of matching items. It calls `provider.getQuery(collection, query)` on the first fetch. Like `ItemStore`, it seeds from memory when available.
+`QueryStore<I, T>` holds [`Items`](/util/item/Items)`<I, T>` — a readonly array of matching items. It calls [`.getQuery()`](/db/DBProvider/getQuery) on the first fetch. Like `ItemStore`, it seeds from memory when available.
 
 Additional accessors beyond the base `FetchStore`:
 
-- `.first` / `.last` — the first or last item; throw `RequiredError` if the result is empty.
-- `.optionalFirst` / `.optionalLast` — same, returning `undefined` instead of throwing.
-- `.limit` — the `$limit` from the query, or `Infinity` if not set.
-- `.hasMore` — whether a subsequent page fetch might return more results (not yet implemented, reserved).
+- [`.first`](/db/QueryStore/first) / [`.last`](/db/QueryStore/last) — the first or last item; throw `RequiredError` if the result is empty.
+- [`.optionalFirst`](/db/QueryStore/optionalFirst) / [`.optionalLast`](/db/QueryStore/optionalLast) — same, returning `undefined` instead of throwing.
+- [`.limit`](/db/QueryStore/limit) — the `$limit` from the query, or `Infinity` if not set.
+- [`.hasMore`](/db/QueryStore/hasMore) — whether a subsequent page fetch might return more results (not yet implemented, reserved).
 - `[Symbol.iterator]` — `QueryStore` is directly iterable, so `for...of store` works.
 
 ## Usage
 
 ### Direct instantiation
 
-You do not usually create these stores directly. [`DBCache`](/db/cache) manages them so only one store exists per (collection, id-or-query). Direct use is shown here for clarity.
+You do not usually create these stores directly. [`DBCache`](/db/DBCache) manages them so only one store exists per (collection, id-or-query). Direct use is shown here for clarity.
 
 ```ts
 import { ItemStore, QueryStore } from "shelving/db";
@@ -64,10 +64,10 @@ console.log(store.loading); // false if already in cache
 
 ### React Suspense integration
 
-In a React app, use [`createDBContext`](/react) instead of managing stores manually. The context wraps a `DBCache` and the `useItem()` / `useQuery()` hooks handle Suspense automatically.
+In a React app, use [`createDBContext()`](/react/createDBContext) instead of managing stores manually. The context wraps a `DBCache` and the [`.useItem()`](/react/DBContext/useItem) / [`.useQuery()`](/react/DBContext/useQuery) hooks handle Suspense automatically.
 
 ## See also
 
-- [store](/store) — `FetchStore`, `OptionalDataStore`, `ArrayStore` base classes
-- [db/cache](/db/cache) — `DBCache` / `CollectionCache` that manage store instances
-- [react](/react) — `createDBContext()` for React hook integration
+- [`store`](/store) — [`FetchStore`](/store/FetchStore), [`OptionalDataStore`](/store/OptionalDataStore), [`ArrayStore`](/store/ArrayStore) base classes
+- [`db`](/db) — [`DBCache`](/db/DBCache) / [`CollectionCache`](/db/CollectionCache) that manage store instances
+- [`react`](/react) — [`createDBContext()`](/react/createDBContext) for React hook integration

--- a/modules/db/store/README.md
+++ b/modules/db/store/README.md
@@ -8,7 +8,7 @@ Both extend [`FetchStore`](/store/FetchStore) from the [`store`](/store) module,
 
 ### ItemStore
 
-`ItemStore<I, T>` holds [`OptionalItem`](/util/item/OptionalItem)`<I, T>` — the current item, or `undefined` if it does not exist. It calls [`.getItem()`](/db/DBProvider/getItem) on the first fetch and whenever `refresh()` is called.
+`ItemStore<I, T>` holds [`OptionalItem<I, T>`](/util/item/OptionalItem) — the current item, or `undefined` if it does not exist. It calls [`.getItem()`](/db/DBProvider/getItem) on the first fetch and whenever `refresh()` is called.
 
 - [`.item`](/db/ItemStore/item) — returns the item or throws [`RequiredError`](/error/RequiredError) if absent. Safe to use once the store is loaded and you know the item exists.
 - `.item = data` — write helper that sets `.value` to [`getItem()`](/util/item/getItem) directly (bypasses the provider; useful for optimistic updates).
@@ -17,7 +17,7 @@ When a [`MemoryDBProvider`](/db/MemoryDBProvider) is supplied (via [`DBCache`](/
 
 ### QueryStore
 
-`QueryStore<I, T>` holds [`Items`](/util/item/Items)`<I, T>` — a readonly array of matching items. It calls [`.getQuery()`](/db/DBProvider/getQuery) on the first fetch. Like `ItemStore`, it seeds from memory when available.
+`QueryStore<I, T>` holds [`Items<I, T>`](/util/item/Items) — a readonly array of matching items. It calls [`.getQuery()`](/db/DBProvider/getQuery) on the first fetch. Like `ItemStore`, it seeds from memory when available.
 
 Additional accessors beyond the base `FetchStore`:
 

--- a/modules/error/README.md
+++ b/modules/error/README.md
@@ -6,7 +6,7 @@ Typed error classes for system and transport failures.
 
 Schema validation in shelving throws plain `string` values, not `Error` instances — form handlers consume those strings directly. The classes in this module are for a different layer: errors that represent infrastructure failures, bad requests, unexpected states, and programmer mistakes.
 
-All classes extend `BaseError`, which itself extends `Error` with two additions:
+All classes extend [`BaseError`](/error/BaseError), which itself extends `Error` with two additions:
 
 - **Extra context fields.** Any key/value pairs passed in the options object (other than `cause` and `caller`) are attached directly to the error instance. Use `received` and `expected` as conventional field names when showing what went wrong.
 - **`caller` trimming.** `Error.captureStackTrace` is called with the public-facing function or class as the `caller` argument, so the stack trace starts at the callsite rather than inside an internal helper.
@@ -28,15 +28,15 @@ function requirePositive(n: number): number {
 
 | Class | When to throw |
 |---|---|
-| `RequiredError` | Something required was absent (also thrown by `require*()` helpers) |
-| `ValueError` | A value was present but invalid in context (e.g. data from a database failed validation) |
-| `NetworkError` | Network-level failure — connection refused, server unreachable |
-| `RequestError` | The request was malformed or unacceptable (HTTP 4xx range; `.code` defaults to `400`) |
-| `ResponseError` | The received response indicated an error (HTTP 4xx/5xx; `.code` defaults to `400`) |
-| `UnexpectedError` | Something that should never happen did — an invariant was violated |
-| `UnimplementedError` | A method or feature is not implemented, e.g. in a provider stub |
+| [`RequiredError`](/error/RequiredError) | Something required was absent (also thrown by `require*()` helpers) |
+| [`ValueError`](/error/ValueError) | A value was present but invalid in context (e.g. data from a database failed validation) |
+| [`NetworkError`](/error/NetworkError) | Network-level failure — connection refused, server unreachable |
+| [`RequestError`](/error/RequestError) | The request was malformed or unacceptable (HTTP 4xx range; [`.code`](/error/RequestError/code) defaults to `400`) |
+| [`ResponseError`](/error/ResponseError) | The received response indicated an error (HTTP 4xx/5xx; [`.code`](/error/ResponseError/code) defaults to `400`) |
+| [`UnexpectedError`](/error/UnexpectedError) | Something that should never happen did — an invariant was violated |
+| [`UnimplementedError`](/error/UnimplementedError) | A method or feature is not implemented, e.g. in a provider stub |
 
-`RequestError` has named subclasses for common HTTP status codes: `UnauthorizedError` (401), `ForbiddenError` (403), `NotFoundError` (404), `MethodNotAllowedError` (405), and `UnprocessableError` (422).
+`RequestError` has named subclasses for common HTTP status codes: [`UnauthorizedError`](/error/UnauthorizedError) (401), [`ForbiddenError`](/error/ForbiddenError) (403), [`NotFoundError`](/error/NotFoundError) (404), [`MethodNotAllowedError`](/error/MethodNotAllowedError) (405), and [`UnprocessableError`](/error/UnprocessableError) (422).
 
 See each class's own page for focused usage examples.
 
@@ -73,5 +73,5 @@ try {
 
 ## See also
 
-- [schema](/schema) — schema validation (throws plain strings, not Error instances)
-- [util](/util) — `require*()` functions that throw `RequiredError`
+- [`schema`](/schema) — schema validation (throws plain strings, not Error instances)
+- [`util`](/util/null) — `require*()` functions that throw [`RequiredError`](/error/RequiredError)

--- a/modules/extract/README.md
+++ b/modules/extract/README.md
@@ -2,28 +2,28 @@
 
 Turn a folder of source files into a navigable tree of documentation. `extract` is the engine behind the Shelving documentation site itself.
 
-API references and hand-written guides usually live in separate tools. `extract` unifies them: it reads files and directories from disk and produces a single `TreeElement` tree describing every directory, file, and exported code symbol. A directory's `README.md` becomes that directory's intro page. A TypeScript file's exports become documented symbols. A `name.md` file sitting next to `name.ts` is merged onto the same page. One tree, one site, prose and source together.
+API references and hand-written guides usually live in separate tools. `extract` unifies them: it reads files and directories from disk and produces a single [`TreeElement`](/util/tree/TreeElement) tree describing every directory, file, and exported code symbol. A directory's `README.md` becomes that directory's intro page. A TypeScript file's exports become documented symbols. A `name.md` file sitting next to `name.ts` is merged onto the same page. One tree, one site, prose and source together.
 
-Pair the tree with the [tree components](/ui/tree) and you have a complete static documentation site — exactly how this site is built.
+Pair the tree with the [`tree components`](/ui) and you have a complete static documentation site — exactly how this site is built.
 
 ## Concepts
 
 ### Extractors
 
-An `Extractor` converts an input into a `TreeElement`. Extractors are composable — an outer extractor delegates to inner ones.
+An [`Extractor`](/extract/Extractor) converts an input into a [`TreeElement`](/util/tree/TreeElement). Extractors are composable — an outer extractor delegates to inner ones.
 
 | Extractor | Input | Output |
 |---|---|---|
-| `DirectoryExtractor` | a directory path | a `tree-element` node, recursing into subdirectories |
-| `FileExtractor` | a file | a `tree-element` node holding the raw text |
-| `MarkupExtractor` | a `.md` file | a `tree-element` node with `title` taken from the first `# heading` |
-| `TypescriptExtractor` | a `.ts` / `.tsx` file | a `tree-element` node whose children are the exported symbols |
+| [`DirectoryExtractor`](/extract/DirectoryExtractor) | a directory path | a `tree-element` node, recursing into subdirectories |
+| [`FileExtractor`](/extract/FileExtractor) | a file | a `tree-element` node holding the raw text |
+| [`MarkupExtractor`](/extract/MarkupExtractor) | a `.md` file | a `tree-element` node with `title` taken from the first `# heading` |
+| [`TypescriptExtractor`](/extract/TypescriptExtractor) | a `.ts` / `.tsx` file | a `tree-element` node whose children are the exported symbols |
 
 `DirectoryExtractor` is the entry point. It walks a directory, dispatches each file to a `FileExtractor` by extension, and recurses into subdirectories.
 
 ### The tree
 
-Every extractor produces a `TreeElement` (see [tree](/util/tree)). There are two element types:
+Every extractor produces a `TreeElement` (see [`tree`](/util/tree)). There are two element types:
 
 - `tree-element` — a directory or a file. A directory's content is absorbed from an index file; a file's children are its exported symbols (for TypeScript). Its `source` records the absolute path it came from.
 - `tree-documentation` — one documented symbol (function, class, type, constant), carrying the `signatures`, `params`, `returns`, `throws`, and `examples` parsed from its JSDoc.
@@ -56,7 +56,7 @@ const root = await new DirectoryExtractor().extract("/path/to/modules");
 
 ### 2. Render with `<TreeApp>`
 
-[`<TreeApp>`](/ui/tree) is the shell. Give it the tree and it produces a complete site — a sidebar menu, routing, and one page per element.
+[`<TreeApp>`](/ui/TreeApp) is the shell. Give it the tree and it produces a complete site — a sidebar menu, routing, and one page per element.
 
 ```tsx
 import { TreeApp } from "shelving/ui";
@@ -66,21 +66,21 @@ import { TreeApp } from "shelving/ui";
 
 Internally `<TreeApp>` wires together:
 
-- [`<Navigation>`](/ui/router) — owns URL state and intercepts link clicks.
-- [`<Router>`](/ui/router) — `/` renders the root; `/{...path}` catches every deeper path.
-- [`<TreePage>`](/ui/tree) — resolves the URL path to a tree element and renders it.
+- [`<Navigation>`](/ui/Navigation) — owns URL state and intercepts link clicks.
+- [`<Router>`](/ui/Router) — `/` renders the root; `/{...path}` catches every deeper path.
+- [`<TreePage>`](/ui/TreePage) — resolves the URL path to a tree element and renders it.
 
-`<TreePage>` dispatches on element type: `tree-element` renders as [`<TreePage>`](/ui/docs) and `tree-documentation` as [`<DocumentationPage>`](/ui/docs).
+`<TreePage>` dispatches on element type: `tree-element` renders as `<TreePage>` and `tree-documentation` as [`<DocumentationPage>`](/ui/DocumentationPage).
 
 ### 3. Build static pages
 
-`docs/build.tsx` shows the production build: extract the tree, write `tree.json`, bundle the browser and server scripts, then render every page to static HTML. `docs/render.tsx`'s `renderApp` enumerates every page from the canonical path keys of `flattenTree()` and writes one `index.html` per page. The browser later fetches `tree.json` and hydrates the same React tree the server rendered.
+`docs/build.tsx` shows the production build: extract the tree, write `tree.json`, bundle the browser and server scripts, then render every page to static HTML. `docs/render.tsx`'s `renderApp` enumerates every page from the canonical path keys of [`flattenTree()`](/util/tree/flattenTree) and writes one `index.html` per page. The browser later fetches `tree.json` and hydrates the same React tree the server rendered.
 
 ## Customising
 
 ### Controlling what gets indexed
 
-`DirectoryExtractor` accepts a `DirectoryExtractorOptions` object:
+[`DirectoryExtractor`](/extract/DirectoryExtractor) accepts a [`DirectoryExtractorOptions`](/extract/DirectoryExtractorOptions) object:
 
 ```ts
 new DirectoryExtractor({
@@ -109,7 +109,7 @@ The tree components render through *mappings* — wrap a subtree to swap a rende
 
 ## See also
 
-- [ui/tree](/ui/tree) — `<TreeApp>`, `<TreePage>`, and the sidebar and menu components
-- [ui/docs](/ui/docs) — the directory, file, and documentation page and card renderers
-- [element](/util/element) — the `TreeElement` types and tree-walking helpers
-- [markup](/markup) — renders the Markdown `content` carried by each element
+- [`ui/tree`](/ui) — [`<TreeApp>`](/ui/TreeApp), [`<TreePage>`](/ui/TreePage), and the sidebar and menu components
+- [`ui/docs`](/ui) — the directory, file, and documentation page and card renderers
+- [`element`](/util/element) — the [`TreeElement`](/util/tree/TreeElement) types and tree-walking helpers
+- [`markup`](/markup) — renders the Markdown `content` carried by each element

--- a/modules/firestore/README.md
+++ b/modules/firestore/README.md
@@ -1,18 +1,18 @@
 # firestore
 
-[DBProvider](/db) implementations for Google Firestore. Three variants are available, each targeting a different SDK and runtime context. Choose the one that matches where your code runs.
+[`DBProvider`](/db/DBProvider) implementations for Google Firestore. Three variants are available, each targeting a different SDK and runtime context. Choose the one that matches where your code runs.
 
 | Provider | SDK | Realtime | Bundle size |
 |---|---|---|---|
-| `FirestoreClientProvider` | `firebase/firestore` | Yes | Full |
-| `FirestoreLiteProvider` | `firebase/firestore/lite` | No | Smaller |
-| `FirestoreServerProvider` | `@google-cloud/firestore` | Yes | Server only |
+| [`FirestoreClientProvider`](/firestore/client/FirestoreClientProvider) | `firebase/firestore` | Yes | Full |
+| [`FirestoreLiteProvider`](/firestore/lite/FirestoreLiteProvider) | `firebase/firestore/lite` | No | Smaller |
+| [`FirestoreServerProvider`](/firestore/server/FirestoreServerProvider) | `@google-cloud/firestore` | Yes | Server only |
 
-All three support filtering, sorting, pagination, partial updates, and `countQuery()`. The difference is in realtime support, SDK size, and where the code runs.
+All three support filtering, sorting, pagination, partial updates, and [`.countQuery()`](/db/DBProvider/countQuery). The difference is in realtime support, SDK size, and where the code runs.
 
 ## Client SDK (`FirestoreClientProvider`)
 
-Use in the browser or in any environment where the full Firebase JS SDK is appropriate. Supports offline persistence and realtime subscriptions via `getItemSequence()` and `getQuerySequence()`.
+Use in the browser or in any environment where the full Firebase JS SDK is appropriate. Supports offline persistence and realtime subscriptions via [`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence).
 
 **Install:**
 
@@ -41,7 +41,7 @@ const provider = new FirestoreClientProvider(db);
 
 A lighter alternative to the full client SDK, suitable for browser or server environments where realtime updates are not needed. Produces a smaller bundle and avoids the overhead of persistent connections.
 
-`getItemSequence()` and `getQuerySequence()` throw `UnimplementedError`.
+`.getItemSequence()` and `.getQuerySequence()` throw [`UnimplementedError`](/error/UnimplementedError).
 
 **Install:**
 

--- a/modules/firestore/client/README.md
+++ b/modules/firestore/client/README.md
@@ -1,10 +1,10 @@
 # Firestore client SDK
 
-`FirestoreClientProvider` for the full Firebase JS SDK (`firebase/firestore`). Use this in browser apps or any environment where you need offline persistence or realtime subscriptions.
+[`FirestoreClientProvider`](/firestore/client/FirestoreClientProvider) for the full Firebase JS SDK (`firebase/firestore`). Use this in browser apps or any environment where you need offline persistence or realtime subscriptions.
 
 ## When to use this
 
-Choose `firestore/client` when your code runs in the browser and you want to receive live updates as documents change. If you do not need realtime and want a smaller bundle, use [firestore/lite](/firestore/lite) instead. For server-side Node.js code, use [firestore/server](/firestore/server).
+Choose [`firestore/client`](/firestore/client) when your code runs in the browser and you want to receive live updates as documents change. If you do not need realtime and want a smaller bundle, use [`firestore/lite`](/firestore/lite) instead. For server-side Node.js code, use [`firestore/server`](/firestore/server).
 
 ## Install
 
@@ -35,7 +35,7 @@ The provider takes a single `Firestore` argument. It delegates all app initializ
 
 ## Realtime subscriptions
 
-`getItemSequence()` and `getQuerySequence()` return `AsyncIterable` backed by Firestore's `onSnapshot` listener. Each new value from Firestore resolves the next iteration:
+[`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) return `AsyncIterable` backed by Firestore's `onSnapshot` listener. Each new value from Firestore resolves the next iteration:
 
 ```ts
 for await (const post of provider.getItemSequence(POSTS, id)) {
@@ -47,11 +47,11 @@ The subscription opens lazily on first `for await` iteration and closes when the
 
 ## Bulk query mutations
 
-`setQuery()`, `updateQuery()`, and `deleteQuery()` fetch matching documents with `getDocs` and then issue parallel `Promise.all` writes. For large result sets, prefer [firestore/server](/firestore/server) which uses `BulkWriter`.
+[`.setQuery()`](/db/DBProvider/setQuery), [`.updateQuery()`](/db/DBProvider/updateQuery), and [`.deleteQuery()`](/db/DBProvider/deleteQuery) fetch matching documents with `getDocs` and then issue parallel `Promise.all` writes. For large result sets, prefer [`firestore/server`](/firestore/server) which uses `BulkWriter`.
 
 ## See also
 
-- [firestore](/firestore) — provider comparison and parent module overview
-- [firestore/lite](/firestore/lite) — smaller bundle, no realtime
-- [firestore/server](/firestore/server) — server-side provider with BulkWriter
-- [db](/db) — `DBProvider` base class, `Collection`, and query syntax
+- [`firestore`](/firestore/client) — provider comparison and parent module overview
+- [`firestore/lite`](/firestore/lite) — smaller bundle, no realtime
+- [`firestore/server`](/firestore/server) — server-side provider with `BulkWriter`
+- [`db`](/db) — [`DBProvider`](/db/DBProvider) base class, [`Collection`](/db/Collection), and query syntax

--- a/modules/firestore/lite/README.md
+++ b/modules/firestore/lite/README.md
@@ -1,10 +1,10 @@
 # Firestore lite SDK
 
-`FirestoreLiteProvider` for the Firebase Lite SDK (`firebase/firestore/lite`). Use this when you want Firestore in the browser or on the server but do not need realtime subscriptions and prefer a smaller bundle.
+[`FirestoreLiteProvider`](/firestore/lite/FirestoreLiteProvider) for the Firebase Lite SDK (`firebase/firestore/lite`). Use this when you want Firestore in the browser or on the server but do not need realtime subscriptions and prefer a smaller bundle.
 
 ## When to use this
 
-Choose `firestore/lite` when realtime updates are not required. The Lite SDK omits the persistent connection, offline cache, and `onSnapshot` infrastructure, resulting in a meaningfully smaller bundle than the full client SDK. If you need realtime, use [firestore/client](/firestore/client). For server-side Node.js, use [firestore/server](/firestore/server).
+Choose [`firestore/lite`](/firestore/lite) when realtime updates are not required. The Lite SDK omits the persistent connection, offline cache, and `onSnapshot` infrastructure, resulting in a meaningfully smaller bundle than the full client SDK. If you need realtime, use [`firestore/client`](/firestore/client). For server-side Node.js, use [`firestore/server`](/firestore/server).
 
 ## Install
 
@@ -33,14 +33,14 @@ Note the import path: `firebase/firestore/lite`, not `firebase/firestore`.
 
 ## Limitations
 
-- **No realtime.** `getItemSequence()` and `getQuerySequence()` throw `UnimplementedError`.
+- **No realtime.** [`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) throw [`UnimplementedError`](/error/UnimplementedError).
 - **No offline persistence.** The Lite SDK does not cache documents locally.
 
-All other operations — `getItem`, `addItem`, `setItem`, `updateItem`, `deleteItem`, `getQuery`, `setQuery`, `updateQuery`, `deleteQuery`, and `countQuery` — work the same as the full client provider.
+All other operations — [`.getItem()`](/db/DBProvider/getItem), [`.addItem()`](/db/DBProvider/addItem), [`.setItem()`](/db/DBProvider/setItem), [`.updateItem()`](/db/DBProvider/updateItem), [`.deleteItem()`](/db/DBProvider/deleteItem), [`.getQuery()`](/db/DBProvider/getQuery), [`.setQuery()`](/db/DBProvider/setQuery), [`.updateQuery()`](/db/DBProvider/updateQuery), [`.deleteQuery()`](/db/DBProvider/deleteQuery), and [`.countQuery()`](/db/DBProvider/countQuery) — work the same as the full client provider.
 
 ## See also
 
-- [firestore](/firestore) — provider comparison and parent module overview
-- [firestore/client](/firestore/client) — full SDK with realtime and offline support
-- [firestore/server](/firestore/server) — server-side provider with BulkWriter
-- [db](/db) — `DBProvider` base class, `Collection`, and query syntax
+- [`firestore`](/firestore/client) — provider comparison and parent module overview
+- [`firestore/client`](/firestore/client) — full SDK with realtime and offline support
+- [`firestore/server`](/firestore/server) — server-side provider with `BulkWriter`
+- [`db`](/db) — [`DBProvider`](/db/DBProvider) base class, [`Collection`](/db/Collection), and query syntax

--- a/modules/firestore/server/README.md
+++ b/modules/firestore/server/README.md
@@ -1,10 +1,10 @@
 # Firestore server SDK
 
-`FirestoreServerProvider` for the Firebase Admin SDK (`@google-cloud/firestore`). Use this in Node.js backends, Cloud Functions, or any server environment that authenticates via a service account or Application Default Credentials.
+[`FirestoreServerProvider`](/firestore/server/FirestoreServerProvider) for the Firebase Admin SDK (`@google-cloud/firestore`). Use this in Node.js backends, Cloud Functions, or any server environment that authenticates via a service account or Application Default Credentials.
 
 ## When to use this
 
-Choose `firestore/server` for server-side code. It uses the `@google-cloud/firestore` package directly (the same driver the Admin SDK uses) rather than the browser-oriented Firebase JS SDK. It supports realtime subscriptions and uses `BulkWriter` for efficient bulk mutations.
+Choose [`firestore/server`](/firestore/server) for server-side code. It uses the `@google-cloud/firestore` package directly (the same driver the Admin SDK uses) rather than the browser-oriented Firebase JS SDK. It supports realtime subscriptions and uses `BulkWriter` for efficient bulk mutations.
 
 ## Install
 
@@ -45,15 +45,15 @@ const provider = new FirestoreServerProvider();
 
 ## Realtime subscriptions
 
-`getItemSequence()` and `getQuerySequence()` use `onSnapshot` from the Admin SDK and return `AsyncIterable` backed by a live Firestore listener.
+[`.getItemSequence()`](/db/DBProvider/getItemSequence) and [`.getQuerySequence()`](/db/DBProvider/getQuerySequence) use `onSnapshot` from the Admin SDK and return `AsyncIterable` backed by a live Firestore listener.
 
 ## Bulk query mutations
 
-`setQuery()`, `updateQuery()`, and `deleteQuery()` use `BulkWriter` for efficient batched writes. Documents are fetched in pages of 1000 using `select()` (a field-mask query with no fields) to minimise data transfer, and writes are flushed as each page is processed.
+[`.setQuery()`](/db/DBProvider/setQuery), [`.updateQuery()`](/db/DBProvider/updateQuery), and [`.deleteQuery()`](/db/DBProvider/deleteQuery) use `BulkWriter` for efficient batched writes. Documents are fetched in pages of 1000 using `select()` (a field-mask query with no fields) to minimise data transfer, and writes are flushed as each page is processed.
 
 ## See also
 
-- [firestore](/firestore) — provider comparison and parent module overview
-- [firestore/client](/firestore/client) — full Firebase JS SDK for browser use
-- [firestore/lite](/firestore/lite) — lighter browser SDK without realtime
-- [db](/db) — `DBProvider` base class, `Collection`, and query syntax
+- [`firestore`](/firestore/client) — provider comparison and parent module overview
+- [`firestore/client`](/firestore/client) — full Firebase JS SDK for browser use
+- [`firestore/lite`](/firestore/lite) — lighter browser SDK without realtime
+- [`db`](/db) — [`DBProvider`](/db/DBProvider) base class, [`Collection`](/db/Collection), and query syntax

--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -6,7 +6,7 @@ A rule-based Markdown renderer that turns user-facing text into React nodes.
 
 This module converts Markdown-ish text into React nodes — suitable for rendering blog post bodies, user-written descriptions, or any rich text that originates outside your code.
 
-Rendering is done by a `MarkupParser` instance. Each block element type — heading, paragraph, blockquote, fenced code, ordered list, unordered list (including `[ ]` / `[x]` todo items), table, separator — is handled by an independent `MarkupRule`. Inline elements — bold, italic, inserted/deleted/highlighted text, inline code, links, autolinks, line breaks — are a separate rule set applied within block content.
+Rendering is done by a [`MarkupParser`](/markup/MarkupParser) instance. Each block element type — heading, paragraph, blockquote, fenced code, ordered list, unordered list (including `[ ]` / `[x]` todo items), table, separator — is handled by an independent [`MarkupRule`](/markup/MarkupRule). Inline elements — bold, italic, inserted/deleted/highlighted text, inline code, links, autolinks, line breaks — are a separate rule set applied within block content.
 
 The engine groups rules into priority tiers and resolves the highest tier first. Once a tier claims a region of the text that region is "masked" so lower tiers cannot match into or across it. Each rule renders its match to a React element and recurses into its own children, optionally in a different context.
 
@@ -22,7 +22,7 @@ The default ruleset intentionally diverges from CommonMark:
 
 ### Rendering markup
 
-Create a `MarkupParser` and call `.parse()`:
+Create a [`MarkupParser`](/markup/MarkupParser) and call [`.parse()`](/markup/MarkupParser/parse):
 
 ```ts
 import { MarkupParser } from "shelving/markup";
@@ -34,7 +34,7 @@ const node = parser.parse("# Hello\n\nThis is *bold* and _italic_.");
 
 `parse()` returns a `ReactNode`: a single element, a string, an array of those, or `null`.
 
-For the common case the shared `MARKUP_PARSER` sentinel — a `MarkupParser` with default options — saves constructing one:
+For the common case the shared [`MARKUP_PARSER`](/markup/MARKUP_PARSER) sentinel — a `MarkupParser` with default options — saves constructing one:
 
 ```ts
 import { MARKUP_PARSER } from "shelving/markup";
@@ -44,15 +44,15 @@ const node = MARKUP_PARSER.parse(content);
 
 ### Options
 
-`MarkupParser` is constructed with `MarkupOptions`:
+`MarkupParser` is constructed with [`MarkupOptions`](/markup/MarkupOptions):
 
 | Option | Type | Description |
 |---|---|---|
-| `rules` | `MarkupRules` | Rules to apply. Defaults to `MARKUP_RULES` (all block + inline rules). |
+| `rules` | [`MarkupRules`](/markup/MarkupRules) | Rules to apply. Defaults to [`MARKUP_RULES`](/markup/MARKUP_RULES) (all block + inline rules). |
 | `rel` | `string` | `rel` attribute applied to every rendered link, e.g. `"nofollow ugc"`. |
-| `url` | `ImmutableURL` | Current page URL — base for resolving relative refs (`./foo`, `#x`). |
+| `url` | [`ImmutableURL`](/util/url/ImmutableURL) | Current page URL — base for resolving relative refs (`./foo`, `#x`). |
 | `root` | `ImmutableURL` | Site root URL — base for resolving site-absolute paths (`/foo`). |
-| `schemes` | `URISchemes` | Allowed URI schemes for links. Defaults to `["http:", "https:"]`. |
+| `schemes` | [`URISchemes`](/util/uri/URISchemes) | Allowed URI schemes for links. Defaults to `["http:", "https:"]`. |
 | `context` | `string` | Default starting context. Defaults to `"block"`. |
 
 ```ts
@@ -64,7 +64,7 @@ const parser = new MarkupParser({
 });
 ```
 
-Link href resolution goes through [`getLink`](/util) — site-absolute paths resolve against `root`, relative refs against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
+Link href resolution goes through [`getLink()`](/util/link/getLink) — site-absolute paths resolve against `root`, relative refs against `url`, scheme-prefixed URIs (`mailto:`, `tel:`, …) pass through, `URL` instances are emitted as-is.
 
 ### Block-only or inline-only rendering
 
@@ -75,11 +75,11 @@ Link href resolution goes through [`getLink`](/util) — site-absolute paths res
 const inline = MARKUP_PARSER.parse("Some *bold* text", "inline");
 ```
 
-`MARKUP_RULES_BLOCK` and `MARKUP_RULES_INLINE` expose the block and inline rule sets separately if you want a parser with only one.
+[`MARKUP_RULES_BLOCK`](/markup/MARKUP_RULES_BLOCK) and [`MARKUP_RULES_INLINE`](/markup/MARKUP_RULES_INLINE) expose the block and inline rule sets separately if you want a parser with only one.
 
 ### Custom rules
 
-Build custom rules with `createMarkupRule` and combine them with the defaults:
+Build custom rules with [`createMarkupRule()`](/markup/createMarkupRule) and combine them with the defaults:
 
 ```tsx
 import { createMarkupRule, MARKUP_RULES, MarkupParser } from "shelving/markup";
@@ -93,7 +93,7 @@ const HIGHLIGHT_RULE = createMarkupRule<{ text: string }>(
 const parser = new MarkupParser({ rules: [...MARKUP_RULES, HIGHLIGHT_RULE] });
 ```
 
-`createMarkupRule` takes a regexp (named captures are typed), a render function `(key, data, parser) => ReactElement`, the `contexts` the rule applies in, and an optional `priority` (default `0`; higher priorities form earlier-resolved tiers). See [markup/rule](/markup/rule) for the full built-in rule set.
+`createMarkupRule()` takes a regexp (named captures are typed), a render function `(key, data, parser) => ReactElement`, the `contexts` the rule applies in, and an optional `priority` (default `0`; higher priorities form earlier-resolved tiers). See [`markup/rule`](/markup) for the full built-in rule set.
 
 ## Input normalisation
 
@@ -106,7 +106,7 @@ The parser expects **normalised** input and deliberately does not try to absorb 
 
 Keeping this guarantee out of the rules is what keeps them simple: nesting — a sub-list inside a list item, a quote inside a quote — is always exactly one extra tab, never an ambiguous run of spaces.
 
-Normalisation is **not** performed by the parser — give it text that is already clean. `sanitizeMultilineText()` from [`shelving/util`](/util) produces exactly this form: it converts four-space indents to tabs, strips sub-tab leading spaces, trims trailing whitespace, and collapses three-or-more newlines to two. [`StringSchema`](/schema) runs `sanitizeMultilineText()` automatically when validating any multi-line field (`rows > 1`), so text stored through a schema is already normalised.
+Normalisation is **not** performed by the parser — give it text that is already clean. [`sanitizeMultilineText()`](/util/string/sanitizeMultilineText) from [`shelving/util`](/util/string) produces exactly this form: it converts four-space indents to tabs, strips sub-tab leading spaces, trims trailing whitespace, and collapses three-or-more newlines to two. [`StringSchema`](/schema/StringSchema) runs `sanitizeMultilineText()` automatically when validating any multi-line field (`rows > 1`), so text stored through a schema is already normalised.
 
 ```ts
 import { sanitizeMultilineText } from "shelving/util";
@@ -119,6 +119,6 @@ If the text reaches you straight from a `StringSchema`-validated field it is alr
 
 ## See also
 
-- [markup/rule](/markup/rule) — the built-in rule set and per-rule syntax reference
-- [util](/util) — shared utilities, including `sanitizeMultilineText` and the regexp helpers used by rules
-- [schema](/schema) — `StringSchema`, which normalises multi-line text on validation
+- [`markup/rule`](/markup) — the built-in rule set and per-rule syntax reference
+- [`util`](/util/string) — shared utilities, including `sanitizeMultilineText` and the regexp helpers used by rules
+- [`schema`](/schema) — `StringSchema`, which normalises multi-line text on validation

--- a/modules/markup/rule/README.md
+++ b/modules/markup/rule/README.md
@@ -1,10 +1,10 @@
 # Markup rules
 
-The built-in rule set that drives the [markup](/markup) renderer. This directory exports every individual rule constant, two context-specific rule arrays, and the combined default ruleset.
+The built-in rule set that drives the [`markup`](/markup) renderer. This directory exports every individual rule constant, two context-specific rule arrays, and the combined default ruleset.
 
 ## Concepts
 
-Each `MarkupRule` in this directory handles one element type. Rules are combined into `MarkupRules` arrays and handed to a `MarkupParser` (via the `rules` option, or the default `MARKUP_RULES`).
+Each [`MarkupRule`](/markup/MarkupRule) in this directory handles one element type. Rules are combined into [`MarkupRules`](/markup/MarkupRules) arrays and handed to a [`MarkupParser`](/markup/MarkupParser) (via the `rules` option, or the default [`MARKUP_RULES`](/markup/MARKUP_RULES)).
 
 The engine groups rules into priority tiers and resolves the highest tier first; once a tier claims a region of the text that region is masked so lower tiers cannot match into or across it. `priority` (default `0`) sets the tier — higher resolves first.
 
@@ -15,35 +15,35 @@ Rules declare which contexts they apply in. Block rules fire in a `"block"` cont
 | Export | Contents |
 |---|---|
 | `MARKUP_RULES` | All block and inline rules — the default, use this unless you have a reason not to |
-| `MARKUP_RULES_BLOCK` | Block-only rules: fenced code, heading, separator, lists, blockquote, table, paragraph |
-| `MARKUP_RULES_INLINE` | Inline-only rules: inline code, link, autolink, strong/em/del/ins/mark, linebreak |
+| [`MARKUP_RULES_BLOCK`](/markup/MARKUP_RULES_BLOCK) | Block-only rules: fenced code, heading, separator, lists, blockquote, table, paragraph |
+| [`MARKUP_RULES_INLINE`](/markup/MARKUP_RULES_INLINE) | Inline-only rules: inline code, link, autolink, strong/em/del/ins/mark, linebreak |
 
 ## Block rules
 
 | Rule constant | Element | Syntax |
 |---|---|---|
-| `FENCED_RULE` | `<pre><code>` | ` ``` ` or `~~~` fenced code block; optional language after the fence |
-| `HEADING_RULE` | `<h1>`–`<h6>` | `#` through `######` followed by a space |
-| `SEPARATOR_RULE` | `<hr>` | Three or more repeated `-`, `*`, `•`, `+`, `_`, or `=` characters |
-| `UNORDERED_RULE` | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab; blank lines between items make the list loose (`<p>`-wrapped); items starting with `[ ]` / `[x]` render a todo checkbox |
-| `ORDERED_RULE` | `<ol>` | Lines starting with a number followed by `.`, `)`, or `:`; blank lines between items make the list loose (`<p>`-wrapped) |
-| `BLOCKQUOTE_RULE` | `<blockquote>` | Lines starting with `>` |
-| `TABLE_RULE` | `<table>` | Pipe table: header row, `\|---|` delimiter row, body rows |
-| `PARAGRAPH_RULE` | `<p>` | Any remaining block content (priority `-10`, matches last) |
+| [`FENCED_RULE`](/markup/FENCED_RULE) | `<pre><code>` | ` ``` ` or `~~~` fenced code block; optional language after the fence |
+| [`HEADING_RULE`](/markup/HEADING_RULE) | `<h1>`–`<h6>` | `#` through `######` followed by a space |
+| [`SEPARATOR_RULE`](/markup/SEPARATOR_RULE) | `<hr>` | Three or more repeated `-`, `*`, `•`, `+`, `_`, or `=` characters |
+| [`UNORDERED_RULE`](/markup/UNORDERED_RULE) | `<ul>` | Lines starting with `-`, `*`, `•`, or `+`; nest with a tab; blank lines between items make the list loose (`<p>`-wrapped); items starting with `[ ]` / `[x]` render a todo checkbox |
+| [`ORDERED_RULE`](/markup/ORDERED_RULE) | `<ol>` | Lines starting with a number followed by `.`, `)`, or `:`; blank lines between items make the list loose (`<p>`-wrapped) |
+| [`BLOCKQUOTE_RULE`](/markup/BLOCKQUOTE_RULE) | `<blockquote>` | Lines starting with `>` |
+| [`TABLE_RULE`](/markup/TABLE_RULE) | `<table>` | Pipe table: header row, `\|---|` delimiter row, body rows |
+| [`PARAGRAPH_RULE`](/markup/PARAGRAPH_RULE) | `<p>` | Any remaining block content (priority `-10`, matches last) |
 
 ## Inline rules
 
 | Rule constant | Element | Syntax |
 |---|---|---|
-| `CODE_RULE` | `<code>` | `` `backtick-wrapped` `` text (priority `10`) |
-| `LINK_RULE` | `<a>` | `[title](url)` |
-| `AUTOLINK_RULE` | `<a>` | Bare URL starting with any scheme, e.g. `https://example.com` |
-| `INLINE_RULE` | `<strong>`, `<em>`, `<del>`, `<ins>`, `<mark>` | `*bold*`, `_italic_`, `~del~`, `+ins+`, `=mark=` |
-| `LINEBREAK_RULE` | `<br>` | Any single `\n` newline inside inline content |
+| [`CODE_RULE`](/markup/CODE_RULE) | `<code>` | `` `backtick-wrapped` `` text (priority `10`) |
+| [`LINK_RULE`](/markup/LINK_RULE) | `<a>` | `[title](url)` |
+| [`AUTOLINK_RULE`](/markup/AUTOLINK_RULE) | `<a>` | Bare URL starting with any scheme, e.g. `https://example.com` |
+| [`INLINE_RULE`](/markup/INLINE_RULE) | `<strong>`, `<em>`, `<del>`, `<ins>`, `<mark>` | `*bold*`, `_italic_`, `~del~`, `+ins+`, `=mark=` |
+| [`LINEBREAK_RULE`](/markup/LINEBREAK_RULE) | `<br>` | Any single `\n` newline inside inline content |
 
 ## Adding a custom rule
 
-Use `createMarkupRule` from `shelving/markup` to build a typed rule, then merge it into the rules array you give a `MarkupParser`:
+Use [`createMarkupRule()`](/markup/createMarkupRule) from `shelving/markup` to build a typed rule, then merge it into the rules array you give a `MarkupParser`:
 
 ```tsx
 import { createMarkupRule, MARKUP_RULES, MarkupParser } from "shelving/markup";
@@ -58,9 +58,9 @@ const HIGHLIGHT_RULE = createMarkupRule<{ text: string }>(
 const parser = new MarkupParser({ rules: [...MARKUP_RULES, HIGHLIGHT_RULE] });
 ```
 
-`createMarkupRule` accepts:
+`createMarkupRule()` accepts:
 
-1. A `RegExp` or named-capture `NamedRegExp`.
+1. A `RegExp` or named-capture [`NamedRegExp`](/util/regexp/NamedRegExp).
 2. A render function `(key, data, parser) => ReactElement`. `data` is the regexp's named capture groups, typed when you pass a `NamedRegExp`.
 3. A `contexts` array — at least one of `"block"`, `"inline"`, `"list"`, `"link"`.
 4. An optional `priority` number (default `0`). Higher priorities form earlier-resolved tiers.
@@ -69,5 +69,5 @@ To replace the built-in rule for a specific element, omit that constant from the
 
 ## See also
 
-- [markup](/markup) — `MarkupParser`, `MarkupRule`, `createMarkupRule`, and the full renderer
-- [markup/util](/markup/util) — regexp helpers and internal types used by the rules
+- [`markup`](/markup) — `MarkupParser`, `MarkupRule`, `createMarkupRule`, and the full renderer
+- [`markup/util`](/markup) — regexp helpers and internal types used by the rules

--- a/modules/react/README.md
+++ b/modules/react/README.md
@@ -1,20 +1,20 @@
 # react
 
-React hooks and context helpers for integrating Shelving [stores](/store), async sequences, and API/DB providers into React components. The module is built on `useSyncExternalStore` and standard React patterns — no magic, no global state.
+React hooks and context helpers for integrating Shelving [`stores`](/store), async sequences, and API/DB providers into React components. The module is built on `useSyncExternalStore` and standard React patterns — no magic, no global state.
 
 ## Concepts
 
 ### Stores and Suspense
 
-`Store.value` implements the React Suspense contract directly: it throws a `Promise` while the store is loading (which Suspense catches and shows the fallback) and throws the error reason if the store has failed (which an error boundary catches). `useStore(store)` wires a store into `useSyncExternalStore` so the component re-renders whenever the store emits a new value.
+[`.value`](/store/Store/value) implements the React Suspense contract directly: it throws a `Promise` while the store is loading (which Suspense catches and shows the fallback) and throws the error reason if the store has failed (which an error boundary catches). [`useStore()`](/react/useStore) wires a store into `useSyncExternalStore` so the component re-renders whenever the store emits a new value.
 
 ### Context helpers
 
-`createAPIContext(provider)` and `createDBContext(provider)` are factory functions that return a React context component plus typed hooks. Each mounted context instance gets its own in-memory cache, so multiple subtrees can use independent providers. This mirrors the `createDataContext` / `createCacheContext` pattern used throughout the library.
+[`createAPIContext()`](/react/createAPIContext) and [`createDBContext()`](/react/createDBContext) are factory functions that return a React context component plus typed hooks. Each mounted context instance gets its own in-memory cache, so multiple subtrees can use independent providers. This mirrors the `createDataContext()` / `createCacheContext()` pattern used throughout the library.
 
 ### Stable references
 
-A recurring React problem is stale closures and unnecessary re-renders caused by objects being recreated on every render. `useInstance`, `useLazy`, `useReduce`, and `useMap` each solve a specific variant of this: `useInstance` memoises a class constructor call; `useLazy` memoises an arbitrary factory call; `useReduce` lets you fold render state with custom equality logic; `useMap` gives you a single mutable `Map` that lives for the lifetime of the component.
+A recurring React problem is stale closures and unnecessary re-renders caused by objects being recreated on every render. [`useInstance()`](/react/useInstance), [`useLazy()`](/react/useLazy), [`useReduce()`](/react/useReduce), and [`useMap()`](/react/useMap) each solve a specific variant of this: `useInstance()` memoises a class constructor call; `useLazy()` memoises an arbitrary factory call; `useReduce()` lets you fold render state with custom equality logic; `useMap()` gives you a single mutable `Map` that lives for the lifetime of the component.
 
 ## Usage
 
@@ -22,7 +22,7 @@ The per-symbol pages below carry the detailed usage for each hook and context fa
 
 ### Rendering data with a DB context
 
-Create a context once at module scope, wrap the tree in it, and let child components suspend while data loads. The same shape works for `createAPIContext` — swap `useItem` / `useQuery` for `useAPI`.
+Create a context once at module scope, wrap the tree in it, and let child components suspend while data loads. The same shape works for [`createAPIContext()`](/react/createAPIContext) — swap [`.useItem()`](/react/DBContext/useItem) / [`.useQuery()`](/react/DBContext/useQuery) for [`.useAPI()`](/react/APIContext/useAPI).
 
 ```tsx
 import { Suspense } from "react";
@@ -55,7 +55,7 @@ function App() {
 
 ### Building a store inside a component
 
-A store that depends on props can't live at module scope. `useInstance` constructs it once and keeps it stable across renders, while `useStore` subscribes the component to its updates.
+A store that depends on props can't live at module scope. [`useInstance()`](/react/useInstance) constructs it once and keeps it stable across renders, while [`useStore()`](/react/useStore) subscribes the component to its updates.
 
 ```tsx
 import { useInstance, useStore } from "shelving/react";
@@ -70,6 +70,6 @@ function Toggle() {
 
 ## See also
 
-- [store](/store) — the `Store` class that `useStore` subscribes to
-- [api](/api) — `APIProvider`, `APICache`, and `EndpointStore`
-- [db](/db) — `DBProvider`, `DBCache`, `ItemStore`, and `QueryStore`
+- [`store`](/store) — the [`Store`](/store/Store) class that `useStore()` subscribes to
+- [`api`](/api) — [`APIProvider`](/api/APIProvider), [`APICache`](/api/APICache), and [`EndpointStore`](/api/EndpointStore)
+- [`db`](/db) — [`DBProvider`](/db/DBProvider), [`DBCache`](/db/DBCache), [`ItemStore`](/db/ItemStore), and [`QueryStore`](/db/QueryStore)

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -1,6 +1,6 @@
 # schema
 
-Schema validation for TypeScript. A [`Schema`](/schema/Schema)`<T>` describes how to coerce and validate an unknown value into a typed `T`. Schemas are the foundation of shelving — database collections, API endpoints, and form handlers all build on them.
+Schema validation for TypeScript. A [`Schema<T>`](/schema/Schema) describes how to coerce and validate an unknown value into a typed `T`. Schemas are the foundation of shelving — database collections, API endpoints, and form handlers all build on them.
 
 By convention, instantiated schemas are constants and use `UPPERCASE`.
 

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -1,6 +1,6 @@
 # schema
 
-Schema validation for TypeScript. A `Schema<T>` describes how to coerce and validate an unknown value into a typed `T`. Schemas are the foundation of shelving — database collections, API endpoints, and form handlers all build on them.
+Schema validation for TypeScript. A [`Schema`](/schema/Schema)`<T>` describes how to coerce and validate an unknown value into a typed `T`. Schemas are the foundation of shelving — database collections, API endpoints, and form handlers all build on them.
 
 By convention, instantiated schemas are constants and use `UPPERCASE`.
 
@@ -8,19 +8,19 @@ By convention, instantiated schemas are constants and use `UPPERCASE`.
 
 ### The `Schema<T>` interface
 
-Every schema has a single `validate(value: unknown): T` method. If the value is valid (after any coercion), it returns `T`. If it is not, it throws a plain **string** error message — for example `"Must be 5–50 characters"` or `"Required"`. This is intentional: form handlers and API layers can consume these strings directly without any unwrapping.
+Every schema has a single [`.validate()`](/schema/Schema/validate) method — `validate(value: unknown): T`. If the value is valid (after any coercion), it returns `T`. If it is not, it throws a plain **string** error message — for example `"Must be 5–50 characters"` or `"Required"`. This is intentional: form handlers and API layers can consume these strings directly without any unwrapping.
 
-Multi-field errors from `DataSchema` are joined by `\n`, one line per failed field, with the field name prepended: `"name: Required\nemail: Invalid format"`.
+Multi-field errors from [`DataSchema`](/schema/DataSchema) are joined by `\n`, one line per failed field, with the field name prepended: `"name: Required\nemail: Invalid format"`.
 
 ### Default value
 
-`validate()` is called with `undefined` when no value is provided; the schema falls back to its `value` default.
+`validate()` is called with `undefined` when no value is provided; the schema falls back to its [`.value`](/schema/Schema/value) default.
 
 ### Coercion
 
 Schema functionality in Shelving follows the **robustness principle**: "be conservative in what you do, be liberal in what you accept from others". Values that are obvious in their intent are coerced to appropriate valid values.
 
-`StringSchema` converts numbers to strings, `BooleanSchema` converts the strings `"no"` and `"false"` to `false` and tests other values for truthiness, `ArraySchema` splits comma-separated strings into arrays, `NumberSchema` parses strings into numbers.
+[`StringSchema`](/schema/StringSchema) converts numbers to strings, [`BooleanSchema`](/schema/BooleanSchema) converts the strings `"no"` and `"false"` to `false` and tests other values for truthiness, [`ArraySchema`](/schema/ArraySchema) splits comma-separated strings into arrays, [`NumberSchema`](/schema/NumberSchema) parses strings into numbers.
 
 ### Metadata
 
@@ -28,35 +28,35 @@ Every schema carries optional display metadata set at construction time:
 
 | Property      | Default         | Purpose                                            |
 | ------------- | --------------- | -------------------------------------------------- |
-| `one`         | `"value"`       | Singular noun, e.g. `"product"`                   |
-| `many`        | `one + "s"`     | Plural noun, e.g. `"products"`                    |
-| `title`       | `""`            | Human-readable label for a field                  |
-| `description` | `""`            | Longer description for a field                    |
-| `placeholder` | `""`            | Placeholder text for an input                     |
-| `value`       | schema-specific | Default used when `validate(undefined)` is called |
-| `format`      | schema-specific | Display formatter for downstream form and UI use  |
+| [`.one`](/schema/Schema/one)         | `"value"`       | Singular noun, e.g. `"product"`                   |
+| [`.many`](/schema/Schema/many)        | `one + "s"`     | Plural noun, e.g. `"products"`                    |
+| [`.title`](/schema/Schema/title)       | `""`            | Human-readable label for a field                  |
+| [`.description`](/schema/Schema/description) | `""`            | Longer description for a field                    |
+| [`.placeholder`](/schema/Schema/placeholder) | `""`            | Placeholder text for an input                     |
+| [`.value`](/schema/Schema/value)       | schema-specific | Default used when `validate(undefined)` is called |
+| [`.format()`](/schema/Schema/format)      | schema-specific | Display formatter for downstream form and UI use  |
 
 ### Sugar instances and factories
 
-For convenience the `schema` module offers sugar constants and factories to improve the readability of code that creates complex schemas. Sugar instances are pre-instantiated copies of `Schema` classes — by convention an instantiated schema is named in `ALL_CAPS`, a convention you will find it convenient to use in your own codebase too. Sugar factories are functions like `OPTIONAL()` and `DATA()` that build a configured schema for you.
+For convenience the [`schema`](/schema) module offers sugar constants and factories to improve the readability of code that creates complex schemas. Sugar instances are pre-instantiated copies of [`Schema`](/schema/Schema) classes — by convention an instantiated schema is named in `ALL_CAPS`, a convention you will find it convenient to use in your own codebase too. Sugar factories are functions like [`OPTIONAL()`](/schema/OPTIONAL) and [`DATA()`](/schema/DATA) that build a configured schema for you.
 
 | Sugar instance / factory | Validated type       |
 | ----------------------- | -------------------- |
-| `STRING`                | `string`             |
-| `NUMBER`                | `number`             |
-| `CURRENCY_AMOUNT(code)` | `number`             |
-| `BOOLEAN`               | `boolean`            |
-| `DATA(props)`           | `T` (plain object)   |
-| `ARRAY(itemSchema)`     | `readonly T[]`       |
-| `CHOICE(options)`       | union of string keys |
-| `NULLABLE(schema)`      | `T \| null`          |
-| `OPTIONAL(schema)`      | `T \| undefined`     |
-| `PARTIAL(schema)`       | `Partial<T>`         |
-| `ITEM(idSchema, props)` | `{ id: I } & T`      |
+| [`STRING`](/schema/STRING)                | `string`             |
+| [`NUMBER`](/schema/NUMBER)                | `number`             |
+| [`CURRENCY_AMOUNT(code)`](/schema/CURRENCY_AMOUNT) | `number`             |
+| [`BOOLEAN`](/schema/BOOLEAN)               | `boolean`            |
+| [`DATA(props)`](/schema/DATA)           | `T` (plain object)   |
+| [`ARRAY(itemSchema)`](/schema/ARRAY)     | `readonly T[]`       |
+| [`CHOICE(options)`](/schema/CHOICE)       | union of string keys |
+| [`NULLABLE(schema)`](/schema/NULLABLE)      | `T \| null`          |
+| [`OPTIONAL(schema)`](/schema/OPTIONAL)      | `T \| undefined`     |
+| [`PARTIAL(schema)`](/schema/PARTIAL)       | `Partial<T>`         |
+| [`ITEM(idSchema, props)`](/schema/ITEM) | `{ id: I } & T`      |
 
 ## Usage
 
-Schemas compose: primitives, wrappers (`NULLABLE`, `OPTIONAL`, `ARRAY`), and `DATA` nest freely to describe an entire payload in a single validator. See each schema's own page for detailed usage of that class and its constants.
+Schemas compose: primitives, wrappers ([`NULLABLE()`](/schema/NULLABLE), [`OPTIONAL()`](/schema/OPTIONAL), [`ARRAY()`](/schema/ARRAY)), and [`DATA()`](/schema/DATA) nest freely to describe an entire payload in a single validator. See each schema's own page for detailed usage of that class and its constants.
 
 ```ts
 import { ITEM, STRING, REQUIRED_STRING, NUMBER, ARRAY, OPTIONAL, INTEGER } from "shelving/schema";
@@ -77,5 +77,5 @@ PRODUCT.validate({ id: 2, name: "", price: 9.99, tags: [] });
 
 ## See also
 
-- [util](/util) — `Data`, `Item`, query, and update types consumed by schemas.
-- [db](/db) — `Collection` extends `DataSchema` and uses schemas to validate stored documents.
+- [`util`](/util/data) — `Data`, `Item`, query, and update types consumed by schemas.
+- [`db`](/db) — [`Collection`](/db/Collection) extends [`DataSchema`](/schema/DataSchema) and uses schemas to validate stored documents.

--- a/modules/sequence/README.md
+++ b/modules/sequence/README.md
@@ -1,24 +1,24 @@
 # sequence
 
-Async-iterator primitives used throughout the shelving library. A "sequence" is an `AsyncIterable<T>` — something you can consume with `for await...of`. This module provides the building blocks for producing and connecting sequences, most importantly `DeferredSequence`, which lets external code drive an async iterator by resolving or rejecting it on demand.
+Async-iterator primitives used throughout the shelving library. A "sequence" is an `AsyncIterable<T>` — something you can consume with `for await...of`. This module provides the building blocks for producing and connecting sequences, most importantly [`DeferredSequence`](/sequence/DeferredSequence), which lets external code drive an async iterator by resolving or rejecting it on demand.
 
 ## Concepts
 
-**`Sequence`** is the abstract base class for every sequence type. It implements `AsyncIterator`, `AsyncIterable`, and `AsyncDisposable` at once, so a single object can be iterated, passed around as an iterable, and disposed. Subclasses implement `next()`.
+**[`Sequence`](/sequence/Sequence)** is the abstract base class for every sequence type. It implements `AsyncIterator`, `AsyncIterable`, and `AsyncDisposable` at once, so a single object can be iterated, passed around as an iterable, and disposed. Subclasses implement [`.next()`](/sequence/Sequence/next).
 
-**`DeferredSequence`** is a sequence you push values into: call `resolve(value)` to publish the next value, `reject(reason)` to publish an error, or `done()` to end iteration. It is also a `Promise`, so you can `await` it to get just the next value. Multiple concurrent iterators all advance together when it resolves.
+**`DeferredSequence`** is a sequence you push values into: call [`.resolve()`](/sequence/DeferredSequence/resolve) to publish the next value, [`.reject()`](/sequence/DeferredSequence/reject) to publish an error, or [`.done()`](/sequence/DeferredSequence/done) to end iteration. It is also a `Promise`, so you can `await` it to get just the next value. Multiple concurrent iterators all advance together when it resolves.
 
-**`ThroughSequence`** wraps a source `AsyncIterator` and presents it as a full `Sequence` — useful for turning a bare iterator into a reusable iterable and guaranteeing `return()` / `throw()` are present.
+**[`ThroughSequence`](/sequence/ThroughSequence)** wraps a source `AsyncIterator` and presents it as a full `Sequence` — useful for turning a bare iterator into a reusable iterable and guaranteeing [`.return()`](/sequence/Sequence/return) / [`.throw()`](/sequence/Sequence/throw) are present.
 
-**`LazySequence`** is a `ThroughSequence` paired with a `StartCallback` / `StopCallback`. The start callback runs when the first iterator begins iterating and is torn down when the last one finishes — the sequence equivalent of an observable subscription.
+**[`LazySequence`](/sequence/LazySequence)** is a `ThroughSequence` paired with a [`StartCallback`](/util/start/StartCallback) / [`StopCallback`](/util/start/StopCallback). The start callback runs when the first iterator begins iterating and is torn down when the last one finishes — the sequence equivalent of an observable subscription.
 
-**`InspectSequence`** is a `ThroughSequence` that records what passed through it — `first`, `last`, `count`, `done`, and `returned` — without changing the values.
+**[`InspectSequence`](/sequence/InspectSequence)** is a `ThroughSequence` that records what passed through it — [`.first`](/sequence/InspectSequence/first), [`.last`](/sequence/InspectSequence/last), [`.count`](/sequence/InspectSequence/count), [`.done`](/sequence/InspectSequence/done), and [`.returned`](/sequence/InspectSequence/returned) — without changing the values.
 
-Most application code interacts with sequences indirectly via [`Store`](/store), which uses `DeferredSequence` internally. Use the sequence primitives directly only when building new reactive data sources.
+Most application code interacts with sequences indirectly via [`Store`](/store/Store), which uses `DeferredSequence` internally. Use the sequence primitives directly only when building new reactive data sources.
 
 ## Usage
 
-The per-class pages carry the detailed usage. As an integration example, wrapping a `DeferredSequence` in a `LazySequence` gives a producer that only runs while something is listening:
+The per-class pages carry the detailed usage. As an integration example, wrapping a [`DeferredSequence`](/sequence/DeferredSequence) in a [`LazySequence`](/sequence/LazySequence) gives a producer that only runs while something is listening:
 
 ```ts
 import { DeferredSequence, LazySequence } from "shelving/sequence";
@@ -38,5 +38,5 @@ for await (const ts of clock) {
 
 ## See also
 
-- [`Store`](/store) — observable value container built on `DeferredSequence`
-- [`db`](/db) — database providers that expose `AsyncIterable` via `getItemSequence` / `getQuerySequence`
+- [`Store`](/store) — observable value container built on [`DeferredSequence`](/sequence/DeferredSequence)
+- [`db`](/db) — database providers that expose `AsyncIterable` via [`.getItemSequence()`](/db/DBProvider/getItemSequence) / [`.getQuerySequence()`](/db/DBProvider/getQuerySequence)

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -1,6 +1,6 @@
 # store
 
-Observable value containers for reactive state. A [`Store`](/store/Store)`<T>` holds a single current value, broadcasts changes to all active consumers, and integrates with React Suspense out of the box. Stores suppress duplicate emissions using deep equality, so consumers only see genuine changes.
+Observable value containers for reactive state. A [`Store<T>`](/store/Store) holds a single current value, broadcasts changes to all active consumers, and integrates with React Suspense out of the box. Stores suppress duplicate emissions using deep equality, so consumers only see genuine changes.
 
 ## Concepts
 
@@ -18,16 +18,16 @@ Observable value containers for reactive state. A [`Store`](/store/Store)`<T>` h
 
 | Class | Description |
 |---|---|
-| [`DataStore`](/store/DataStore)`<T>` | Adds [`.data`](/store/DataStore/data), [`.update()`](/store/DataStore/update), [`.get()`](/store/DataStore/get), [`.set()`](/store/DataStore/set) helpers for object values. |
-| [`OptionalDataStore`](/store/OptionalDataStore)`<T>` | Like `DataStore` but the value may be `undefined`; [`.exists`](/store/OptionalDataStore/exists) and [`.require()`](/store/OptionalDataStore/require) handle the absent case. |
-| [`ArrayStore`](/store/ArrayStore)`<T>` | Stores an array; adds [`.first`](/store/ArrayStore/first), [`.last`](/store/ArrayStore/last), [`.count`](/store/ArrayStore/count), [`.add()`](/store/ArrayStore/add), [`.delete()`](/store/ArrayStore/delete), [`.toggle()`](/store/ArrayStore/toggle). |
-| [`DictionaryStore`](/store/DictionaryStore)`<T>` | Stores a string-keyed object; adds [`.get()`](/store/DictionaryStore/get), [`.set()`](/store/DictionaryStore/set), [`.delete()`](/store/DictionaryStore/delete), [`.update()`](/store/DictionaryStore/update). |
+| [`DataStore<T>`](/store/DataStore) | Adds [`.data`](/store/DataStore/data), [`.update()`](/store/DataStore/update), [`.get()`](/store/DataStore/get), [`.set()`](/store/DataStore/set) helpers for object values. |
+| [`OptionalDataStore<T>`](/store/OptionalDataStore) | Like `DataStore` but the value may be `undefined`; [`.exists`](/store/OptionalDataStore/exists) and [`.require()`](/store/OptionalDataStore/require) handle the absent case. |
+| [`ArrayStore<T>`](/store/ArrayStore) | Stores an array; adds [`.first`](/store/ArrayStore/first), [`.last`](/store/ArrayStore/last), [`.count`](/store/ArrayStore/count), [`.add()`](/store/ArrayStore/add), [`.delete()`](/store/ArrayStore/delete), [`.toggle()`](/store/ArrayStore/toggle). |
+| [`DictionaryStore<T>`](/store/DictionaryStore) | Stores a string-keyed object; adds [`.get()`](/store/DictionaryStore/get), [`.set()`](/store/DictionaryStore/set), [`.delete()`](/store/DictionaryStore/delete), [`.update()`](/store/DictionaryStore/update). |
 | [`BooleanStore`](/store/BooleanStore) | Stores a boolean; adds [`.toggle()`](/store/BooleanStore/toggle). |
 | [`PathStore`](/store/PathStore) | Stores an absolute path; adds [`.isActive()`](/store/PathStore/isActive) / [`.isProud()`](/store/PathStore/isProud) route helpers. |
 | [`URLStore`](/store/URLStore) | Stores a URL; adds query-param helpers and [`.isActive()`](/store/URLStore/isActive) / [`.isProud()`](/store/URLStore/isProud). |
-| [`BusyStore`](/store/BusyStore)`<T>` | Adds a [`.busy`](/store/BusyStore/busy) boolean store that is `true` while awaiting a value. |
-| [`FetchStore`](/store/FetchStore)`<T>` | Fetches its value from a callback; adds [`.refresh()`](/store/FetchStore/refresh) / [`.invalidate()`](/store/FetchStore/invalidate). |
-| [`PayloadFetchStore`](/store/PayloadFetchStore)`<P, R>` | A `FetchStore` driven by a [`.payload`](/store/PayloadFetchStore/payload) store — changing the payload re-fetches. |
+| [`BusyStore<T>`](/store/BusyStore) | Adds a [`.busy`](/store/BusyStore/busy) boolean store that is `true` while awaiting a value. |
+| [`FetchStore<T>`](/store/FetchStore) | Fetches its value from a callback; adds [`.refresh()`](/store/FetchStore/refresh) / [`.invalidate()`](/store/FetchStore/invalidate). |
+| [`PayloadFetchStore<P, R>`](/store/PayloadFetchStore) | A `FetchStore` driven by a [`.payload`](/store/PayloadFetchStore/payload) store — changing the payload re-fetches. |
 
 [`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore) in the [`db`](/db) module extend `FetchStore` directly, adding database-aware fetch and subscription logic.
 

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -1,14 +1,14 @@
 # store
 
-Observable value containers for reactive state. A `Store<T>` holds a single current value, broadcasts changes to all active consumers, and integrates with React Suspense out of the box. Stores suppress duplicate emissions using deep equality, so consumers only see genuine changes.
+Observable value containers for reactive state. A [`Store`](/store/Store)`<T>` holds a single current value, broadcasts changes to all active consumers, and integrates with React Suspense out of the box. Stores suppress duplicate emissions using deep equality, so consumers only see genuine changes.
 
 ## Concepts
 
-**Loading state** — a store starts in a loading state represented internally by the `NONE` sentinel. Reading `store.value` while loading throws a `Promise` (the store's internal `DeferredSequence`), which React Suspense catches and waits on. Reading `store.loading` is safe and never throws.
+**Loading state** — a store starts in a loading state represented internally by the [`NONE`](/util/constants/NONE) sentinel. Reading [`.value`](/store/Store/value) while loading throws a `Promise` (the store's internal [`DeferredSequence`](/sequence/DeferredSequence)), which React Suspense catches and waits on. Reading [`.loading`](/store/Store/loading) is safe and never throws.
 
-**Error state** — setting `store.reason` puts the store in an error state. Subsequent reads of `store.value` throw that reason, which React error boundaries can catch.
+**Error state** — setting [`.reason`](/store/Store/reason) puts the store in an error state. Subsequent reads of `.value` throw that reason, which React error boundaries can catch.
 
-**Async iteration** — `Store<T>` implements `AsyncIterable<T>`. Iterating with `for await...of` first emits the current value (if one exists), then emits each subsequent value as it changes. The iterator blocks between values using the store's internal [`DeferredSequence`](/sequence).
+**Async iteration** — `Store<T>` implements `AsyncIterable<T>`. Iterating with `for await...of` first emits the current value (if one exists), then emits each subsequent value as it changes. The iterator blocks between values using the store's internal `DeferredSequence`.
 
 **Duplicate suppression** — deep equality is checked before emitting. Setting the same value twice only triggers one emission.
 
@@ -18,24 +18,24 @@ Observable value containers for reactive state. A `Store<T>` holds a single curr
 
 | Class | Description |
 |---|---|
-| `DataStore<T>` | Adds `.data`, `.update()`, `.get()`, `.set()` helpers for object values. |
-| `OptionalDataStore<T>` | Like `DataStore` but the value may be `undefined`; `.exists` and `.require()` handle the absent case. |
-| `ArrayStore<T>` | Stores an array; adds `.first`, `.last`, `.count`, `.add()`, `.delete()`, `.toggle()`. |
-| `DictionaryStore<T>` | Stores a string-keyed object; adds `.get()`, `.set()`, `.delete()`, `.update()`. |
-| `BooleanStore` | Stores a boolean; adds `.toggle()`. |
-| `PathStore` | Stores an absolute path; adds `.isActive()` / `.isProud()` route helpers. |
-| `URLStore` | Stores a URL; adds query-param helpers and `.isActive()` / `.isProud()`. |
-| `BusyStore<T>` | Adds a `.busy` boolean store that is `true` while awaiting a value. |
-| `FetchStore<T>` | Fetches its value from a callback; adds `refresh()` / `invalidate()`. |
-| `PayloadFetchStore<P, R>` | A `FetchStore` driven by a `.payload` store — changing the payload re-fetches. |
+| [`DataStore`](/store/DataStore)`<T>` | Adds [`.data`](/store/DataStore/data), [`.update()`](/store/DataStore/update), [`.get()`](/store/DataStore/get), [`.set()`](/store/DataStore/set) helpers for object values. |
+| [`OptionalDataStore`](/store/OptionalDataStore)`<T>` | Like `DataStore` but the value may be `undefined`; [`.exists`](/store/OptionalDataStore/exists) and [`.require()`](/store/OptionalDataStore/require) handle the absent case. |
+| [`ArrayStore`](/store/ArrayStore)`<T>` | Stores an array; adds [`.first`](/store/ArrayStore/first), [`.last`](/store/ArrayStore/last), [`.count`](/store/ArrayStore/count), [`.add()`](/store/ArrayStore/add), [`.delete()`](/store/ArrayStore/delete), [`.toggle()`](/store/ArrayStore/toggle). |
+| [`DictionaryStore`](/store/DictionaryStore)`<T>` | Stores a string-keyed object; adds [`.get()`](/store/DictionaryStore/get), [`.set()`](/store/DictionaryStore/set), [`.delete()`](/store/DictionaryStore/delete), [`.update()`](/store/DictionaryStore/update). |
+| [`BooleanStore`](/store/BooleanStore) | Stores a boolean; adds [`.toggle()`](/store/BooleanStore/toggle). |
+| [`PathStore`](/store/PathStore) | Stores an absolute path; adds [`.isActive()`](/store/PathStore/isActive) / [`.isProud()`](/store/PathStore/isProud) route helpers. |
+| [`URLStore`](/store/URLStore) | Stores a URL; adds query-param helpers and [`.isActive()`](/store/URLStore/isActive) / [`.isProud()`](/store/URLStore/isProud). |
+| [`BusyStore`](/store/BusyStore)`<T>` | Adds a [`.busy`](/store/BusyStore/busy) boolean store that is `true` while awaiting a value. |
+| [`FetchStore`](/store/FetchStore)`<T>` | Fetches its value from a callback; adds [`.refresh()`](/store/FetchStore/refresh) / [`.invalidate()`](/store/FetchStore/invalidate). |
+| [`PayloadFetchStore`](/store/PayloadFetchStore)`<P, R>` | A `FetchStore` driven by a [`.payload`](/store/PayloadFetchStore/payload) store — changing the payload re-fetches. |
 
-`ItemStore` and `QueryStore` in the [`db`](/db) module extend `FetchStore` directly, adding database-aware fetch and subscription logic.
+[`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore) in the [`db`](/db) module extend `FetchStore` directly, adding database-aware fetch and subscription logic.
 
 ## Usage
 
 Every store shares the same core: set `.value`, read it back (or `for await` it), and consumers see the change. The base [`Store`](/store/Store) page covers the full lifecycle; each subclass page covers its own helpers.
 
-As an integration example, `store.through(sequence)` bridges any `AsyncIterable` source into a store — it sets the store's value for each item yielded and re-yields it:
+As an integration example, [`.through()`](/store/Store/through) bridges any `AsyncIterable` source into a store — it sets the store's value for each item yielded and re-yields it:
 
 ```ts
 import { Store, NONE } from "shelving/store";
@@ -51,6 +51,6 @@ async function connect(stream: AsyncIterable<number>) {
 
 ## See also
 
-- [`sequence`](/sequence) — `DeferredSequence` that powers the store's async iteration
-- [`db`](/db) — `ItemStore` and `QueryStore` extend `Store` for database-backed reactive state
-- [`react`](/react) — `useStore()` subscribes a React component to a store
+- [`sequence`](/sequence) — [`DeferredSequence`](/sequence/DeferredSequence) that powers the store's async iteration
+- [`db`](/db) — [`ItemStore`](/db/ItemStore) and [`QueryStore`](/db/QueryStore) extend `Store` for database-backed reactive state
+- [`react`](/react) — [`useStore()`](/react/useStore) subscribes a React component to a store

--- a/modules/test/README.md
+++ b/modules/test/README.md
@@ -10,7 +10,7 @@ Reach for these fixtures whenever a test needs a schema, a collection, or a hand
 
 ### Basics
 
-`BASIC_SCHEMA` is a [`DataSchema`](/schema) covering every common field type — string, number, choice, array, boolean, and a nested object. `basic1` … `basic9` are ready-made items. `basics` is those nine in a deliberately unsorted order, so a test that sorts or queries them actually proves something. `basic999` is a tenth item kept out of the array — handy as an "add this" payload.
+[`BASIC_SCHEMA`](/test/BASIC_SCHEMA) is a [`DataSchema`](/schema/DataSchema) covering every common field type — string, number, choice, array, boolean, and a nested object. [`basic1`](/test/basic1) … [`basic9`](/test/basic9) are ready-made items. [`basics`](/test/basics) is those nine in a deliberately unsorted order, so a test that sorts or queries them actually proves something. [`basic999`](/test/basic999) is a tenth item kept out of the array — handy as an "add this" payload.
 
 ```ts
 import { BASIC_SCHEMA, basics, basic1 } from "shelving/test";
@@ -21,7 +21,7 @@ basics.length;                 // 9, in unsorted order.
 
 ### People
 
-`PERSON_SCHEMA` is a smaller, more lifelike shape — a nested `name` object and a nullable `birthday`. `person1` … `person5` and the `people` array supply the data.
+[`PERSON_SCHEMA`](/test/PERSON_SCHEMA) is a smaller, more lifelike shape — a nested `name` object and a nullable `birthday`. [`person1`](/test/person1) … [`person5`](/test/person5) and the [`people`](/test/people) array supply the data.
 
 ```ts
 import { PERSON_SCHEMA, people } from "shelving/test";
@@ -29,7 +29,7 @@ import { PERSON_SCHEMA, people } from "shelving/test";
 
 ### Collections
 
-`BASICS_COLLECTION` and `PEOPLE_COLLECTION` wrap the two schemas as [`Collection`](/db) definitions, ready to hand straight to a provider.
+[`BASICS_COLLECTION`](/test/BASICS_COLLECTION) and [`PEOPLE_COLLECTION`](/test/PEOPLE_COLLECTION) wrap the two schemas as [`Collection`](/db/Collection) definitions, ready to hand straight to a provider.
 
 ```ts
 import { MemoryDBProvider } from "shelving/db";
@@ -43,11 +43,11 @@ await provider.addItem(BASICS_COLLECTION, basic1);
 
 | Helper | Use |
 |---|---|
-| `expectOrderedItems(items, ids)` | Assert an iterable of items has exactly these ids, in this order. |
-| `expectUnorderedItems(items, ids)` | The same, but order does not matter. |
-| `EXPECT_PROMISELIKE` | A matcher for "this value looks like a promise". |
+| [`expectOrderedItems()`](/test/expectOrderedItems) | Assert an iterable of items has exactly these ids, in this order. |
+| [`expectUnorderedItems()`](/test/expectUnorderedItems) | The same, but order does not matter. |
+| [`EXPECT_PROMISELIKE`](/test/EXPECT_PROMISELIKE) | A matcher for "this value looks like a promise". |
 
-`expectOrderedItems` and `expectUnorderedItems` compare by `id`, so a failure reports the ids that were wrong — far more readable than a deep object diff. Both trim their own stack frame, so the reported failure points at your test.
+`expectOrderedItems()` and `expectUnorderedItems()` compare by `id`, so a failure reports the ids that were wrong — far more readable than a deep object diff. Both trim their own stack frame, so the reported failure points at your test.
 
 ```ts
 import { expectOrderedItems } from "shelving/test";
@@ -58,5 +58,5 @@ expectOrderedItems(results, ["basic1", "basic2", "basic3"]);
 
 ## See also
 
-- [schema](/schema) — the schemas these fixtures are built on
-- [db](/db) — `Collection` and the providers the fixtures are designed to exercise
+- [`schema`](/schema) — the schemas these fixtures are built on
+- [`db`](/db) — [`Collection`](/db/Collection) and the providers the fixtures are designed to exercise

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -11,7 +11,7 @@ The `ui` module exists so an app never hand-rolls the same form field, card, or 
 A few conventions run through every component:
 
 - **Styling props are for one-off overrides.** Visual options are props on the component — enumerated props for the scales (`color="red"`, `size="large"`, `space="none"`, `width="narrow"`) and boolean props for on/off variants (`<Button strong>`, `<Title center>`, `<Flex wrap>`). Each maps to a class in a CSS Module. Reach for them when a component needs to look different in *one place* — the way the docs site tints its accents purple — not as the way to dress a whole app. You never pass `style` or raw `className`.
-- **Composition.** Higher-level components — a `*Page`, a `*Card` — take their identity from library components like [`Card`](/ui/Card), [`Section`](/ui/Section), [`Button`](/ui/Button), and [`Tag`](/ui/Tag) rather than shipping their own styling.
+- **Composition.** Higher-level components — a `*Page`, a `*Card` — take their identity from library components like [`<Card>`](/ui/Card), [`<Section>`](/ui/Section), [`<Button>`](/ui/Button), and [`<Tag>`](/ui/Tag) rather than shipping their own styling.
 - **Sentence case.** Titles, headings, and button labels capitalise only the first word.
 - **Theme with CSS.** An app-wide custom look is a CSS file, not a wall of props. Write a `theme.css` that overrides the base design-token variables (and, where needed, per-component hooks) at `:root`, and import it after the library styles. The recommended workflow is to spend time tuning those variables to match your design — see [Theming](#theming) below.
 
@@ -19,15 +19,15 @@ A few conventions run through every component:
 
 The styling system lives in `style/` and has four moving parts: design tokens, the tint scale, cascade layers, and the styling props. Components compose them in a predictable shape; consumers theme by overriding CSS custom properties at `:root`.
 
-**Design tokens.** Every design-token constant is defined at `:root`, split across the themed token modules in `style/` — each module owns one domain, documents the variables it defines, and is the page a theme author overrides. `style/layers.css` is the cascade-layer anchor; every `*.module.css` `@import`s it plus the specific token modules it references, so the tokens and the layer order reach every component regardless of bundle order. The domains are: colours ([`getColorClass`](/ui/getColorClass)), font sizes ([`getSizeClass`](/ui/getSizeClass)), font weights ([`getWeightClass`](/ui/getWeightClass)), font faces ([`getFontClass`](/ui/getFontClass)), spacing ([`getSpaceClass`](/ui/getSpaceClass)), widths ([`getWidthClass`](/ui/getWidthClass)), radii ([`getRadiusClass`](/ui/getRadiusClass)), strokes ([`getStrokeClass`](/ui/getStrokeClass)), shadows ([`getShadowClass`](/ui/getShadowClass)), and durations ([`getDurationClass`](/ui/getDurationClass)). Each also defines the semantic aliases a theme usually targets (`--color-primary`, `--color-link`, `--space-paragraph`, …). Components read tokens via `var(--token)`.
+**Design tokens.** Every design-token constant is defined at `:root`, split across the themed token modules in `style/` — each module owns one domain, documents the variables it defines, and is the page a theme author overrides. `style/layers.css` is the cascade-layer anchor; every `*.module.css` `@import`s it plus the specific token modules it references, so the tokens and the layer order reach every component regardless of bundle order. The domains are: colours ([`getColorClass()`](/ui/getColorClass)), font sizes ([`getSizeClass()`](/ui/getSizeClass)), font weights ([`getWeightClass()`](/ui/getWeightClass)), font faces ([`getFontClass()`](/ui/getFontClass)), spacing ([`getSpaceClass()`](/ui/getSpaceClass)), widths ([`getWidthClass()`](/ui/getWidthClass)), radii ([`getRadiusClass()`](/ui/getRadiusClass)), strokes ([`getStrokeClass()`](/ui/getStrokeClass)), shadows ([`getShadowClass()`](/ui/getShadowClass)), and durations ([`getDurationClass()`](/ui/getDurationClass)). Each also defines the semantic aliases a theme usually targets (`--color-primary`, `--color-link`, `--space-paragraph`, …). Components read tokens via `var(--token)`.
 
-**The tint scale.** All colour flows from one anchor variable, `--tint-50`, from which a 21-step ladder is computed and *recomputed* under [`TINT_CLASS`](/ui/TINT_CLASS) — the heart of how `color=` and `status=` retint a whole subtree. The ladder, the recompute trick, the painting conventions, and the theming guide all live on the [`TINT_CLASS`](/ui/TINT_CLASS) page.
+**The tint scale.** All colour flows from one anchor variable, `--tint-50`, from which a 21-step ladder is computed and *recomputed* under [`TINT_CLASS`](/ui/TINT_CLASS) — the heart of how `color=` and `status=` retint a whole subtree. The ladder, the recompute trick, the painting conventions, and the theming guide all live on the `TINT_CLASS` page.
 
 **Cascade layers.** Styles are ordered by `@layer`, lowest to highest priority: `defaults` (`:root` tokens, the tint ladder, body baseline) → `components` (the bulk of the CSS: `.card`, `.button`, …) → `variants` (cross-cutting opt-in modifiers, which always beat components) → `overrides` (top-priority structural fixes like `:first-child` / `:last-child` margin collapses). Unlayered rules beat all layered rules, so a theme should set tokens at `:root` or wrap its rules in `@layer`.
 
-**Styling props.** The cross-cutting visual options are props, each backed by a helper in `style/` that maps the prop to a class. Colour and status move the tint anchor — [`getColorClass`](/ui/getColorClass) and [`getStatusClass`](/ui/getStatusClass); font size, weight, and family come from [`getSizeClass`](/ui/getSizeClass), [`getWeightClass`](/ui/getWeightClass), and [`getFontClass`](/ui/getFontClass), which [`getTypographyClass`](/ui/getTypographyClass) combines with text alignment and tint; spacing, padding, and gap from [`getSpaceClass`](/ui/getSpaceClass), [`getPaddingClass`](/ui/getPaddingClass), and [`getGapClass`](/ui/getGapClass); width constraints from [`getWidthClass`](/ui/getWidthClass); flex layout from [`getFlexClass`](/ui/getFlexClass); and opt-in scrolling from [`getScrollClass`](/ui/getScrollClass). Each helper's page lists its exact prop values and what they set. A component opts into the props it wants by extending the matching `*Props` interfaces and composing the `getXxxClass(props)` calls.
+**Styling props.** The cross-cutting visual options are props, each backed by a helper in `style/` that maps the prop to a class. Colour and status move the tint anchor — `getColorClass()` and [`getStatusClass()`](/ui/getStatusClass); font size, weight, and family come from `getSizeClass()`, `getWeightClass()`, and `getFontClass()`, which [`getTypographyClass()`](/ui/getTypographyClass) combines with text alignment and tint; spacing, padding, and gap from `getSpaceClass()`, [`getPaddingClass()`](/ui/getPaddingClass), and [`getGapClass()`](/ui/getGapClass); width constraints from `getWidthClass()`; flex layout from [`getFlexClass()`](/ui/getFlexClass); and opt-in scrolling from [`getScrollClass()`](/ui/getScrollClass). Each helper's page lists its exact prop values and what they set. A component opts into the props it wants by extending the matching `*Props` interfaces and composing the `getXxxClass(props)` calls.
 
-Each painting component also exposes its own theme hooks — a single tint hook (`--card-tint`) to recolour the whole component, plus per-property hooks (`--card-background`, `--card-radius`, …) for surgical overrides. Those are documented in each component's own **Styling** section (see [`Card`](/ui/Card) for the precedent).
+Each painting component also exposes its own theme hooks — a single tint hook (`--card-tint`) to recolour the whole component, plus per-property hooks (`--card-background`, `--card-radius`, …) for surgical overrides. Those are documented in each component's own **Styling** section (see [`<Card>`](/ui/Card) for the precedent).
 
 ## Theming
 
@@ -45,10 +45,10 @@ The recommended way to give an app its own look is a **theme stylesheet**, not s
 
 Each base token lives in a themed module that documents the variables it defines and which ones a theme usually overrides. Work from broadest (a palette colour or scale root) to narrowest (a single semantic alias):
 
-- [weight](/ui/getWeightClass) · [size](/ui/getSizeClass) · [font](/ui/getFontClass) — typography (`--weight-*`, `--size-*`, `--font-*`, `--case-label`).
-- [color](/ui/getColorClass) — palette, semantic, and brand colours (`--color-*`).
-- [space](/ui/getSpaceClass) · [width](/ui/getWidthClass) — layout spacing and widths (`--space-*`, `--width-*`).
-- [radius](/ui/getRadiusClass) · [stroke](/ui/getStrokeClass) · [shadow](/ui/getShadowClass) · [duration](/ui/getDurationClass) — surface tokens (`--radius-*`, `--stroke-*`, `--shadow-*`, `--duration-*`).
+- [`weight`](/ui/getWeightClass) · [`size`](/ui/getSizeClass) · [`font`](/ui/getFontClass) — typography (`--weight-*`, `--size-*`, `--font-*`, `--case-label`).
+- [`color`](/ui/getColorClass) — palette, semantic, and brand colours (`--color-*`).
+- [`space`](/ui/getSpaceClass) · [`width`](/ui/getWidthClass) — layout spacing and widths (`--space-*`, `--width-*`).
+- [`radius`](/ui/getRadiusClass) · [`stroke`](/ui/getStrokeClass) · [`shadow`](/ui/getShadowClass) · [`duration`](/ui/getDurationClass) — surface tokens (`--radius-*`, `--stroke-*`, `--shadow-*`, `--duration-*`).
 
 The **tint ladder** is the one exception that doesn't follow the override-a-variable pattern: its 21 steps are *recomputed* from a single anchor inside every tinted scope, so you move the anchor rather than overriding individual steps. See [`TINT_CLASS`](/ui/TINT_CLASS) for the full theming guide, and each component's **Styling** section for its per-component hooks.
 
@@ -56,19 +56,19 @@ The **tint ladder** is the one exception that doesn't follow the override-a-vari
 
 The components below are listed in the index following this page; this is the short version of where to start reading.
 
-**Content.** Block-level structure starts with [`Card`](/ui/Card), [`Section`](/ui/Section), and the [`Heading`](/ui/Heading) / [`Title`](/ui/Title) family, with [`Table`](/ui/Table), [`List`](/ui/List), and [`Figure`](/ui/Figure) for specific shapes; wrap longform copy in [`Prose`](/ui/Prose). Inline pieces — [`Link`](/ui/Link), [`Code`](/ui/Code), [`Strong`](/ui/Strong), [`Mark`](/ui/Mark) — live inside that block content. To render a Markdown string as components, use [`Markup`](/ui/Markup).
+**Content.** Block-level structure starts with [`<Card>`](/ui/Card), [`<Section>`](/ui/Section), and the [`<Heading>`](/ui/Heading) / [`<Title>`](/ui/Title) family, with [`<Table>`](/ui/Table), [`<List>`](/ui/List), and [`<Figure>`](/ui/Figure) for specific shapes; wrap longform copy in [`<Prose>`](/ui/Prose). Inline pieces — [`<Link>`](/ui/Link), [`<Code>`](/ui/Code), [`<Strong>`](/ui/Strong), [`<Mark>`](/ui/Mark) — live inside that block content. To render a Markdown string as components, use [`<Markup>`](/ui/Markup).
 
-**Structure.** Mount a client app with [`App`](/ui/App), or render a full server document with [`HTML`](/ui/HTML) and [`Page`](/ui/Page). Arrange the screen with [`CenteredLayout`](/ui/CenteredLayout) or [`SidebarLayout`](/ui/SidebarLayout), and drive URLs with [`Navigation`](/ui/Navigation) and [`Router`](/ui/Router).
+**Structure.** Mount a client app with [`<App>`](/ui/App), or render a full server document with [`<HTML>`](/ui/HTML) and [`<Page>`](/ui/Page). Arrange the screen with [`<CenteredLayout>`](/ui/CenteredLayout) or [`<SidebarLayout>`](/ui/SidebarLayout), and drive URLs with [`<Navigation>`](/ui/Navigation) and [`<Router>`](/ui/Router).
 
-**Interaction.** Forms start at [`Form`](/ui/Form), which wires [`Field`](/ui/Field) and the typed inputs to a [`FormStore`](/ui/FormStore); [`Button`](/ui/Button) is the standalone action. Overlays are [`Dialog`](/ui/Dialog) and [`Modal`](/ui/Modal); navigation menus are [`Menu`](/ui/Menu) and [`MenuItem`](/ui/MenuItem); transient feedback is [`Notice`](/ui/Notice) (and the global [`Notices`](/ui/Notices) list); animate enter/leave with [`Transition`](/ui/Transition).
+**Interaction.** Forms start at [`<Form>`](/ui/Form), which wires [`<Field>`](/ui/Field) and the typed inputs to a [`FormStore`](/ui/FormStore); [`<Button>`](/ui/Button) is the standalone action. Overlays are [`<Dialog>`](/ui/Dialog) and [`<Modal>`](/ui/Modal); navigation menus are [`<Menu>`](/ui/Menu) and [`<MenuItem>`](/ui/MenuItem); transient feedback is [`<Notice>`](/ui/Notice) (and the global [`<Notices>`](/ui/Notices) list); animate enter/leave with [`<Transition>`](/ui/Transition).
 
-**Documentation site.** Hand an extracted tree to [`TreeApp`](/ui/TreeApp) and you get a complete site — sidebar, routing, and a rendered page per element — using the renderers in `docs/`.
+**Documentation site.** Hand an extracted tree to [`<TreeApp>`](/ui/TreeApp) and you get a complete site — sidebar, routing, and a rendered page per element — using the renderers in `docs/`.
 
 ## See also
 
-- [extract](/extract) — builds the tree that the documentation components render
-- [markup](/markup) — Markdown rendering used by [`Markup`](/ui/Markup) and [`Prose`](/ui/Prose)
-- [store](/store) — reactive state behind [`FormStore`](/ui/FormStore), `NavigationStore`, and notices
-- [react](/react) — store and provider hooks used alongside these components
+- [`extract`](/extract) — builds the tree that the documentation components render
+- [`markup`](/markup) — Markdown rendering used by [`<Markup>`](/ui/Markup) and [`<Prose>`](/ui/Prose)
+- [`store`](/store) — reactive state behind [`FormStore`](/ui/FormStore), [`NavigationStore`](/ui/NavigationStore), and notices
+- [`react`](/react) — store and provider hooks used alongside these components
 
 > Building or extending a component? The contributor walkthrough (file layout, the tint-anchor + per-property-hook pattern, `:first-child` / `:last-child` overrides, and the checklist) lives in the **React Components** section of `AGENTS.md`.


### PR DESCRIPTION
Add a "Cross-references and token display" rule to AGENTS.md and apply it
consistently across every module README.

- Link every module/token reference to its canonical docs-site page using
  backtick-quoted link text: [`BooleanSchema`](/schema/BooleanSchema).
- Style tokens by kind: functions `formatDate()`, methods `.validate()`,
  properties `.value`, components `<Section>`, classes/types/constants bare.
- Repoint links that pointed at non-existent submodule pages
  (/db/collection, /api/provider, /markup/rule, /ui/tree, bare /firestore,
  bare /util) to their nearest real page (the flat module page, a real token
  page, or the specific /util/<file>).

Every link target was validated against the generated docs tree so each one
resolves to a real page.