### PR TITLE
feat: full-width tables with width variant, default code size in docs tables

### DIFF
--- a/modules/ui/block/Table.md
+++ b/modules/ui/block/Table.md
@@ -8,6 +8,7 @@ A data table — renders a `<table>`. Compose the usual `<thead>` / `<tbody>` / 
 - First and last cells in a row drop their outer inline padding so the table aligns flush with the surrounding text column.
 - Wrap a wide table in a horizontally scrollable container if it may exceed the content width on small screens.
 - Like the other block components it collapses its outer block margin when it is the first or last child.
+- Spans the full width of its container by default; set the `width` variant (`narrow` / `normal` / `wide` / `full` / `fit`) to constrain it.
 - Inside [`Prose`](/ui/Prose) a raw `<table>` picks up the same styling, so Markdown-rendered tables match component ones.
 
 ## Usage

--- a/modules/ui/block/Table.module.css
+++ b/modules/ui/block/Table.module.css
@@ -11,6 +11,7 @@
 	.prose table {
 		/* Box */
 		display: table;
+		inline-size: 100%;
 		margin-inline: 0;
 		margin-block: var(--table-space, var(--space-paragraph));
 		text-indent: 0;

--- a/modules/ui/block/Table.tsx
+++ b/modules/ui/block/Table.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import { type ColorVariants, getColorClass } from "../style/Color.js";
 import { getSpaceClass, type SpaceVariants } from "../style/Space.js";
 import { getTypographyClass, type TypographyVariants } from "../style/Typography.js";
+import { getWidthClass, type WidthVariants } from "../style/Width.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import type { ChildProps } from "../util/props.js";
 import TABLE_CSS from "./Table.module.css";
@@ -9,11 +10,11 @@ import TABLE_CSS from "./Table.module.css";
 const TABLE_CLASS = getModuleClass(TABLE_CSS, "table");
 
 /**
- * Props for `Table` — colour, space, and typography variants plus `children`.
+ * Props for `Table` — colour, space, typography, and width variants plus `children`.
  *
  * @see https://dhoulb.github.io/shelving/ui/block/Table/TableProps
  */
-export interface TableProps extends ColorVariants, SpaceVariants, TypographyVariants, ChildProps {}
+export interface TableProps extends ColorVariants, SpaceVariants, TypographyVariants, WidthVariants, ChildProps {}
 
 /**
  * Table block — rendered as `<table>`.
@@ -21,7 +22,7 @@ export interface TableProps extends ColorVariants, SpaceVariants, TypographyVari
  * - `<th>` / `<td>` cells draw the borders (the `<table>` element itself has none); override their weight via the `--table-border` / `--table-stroke` hooks.
  *
  * @kind component
- * @param props Colour, space, and typography variants plus `children`.
+ * @param props Colour, space, typography, and width variants plus `children`.
  * @returns Rendered `<table>` element.
  * @example <Table><tbody><tr><td>Cell</td></tr></tbody></Table>
  * @see https://dhoulb.github.io/shelving/ui/block/Table/Table
@@ -34,6 +35,7 @@ export function Table({ children, ...props }: TableProps): ReactElement {
 				getColorClass(props),
 				getSpaceClass(props),
 				getTypographyClass(props),
+				getWidthClass(props),
 			)}
 		>
 			{children}

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -127,12 +127,12 @@ export function DocumentationPage({
 											{params.map(({ name, type = DEFAULT_TYPE, description = "", default: def }) => (
 												<tr key={`${name}-${type}-${description}`}>
 													<td>
-														<Code size="normal">{name}</Code>
+														<Code>{name}</Code>
 													</td>
 													<td>
-														<Code size="normal">{type}</Code>
+														<Code>{type}</Code>
 													</td>
-													<td>{def ? <Code size="normal">{def}</Code> : "-"}</td>
+													<td>{def ? <Code>{def}</Code> : "-"}</td>
 													<td>{description}</td>
 												</tr>
 											))}
@@ -155,7 +155,7 @@ export function DocumentationPage({
 											{returns.map(({ type = DEFAULT_TYPE, description = "" }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
-														<Code size="normal">{type}</Code>
+														<Code>{type}</Code>
 													</td>
 													<td>{description}</td>
 												</tr>
@@ -179,7 +179,7 @@ export function DocumentationPage({
 											{throws.map(({ type = DEFAULT_TYPE, description = "" }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
-														<Code size="normal">{type}</Code>
+														<Code>{type}</Code>
 													</td>
 													<td>{description}</td>
 												</tr>


### PR DESCRIPTION
## Summary

- **`Table` now spans full width by default.** Added `inline-size: 100%` to the `.table` / `.prose table` rule so both component-rendered and Prose/Markdown tables fill their container.
- **`Table` accepts the `width` variant.** Composed `WidthVariants` (`narrow` / `normal` / `wide` / `full` / `fit`) into `TableProps`, matching the pattern used by `Card`. The variant lives in `@layer variants`, which beats the `@layer components` default, so it cleanly overrides the full-width default.
- **Docs parameter / returns / throws tables use the default code size.** Dropped `size="normal"` from the `<Code>` cells in `DocumentationPage`, so the code elements fall back to their default size instead of being forced to `normal`.

## Notes

- Updated the `Table.tsx` docblocks and `Table.md` ("Things to know" + the new `width` variant) to stay in sync.
- Like the other block components, the constrained width variants center via `margin-inline: auto` only in `@layer defaults`, so a constrained table stays left-aligned (consistent with the existing Width system) rather than centered.

## Verification

- `bun run fix` (clean; the single info is a pre-existing `biome.json` deprecation)
- `bun run test:type` (passed)
- `bun test modules/ui/docs/DocumentationPage.test.tsx` (4 pass)

https://claude.ai/code/session_01L72ervdEXK8BA8X2RzCiJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L72ervdEXK8BA8X2RzCiJV)_