### PR TITLE
refactor: extract SlugSchemaOptions, EmailSchemaOptions and UUIDSchemaOptions interfaces

### DIFF
--- a/modules/schema/ColorSchema.ts
+++ b/modules/schema/ColorSchema.ts
@@ -9,7 +9,7 @@ const NOT_HEX_REGEXP = /[^0-9A-F]/g;
  *
  * @see https://dhoulb.github.io/shelving/schema/ColorSchema/ColorSchemaOptions
  */
-export interface ColorSchemaOptions extends Omit<StringSchemaOptions, "type" | "min" | "max" | "match" | "rows"> {}
+export interface ColorSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {}
 
 /**
  * Schema that defines a valid color hex string, e.g. `#00CCFF`
@@ -24,20 +24,22 @@ export class ColorSchema extends StringSchema {
 	/**
 	 * Create a new `ColorSchema`.
 	 *
-	 * @param options Options for the schema (inherits `StringSchema` options except `type`, `min`, `max`, `match`, and `rows`, which are fixed for hex colors).
+	 * @param options Options for the schema (inherits `StringSchema` options except `min`, `match`, and `rows`, which are fixed for hex colors).
 	 * @param options.one Singular noun describing one value, used in error messages (defaults to `"color"`).
 	 * @param options.title Title of the schema, e.g. for a corresponding field (defaults to `"Color"`).
 	 * @param options.value Default hex value used when the input is `undefined` (defaults to `"#000000"`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"color"`).
+	 * @param options.max Maximum allowed character length (defaults to `7`).
 	 */
-	constructor({ one = "color", title = "Color", value = "#000000", ...options }: ColorSchemaOptions) {
+	constructor({ one = "color", title = "Color", value = "#000000", input = "color", max = 7, ...options }: ColorSchemaOptions) {
 		super({
 			one,
 			title,
 			value,
 			...options,
-			input: "color",
+			input,
+			max,
 			min: 1,
-			max: 7,
 			rows: 1,
 			match: COLOR_REGEXP,
 		});

--- a/modules/schema/CurrencyCodeSchema.ts
+++ b/modules/schema/CurrencyCodeSchema.ts
@@ -11,7 +11,7 @@ import { StringSchema } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchemaOptions
  */
-export interface CurrencyCodeSchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "match" | "rows"> {
+export interface CurrencyCodeSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {
 	currencies?: ImmutableArray<CurrencyCode>;
 }
 
@@ -36,17 +36,17 @@ export class CurrencyCodeSchema extends StringSchema {
 	/**
 	 * Create a new `CurrencyCodeSchema`.
 	 *
-	 * @param options Options for the schema (`currencies`, plus base `StringSchemaOptions` except `input`/`min`/`max`/`match`/`rows`).
+	 * @param options Options for the schema (`currencies`, plus base `StringSchemaOptions` except `min`/`match`/`rows`).
 	 * @example new CurrencyCodeSchema({ currencies: ["GBP", "USD"] })
 	 * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema
 	 */
-	constructor({ one = "currency", title = "Currency", currencies = CURRENCY_CODES, ...options }: CurrencyCodeSchemaOptions) {
+	constructor({ one = "currency", title = "Currency", currencies = CURRENCY_CODES, max = 3, ...options }: CurrencyCodeSchemaOptions) {
 		super({
 			one,
 			title,
 			...options,
+			max, // Valid currency code is 3 uppercase letters.
 			min: 3,
-			max: 3, // Valid currency code is 3 uppercase letters.
 			rows: 1,
 			case: "upper",
 			match: /^[A-Z]{3}$/, // Valid currency code is 3 uppercase letters.

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -7,6 +7,13 @@ const R_MATCH =
 	/^[a-z0-9](?:[a-zA-Z0-9._+-]{0,62}[a-zA-Z0-9])?@(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){1,3}(?:[a-z]{2,63}|xn--[a-z0-9-]{0,58}[a-z0-9])$/;
 
 /**
+ * Options for an `EmailSchema`.
+ *
+ * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchemaOptions
+ */
+export interface EmailSchemaOptions extends Omit<StringSchemaOptions, "type" | "min" | "max" | "match" | "rows"> {}
+
+/**
  * Schema that defines a valid email address.
  *
  * - Falsy values are converted to `""` empty string.
@@ -34,11 +41,7 @@ export class EmailSchema extends StringSchema {
 	 * @param options.one Singular noun describing one value, used in error messages (defaults to `"email address"`).
 	 * @param options.title Title of the schema, e.g. for a corresponding field (defaults to `"Email"`).
 	 */
-	constructor({
-		one = "email address",
-		title = "Email",
-		...options
-	}: Omit<StringSchemaOptions, "type" | "min" | "max" | "match" | "rows">) {
+	constructor({ one = "email address", title = "Email", ...options }: EmailSchemaOptions) {
 		super({
 			one,
 			title,

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -11,7 +11,7 @@ const R_MATCH =
  *
  * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchemaOptions
  */
-export interface EmailSchemaOptions extends Omit<StringSchemaOptions, "type" | "min" | "max" | "match" | "rows"> {}
+export interface EmailSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {}
 
 /**
  * Schema that defines a valid email address.
@@ -37,18 +37,20 @@ export class EmailSchema extends StringSchema {
 	/**
 	 * Create a new `EmailSchema`.
 	 *
-	 * @param options Options for the schema (inherits `StringSchema` options except `type`, `min`, `max`, `match`, and `rows`, which are fixed for emails).
+	 * @param options Options for the schema (inherits `StringSchema` options except `min`, `match`, and `rows`, which are fixed for emails).
 	 * @param options.one Singular noun describing one value, used in error messages (defaults to `"email address"`).
 	 * @param options.title Title of the schema, e.g. for a corresponding field (defaults to `"Email"`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"email"`).
+	 * @param options.max Maximum allowed character length (defaults to `254`).
 	 */
-	constructor({ one = "email address", title = "Email", ...options }: EmailSchemaOptions) {
+	constructor({ one = "email address", title = "Email", input = "email", max = 254, ...options }: EmailSchemaOptions) {
 		super({
 			one,
 			title,
 			...options,
-			input: "email",
+			input,
+			max,
 			min: 1,
-			max: 254,
 			rows: 1,
 			match: R_MATCH,
 		});

--- a/modules/schema/PasswordSchema.test.ts
+++ b/modules/schema/PasswordSchema.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { PASSWORD, PasswordSchema } from "../index.js";
+
+test("constructor()", () => {
+	const schema1 = new PasswordSchema({});
+	expect(schema1).toBeInstanceOf(PasswordSchema);
+	const schema2 = PASSWORD;
+	expect(schema2).toBeInstanceOf(PasswordSchema);
+});
+test("defaults the input hint to password", () => {
+	expect(new PasswordSchema({}).input).toBe("password");
+});
+test("allows the input hint to be overridden (e.g. show-password toggle)", () => {
+	expect(new PasswordSchema({ input: "text" }).input).toBe("text");
+});
+test("validates a password string", () => {
+	expect(PASSWORD.validate("hunter2")).toBe("hunter2");
+});
+test("never formats a password for display", () => {
+	expect(PASSWORD.format()).toBe("");
+});

--- a/modules/schema/PasswordSchema.ts
+++ b/modules/schema/PasswordSchema.ts
@@ -1,16 +1,9 @@
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
- * Options for a `PasswordSchema`.
- *
- * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PasswordSchemaOptions
- */
-export interface PasswordSchemaOptions extends Omit<StringSchemaOptions, "input"> {}
-
-/**
  * Schema that defines a valid password string.
  *
- * - Forces the `<input />` hint to `"password"` for downstream UIs.
+ * - Defaults the `<input />` hint to `"password"`, but a caller can override it (e.g. `"text"` for a show-password toggle).
  * - Never formats the value for display (`format()` always returns `""`).
  *
  * @example new PasswordSchema({}).validate("hunter2"); // Returns "hunter2"
@@ -20,13 +13,14 @@ export class PasswordSchema extends StringSchema {
 	/**
 	 * Create a new `PasswordSchema`.
 	 *
-	 * @param options Options for the schema (inherits `StringSchema` options except `input`, which is fixed to `"password"`).
+	 * @param options Options for the schema (inherits all `StringSchema` options).
 	 * @param options.one Singular noun describing one value, used in error messages (defaults to `"password"`).
 	 * @param options.title Title of the schema, e.g. for a corresponding field (defaults to `"Password"`).
 	 * @param options.min Minimum allowed character length (defaults to `6`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"password"`).
 	 */
-	constructor({ one = "password", title = "Password", min = 6, ...options }: PasswordSchemaOptions = {}) {
-		super({ one, title, min, ...options, input: "password" });
+	constructor({ one = "password", title = "Password", min = 6, input = "password", ...options }: StringSchemaOptions = {}) {
+		super({ one, title, min, input, ...options });
 	}
 
 	/**

--- a/modules/schema/PasswordSchema.ts
+++ b/modules/schema/PasswordSchema.ts
@@ -38,9 +38,9 @@ export class PasswordSchema extends StringSchema {
 }
 
 /**
- * Sugar instance of [`StringSchema`](/schema/StringSchema) for a password string. Equivalent to `new StringSchema({})`.
+ * Sugar instance of [`PasswordSchema`](/schema/PasswordSchema) for a password string. Equivalent to `new PasswordSchema({})`.
  *
  * @example PASSWORD.validate("hunter2"); // Returns "hunter2"
  * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PASSWORD
  */
-export const PASSWORD = new StringSchema({});
+export const PASSWORD = new PasswordSchema({});

--- a/modules/schema/PhoneSchema.ts
+++ b/modules/schema/PhoneSchema.ts
@@ -7,7 +7,7 @@ import { StringSchema } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PhoneSchemaOptions
  */
-export interface PhoneSchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "match" | "rows"> {}
+export interface PhoneSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {}
 
 /**
  * Schema that defines a valid phone number.
@@ -22,19 +22,21 @@ export class PhoneSchema extends StringSchema {
 	/**
 	 * Create a new `PhoneSchema`.
 	 *
-	 * @param options Options for the schema (inherits `StringSchema` options except `input`, `min`, `max`, `match`, and `rows`, which are fixed for phone numbers).
+	 * @param options Options for the schema (inherits `StringSchema` options except `min`, `match`, and `rows`, which are fixed for phone numbers).
 	 * @param options.one Singular noun describing one value, used in error messages (defaults to `"phone number"`).
 	 * @param options.title Title of the schema, e.g. for a corresponding field (defaults to `"Phone"`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"tel"`).
+	 * @param options.max Maximum allowed character length (defaults to `16`).
 	 */
-	constructor({ one = "phone number", title = "Phone", ...options }: PhoneSchemaOptions) {
+	constructor({ one = "phone number", title = "Phone", input = "tel", max = 16, ...options }: PhoneSchemaOptions) {
 		super({
 			one,
 			title,
 			...options,
-			input: "tel",
-			min: 1,
+			input,
 			// Valid phone number is 16 digits or fewer (15 numerals with a leading `+` plus).
-			max: 16,
+			max,
+			min: 1,
 			rows: 1,
 			// Valid phone number is max 16 digits made up of:
 			// - Country code (`+` plus character and 1-3 digits, e.g. `+44` or `+1`).

--- a/modules/schema/SlugSchema.ts
+++ b/modules/schema/SlugSchema.ts
@@ -7,7 +7,7 @@ import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchemaOptions
  */
-export interface SlugSchemaOptions extends Omit<StringSchemaOptions, "min" | "max" | "rows"> {}
+export interface SlugSchemaOptions extends Omit<StringSchemaOptions, "min" | "rows"> {}
 
 /**
  * Schema that defines a valid slug, e.g. `this-is-a-slug`.
@@ -27,11 +27,11 @@ export class SlugSchema extends StringSchema {
 	 *
 	 * @param options Options for the schema (inherited string options like `one`, `title`, `value`).
 	 */
-	constructor(options: SlugSchemaOptions) {
+	constructor({ max = 32, ...options }: SlugSchemaOptions) {
 		super({
 			...options,
+			max,
 			min: 1,
-			max: 32,
 			rows: 1,
 		});
 	}

--- a/modules/schema/SlugSchema.ts
+++ b/modules/schema/SlugSchema.ts
@@ -3,6 +3,13 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
+ * Options for a `SlugSchema`.
+ *
+ * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchemaOptions
+ */
+export interface SlugSchemaOptions extends Omit<StringSchemaOptions, "min" | "max" | "rows"> {}
+
+/**
  * Schema that defines a valid slug, e.g. `this-is-a-slug`.
  *
  * - Useful for URL components, usernames, etc.
@@ -20,7 +27,7 @@ export class SlugSchema extends StringSchema {
 	 *
 	 * @param options Options for the schema (inherited string options like `one`, `title`, `value`).
 	 */
-	constructor(options: Omit<StringSchemaOptions, "min" | "max" | "rows">) {
+	constructor(options: SlugSchemaOptions) {
 		super({
 			...options,
 			min: 1,

--- a/modules/schema/URISchema.ts
+++ b/modules/schema/URISchema.ts
@@ -12,7 +12,7 @@ import { StringSchema } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchemaOptions
  */
-export interface URISchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "rows"> {
+export interface URISchemaOptions extends Omit<StringSchemaOptions, "min" | "rows"> {
 	readonly schemes?: URISchemes | undefined;
 }
 
@@ -34,16 +34,18 @@ export class URISchema extends StringSchema {
 	/**
 	 * Create a new `URISchema`.
 	 *
-	 * @param options Options for the schema (`schemes`, plus inherited string options like `one`, `title`, `value`).
+	 * @param options Options for the schema (`schemes`, plus inherited string options like `one`, `title`, `value`, `input`, `max`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"url"`).
+	 * @param options.max Maximum allowed character length (defaults to `512`).
 	 */
-	constructor({ one = "URI", title = "URI", schemes = HTTP_SCHEMES, ...options }: URISchemaOptions) {
+	constructor({ one = "URI", title = "URI", schemes = HTTP_SCHEMES, input = "url", max = 512, ...options }: URISchemaOptions) {
 		super({
 			one,
 			title,
 			...options,
-			input: "url",
+			input,
+			max,
 			min: 1,
-			max: 512,
 			rows: 1,
 		});
 		this.schemes = schemes;

--- a/modules/schema/URLSchema.ts
+++ b/modules/schema/URLSchema.ts
@@ -14,7 +14,7 @@ import { StringSchema } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchemaOptions
  */
-export interface URLSchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "rows"> {
+export interface URLSchemaOptions extends Omit<StringSchemaOptions, "min" | "rows"> {
 	readonly base?: URL | URLString | undefined;
 	readonly schemes?: URISchemes | undefined;
 }
@@ -39,16 +39,18 @@ export class URLSchema extends StringSchema {
 	/**
 	 * Create a new `URLSchema`.
 	 *
-	 * @param options Options for the schema (`base`, `schemes`, plus inherited string options like `one`, `title`, `value`).
+	 * @param options Options for the schema (`base`, `schemes`, plus inherited string options like `one`, `title`, `value`, `input`, `max`).
+	 * @param options.input HTML `<input />` `type=""` hint (defaults to `"url"`).
+	 * @param options.max Maximum allowed character length (defaults to `512`).
 	 */
-	constructor({ one = "URL", title = "URL", base, schemes = HTTP_SCHEMES, ...options }: URLSchemaOptions) {
+	constructor({ one = "URL", title = "URL", base, schemes = HTTP_SCHEMES, input = "url", max = 512, ...options }: URLSchemaOptions) {
 		super({
 			one,
 			title,
 			...options,
-			input: "url",
+			input,
+			max,
 			min: 1,
-			max: 512,
 			rows: 1,
 		});
 		this.base = getURL(base)?.href;

--- a/modules/schema/UUIDSchema.ts
+++ b/modules/schema/UUIDSchema.ts
@@ -3,6 +3,13 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
+ * Options for a `UUIDSchema`.
+ *
+ * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchemaOptions
+ */
+export interface UUIDSchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "match" | "rows"> {}
+
+/**
  * Schema that defines a valid UUID string (versions 1-5). Defaults to any-version validation.
  *
  * - Input is trimmed and lowercased.
@@ -19,7 +26,7 @@ export class UUIDSchema extends StringSchema {
 	 *
 	 * @param options Options for the schema (inherited string options like `one`, `title`, `value`).
 	 */
-	constructor({ one = "UUID", title = "UUID", ...rest }: Omit<StringSchemaOptions, "input" | "min" | "max" | "match" | "rows"> = {}) {
+	constructor({ one = "UUID", title = "UUID", ...rest }: UUIDSchemaOptions = {}) {
 		super({
 			one,
 			title,

--- a/modules/schema/UUIDSchema.ts
+++ b/modules/schema/UUIDSchema.ts
@@ -7,7 +7,7 @@ import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
  *
  * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchemaOptions
  */
-export interface UUIDSchemaOptions extends Omit<StringSchemaOptions, "input" | "min" | "max" | "match" | "rows"> {}
+export interface UUIDSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {}
 
 /**
  * Schema that defines a valid UUID string (versions 1-5). Defaults to any-version validation.
@@ -24,15 +24,16 @@ export class UUIDSchema extends StringSchema {
 	/**
 	 * Create a new `UUIDSchema`.
 	 *
-	 * @param options Options for the schema (inherited string options like `one`, `title`, `value`).
+	 * @param options Options for the schema (inherited string options like `one`, `title`, `value`, `input`, `max`).
+	 * @param options.max Maximum allowed character length (defaults to `36`).
 	 */
-	constructor({ one = "UUID", title = "UUID", ...rest }: UUIDSchemaOptions = {}) {
+	constructor({ one = "UUID", title = "UUID", max = 36, ...rest }: UUIDSchemaOptions = {}) {
 		super({
 			one,
 			title,
 			...rest,
+			max, // 36 chars including hyphens (which get stripped by sanitize for appearances).
 			min: 32,
-			max: 36, // 36 chars including hyphens (which get stripped by sanitize for appearances).
 			rows: 1,
 		});
 	}


### PR DESCRIPTION
Replace inline Omit<StringSchemaOptions, ...> constructor parameter types
with named, exported options interfaces, matching the existing pattern used
by ColorSchema, PasswordSchema and the other string-based schemas.