### PR TITLE
Link types in documentation tables and flatten options-bag parameters

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -307,6 +307,21 @@ export class MemoryStore extends AbstractStore implements Serializable, Disposab
 		]);
 	});
 
+	test("keeps generic arguments in heritage text", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A typed store. */
+export class StringStore extends AbstractStore<string> implements Serializable<string> {}
+/** Slug options. */
+export interface SlugSchemaOptions extends Omit<StringSchemaOptions, "value"> {}
+`),
+		);
+		expect(element.props.children).toMatchObject([
+			{ props: { name: "StringStore", extends: "AbstractStore<string>", implements: ["Serializable<string>"] } },
+			{ props: { name: "SlugSchemaOptions", extends: 'Omit<StringSchemaOptions, "value">' } },
+		]);
+	});
+
 	test("stamps the owning class onto members and skips `override` members", async () => {
 		const element = await extractor.extract(
 			file(`

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -766,7 +766,7 @@ export type Pair = { a: string; b: number };
 `),
 		);
 		expect(element.props.children).toMatchObject([
-			{ type: "tree-documentation", props: { kind: "type", name: "Pair", signatures: ["{ a: string; b: number }"] } },
+			{ type: "tree-documentation", props: { kind: "type", name: "Pair", signatures: ["{\n\ta: string;\n\tb: number;\n}"] } },
 		]);
 	});
 
@@ -783,8 +783,70 @@ export interface ThingOptions {
 		expect(element.props.children).toMatchObject([
 			{
 				type: "tree-documentation",
-				props: { kind: "interface", name: "ThingOptions", signatures: ["{ verbose?: boolean; retries: number }"] },
+				props: { kind: "interface", name: "ThingOptions", signatures: ["{\n\tverbose?: boolean;\n\tretries: number;\n}"] },
 			},
+		]);
+	});
+
+	test("collects referenced type names from a type alias body into `types`", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A nullable other. */
+export type Wrapped<T> = string | OtherType | ReadonlyArray<DeepType> | T;
+`),
+		);
+		const props = (element.props.children as { props: { types?: string[] } }[])[0]?.props;
+		// Primitives (\`string\`) and the alias's own generic param (\`T\`) are excluded; nested references (\`DeepType\`) are caught; order preserved and de-duplicated.
+		expect(props?.types).toEqual(["OtherType", "ReadonlyArray", "DeepType"]);
+	});
+
+	test("leaves `types` undefined for a non-alias and an alias with no references", async () => {
+		const element = await extractor.extract(
+			file(`
+/** Just primitives. */
+export type Plain = string | number | null;
+/** A class. */
+export class Thing {}
+`),
+		);
+		const children = element.props.children as { props: { name: string; types?: string[] } }[];
+		expect(children.find(c => c.props.name === "Plain")?.props.types).toBeUndefined();
+		expect(children.find(c => c.props.name === "Thing")?.props.types).toBeUndefined();
+	});
+
+	test("extracts a structured `properties` list from an interface, with `@default` and descriptions", async () => {
+		const element = await extractor.extract(
+			file(`
+/** Options for the thing. */
+export interface ThingOptions {
+	/**
+	 * The minimum length.
+	 * @default 6
+	 */
+	min?: number;
+	/** Whether to be loud. */
+	verbose: boolean;
+}
+`),
+		);
+		const props = (element.props.children as { props: { properties?: unknown[] } }[])[0]?.props;
+		expect(props?.properties).toEqual([
+			{ name: "min", type: "number", description: "The minimum length.", optional: true, default: "6" },
+			{ name: "verbose", type: "boolean", description: "Whether to be loud.", optional: false, default: undefined },
+		]);
+	});
+
+	test("extracts `properties` from an object-literal type alias too", async () => {
+		const element = await extractor.extract(
+			file(`
+/** A pair. */
+export type Pair = { a: string; b?: number };
+`),
+		);
+		const props = (element.props.children as { props: { properties?: unknown[] } }[])[0]?.props;
+		expect(props?.properties).toEqual([
+			{ name: "a", type: "string", description: undefined, optional: false, default: undefined },
+			{ name: "b", type: "number", description: undefined, optional: true, default: undefined },
 		]);
 	});
 

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -21,7 +21,9 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - A `@kind` tag in a symbol's JSDoc overrides the inferred kind — e.g. `@kind component` relabels a React component (otherwise a `function`) so the docs site groups and colours it as a component. The override also drops the trailing `()` from the title, since a non-function kind reads as a bare name.
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on every `tree-documentation` child.
  * - Sets `title` on every `tree-documentation` child — `name()` for functions, `Class.name()` for methods, `Class.name` for properties, bare `name` for other kinds.
- * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`.
+ * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`, and `types` (the type names a `type` alias's body references, e.g. `OtherType` in `string | OtherType`).
+ * - Records a structured `properties` list for interfaces and object-literal `type` aliases — each member's name, type, optionality, `@default`, and description — so an options-bag parameter can be flattened into its fields at render time.
+ * - Pretty-prints object-literal signatures (interfaces and object-literal `type` aliases) as multi-line `{ … }` blocks, one member per line; other type bodies (`string | null`, mapped types, …) are emitted verbatim.
  * - Members declared with the `override` or `declare` modifier are skipped — the base class already documents overrides, and `declare` members are ambient type-only re-declarations rather than new API.
  * - Keys are the raw declared `name` (case-preserving) so case-distinct exports like `Collection` and `COLLECTION` stay separate.
  * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
@@ -129,6 +131,9 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 	const examples = jsDoc?.examples;
 	// Heritage (`extends` / `implements`) is only meaningful for classes and interfaces.
 	const heritage = _getHeritage(statement, source);
+	// Referenced type names (type aliases) and structured property lists (interfaces / object-literal types) — both resolved to links at render time.
+	const types = _getReferencedTypes(statement, source);
+	const properties = _getProperties(statement, source);
 	const children = _getClassMembers(statement, source, name);
 
 	return {
@@ -148,6 +153,8 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 			examples,
 			extends: heritage?.extends,
 			implements: heritage?.implements,
+			types,
+			properties,
 			children,
 		},
 	};
@@ -169,6 +176,60 @@ function _getHeritage(
 	}
 	if (!extendsName && !implementsNames.length) return;
 	return { extends: extendsName, implements: implementsNames.length ? implementsNames : undefined };
+}
+
+/**
+ * Collect the type names a `type` alias's body references (e.g. `OtherType` in `type X = string | OtherType`), for render-time linking.
+ * - Walks the whole type expression so names nested inside generics, unions, arrays, etc. are all caught.
+ * - Primitive keyword types (`string`, `number`, …) aren't type references so they're naturally excluded; the alias's own generic parameters are filtered out explicitly.
+ * - Order-preserving and de-duplicated. Unresolved names (builtins like `Record`, externals) simply stay as plain text at render time.
+ */
+function _getReferencedTypes(statement: ts.Statement, source: ts.SourceFile): ImmutableArray<string> | undefined {
+	if (!ts.isTypeAliasDeclaration(statement)) return;
+	const generics = new Set(statement.typeParameters?.map(t => t.name.text) ?? []);
+	const names: string[] = [];
+	const seen = new Set<string>();
+	const visit = (node: ts.Node): void => {
+		if (ts.isTypeReferenceNode(node)) {
+			const name = node.typeName.getText(source);
+			if (!generics.has(name) && !seen.has(name)) {
+				seen.add(name);
+				names.push(name);
+			}
+		}
+		node.forEachChild(visit);
+	};
+	visit(statement.type);
+	return names.length ? names : undefined;
+}
+
+/**
+ * Extract structured property entries from an interface or object-literal `type` alias, mirroring the `DocumentationParam` shape.
+ * - Lets a consumer flatten an options-bag parameter into its individual fields at render time (resolve the param's type in the tree map, then list these).
+ * - Skips private `_`-prefixed members. Descriptions and `@default` values come from each member's own JSDoc.
+ */
+function _getProperties(statement: ts.Statement, source: ts.SourceFile): ImmutableArray<DocumentationParam> | undefined {
+	const members = ts.isInterfaceDeclaration(statement)
+		? statement.members
+		: ts.isTypeAliasDeclaration(statement) && ts.isTypeLiteralNode(statement.type)
+			? statement.type.members
+			: undefined;
+	if (!members) return;
+	const properties: DocumentationParam[] = [];
+	for (const member of members) {
+		if (!ts.isPropertySignature(member)) continue;
+		const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+		if (!name || name.startsWith("_")) continue;
+		const jsDoc = _getJSDoc(member, source);
+		properties.push({
+			name,
+			type: member.type?.getText(source),
+			description: jsDoc?.description,
+			optional: !!member.questionToken,
+			default: jsDoc?.default,
+		});
+	}
+	return properties.length ? properties : undefined;
 }
 
 /**
@@ -226,18 +287,25 @@ function _getSignatures(statement: ts.Statement, source: ts.SourceFile, name: st
 		return _getConstructorSignatures(statement, source, name);
 	}
 	if (ts.isInterfaceDeclaration(statement)) {
-		// Emit `{ member; member }` — the same shape a `type` object body produces, distinguished only by the `kind` badge.
-		const members = statement.members.map(m => m.getText(source).replace(/;\s*$/, "").trim()).join("; ");
-		return [members ? `{ ${members} }` : "{}"];
+		// Emit a pretty-printed `{ member; member }` block — the same shape a `type` object body produces, distinguished only by the `kind` badge.
+		return [_formatObjectSignature(statement.members, source)];
 	}
 	if (ts.isTypeAliasDeclaration(statement)) {
-		// Emit only the type body (e.g. `{ a: string }` or `string | null`) — the alias name is already the page title.
+		// Pretty-print object-literal aliases multi-line like an interface; emit other bodies (`string | null`, mapped types, …) verbatim. The alias name is already the page title.
+		if (ts.isTypeLiteralNode(statement.type)) return [_formatObjectSignature(statement.type.members, source)];
 		return [statement.type.getText(source)];
 	}
 	if (ts.isVariableStatement(statement)) {
 		const declaration = statement.declarationList.declarations[0];
 		if (declaration?.type) return [`${name}: ${declaration.type.getText(source)}`];
 	}
+}
+
+/** Pretty-print object-type members as a multi-line `{ … }` block — one member per tab-indented line ending in `;` — or `{}` when empty. */
+function _formatObjectSignature(members: readonly ts.TypeElement[], source: ts.SourceFile): string {
+	if (!members.length) return "{}";
+	const lines = members.map(m => `\t${m.getText(source).replace(/;\s*$/, "").trim()};`);
+	return `{\n${lines.join("\n")}\n}`;
 }
 
 /** Render a class's generic parameter names as `<P, R>` (names only, no constraints), or `""` when non-generic. */
@@ -453,6 +521,8 @@ interface JSDocResult {
 	description?: string | undefined;
 	/** Explicit kind override from an `@kind` tag (e.g. `"component"`), or `undefined` to use the AST-inferred kind. */
 	kind?: string | undefined;
+	/** Default-value text from a `@default` tag (e.g. on a property), or `undefined`. */
+	default?: string | undefined;
 	params?: DocumentationParam[] | undefined;
 	returns?: DocumentationReturn[] | undefined;
 	throws?: DocumentationThrow[] | undefined;
@@ -481,6 +551,7 @@ function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefine
 	const description = ts.getTextOfJSDocComment(jsDoc.comment)?.trim();
 
 	let kind: string | undefined;
+	let def: string | undefined;
 	const params: DocumentationParam[] = [];
 	const returns: DocumentationReturn[] = [];
 	const throws: DocumentationThrow[] = [];
@@ -505,6 +576,8 @@ function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefine
 			const name = tag.tagName.text;
 			// `@kind <name>` overrides the AST-inferred kind (e.g. `@kind component` for a React component declared as a function).
 			if (name === "kind") kind = comment?.match(/^[\w-]+/)?.[0];
+			// `@default <value>` documents a property's default — surfaced structurally (e.g. on `properties`) rather than rendered into the body.
+			else if (name === "default") def = comment || undefined;
 			else if (name === "example") {
 				if (comment) examples.push({ description: comment });
 			} else unhandled.push(comment ? `@${name} ${comment}` : `@${name}`);
@@ -514,6 +587,7 @@ function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefine
 	return {
 		description: description || undefined,
 		kind,
+		default: def,
 		params: params.length ? params : undefined,
 		returns: returns.length ? returns : undefined,
 		throws: throws.length ? throws : undefined,

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -21,7 +21,7 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - A `@kind` tag in a symbol's JSDoc overrides the inferred kind — e.g. `@kind component` relabels a React component (otherwise a `function`) so the docs site groups and colours it as a component. The override also drops the trailing `()` from the title, since a non-function kind reads as a bare name.
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on every `tree-documentation` child.
  * - Sets `title` on every `tree-documentation` child — `name()` for functions, `Class.name()` for methods, `Class.name` for properties, bare `name` for other kinds.
- * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends`, `implements`, and `types` (the type names a `type` alias's body references, e.g. `OtherType` in `string | OtherType`).
+ * - Records relational metadata as raw strings for render-time linking: `class` (owning class), `readonly`, `extends` / `implements` (full heritage type text including generic arguments, e.g. `AbstractStore<string>` or `Omit<StringSchemaOptions, "value">`), and `types` (the type names a `type` alias's body references, e.g. `OtherType` in `string | OtherType`).
  * - Records a structured `properties` list for interfaces and object-literal `type` aliases — each member's name, type, optionality, `@default`, and description — so an options-bag parameter can be flattened into its fields at render time.
  * - Pretty-prints object-literal signatures (interfaces and object-literal `type` aliases) as multi-line `{ … }` blocks, one member per line; other type bodies (`string | null`, mapped types, …) are emitted verbatim.
  * - Members declared with the `override` or `declare` modifier are skipped — the base class already documents overrides, and `declare` members are ambient type-only re-declarations rather than new API.
@@ -160,7 +160,7 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 	};
 }
 
-/** Extract the `extends` (single base type) and `implements` (interface list) names from a class or interface declaration. */
+/** Extract the `extends` (single base type) and `implements` (interface list) heritage from a class or interface declaration, as full type text including any generic arguments (e.g. `AbstractStore<string>`, `Omit<StringSchemaOptions, "value">`). */
 function _getHeritage(
 	statement: ts.Statement,
 	source: ts.SourceFile,
@@ -169,7 +169,8 @@ function _getHeritage(
 	let extendsName: string | undefined;
 	const implementsNames: string[] = [];
 	for (const clause of statement.heritageClauses ?? []) {
-		const names = clause.types.map(t => t.expression.getText(source));
+		// Full text — keep generic arguments (`Foo<T>`) and wrappers (`Omit<…>`) intact; render-time lookup trims them to the bare name to resolve a link.
+		const names = clause.types.map(t => t.getText(source));
 		// `extends` keeps the first base type; an interface extending several still surfaces its primary base.
 		if (clause.token === ts.SyntaxKind.ExtendsKeyword) extendsName ??= names[0];
 		else if (clause.token === ts.SyntaxKind.ImplementsKeyword) implementsNames.push(...names);

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -24,6 +24,11 @@ import { DocumentationSignatures } from "./DocumentationSignatures.js";
 
 const DEFAULT_TYPE = "unknown";
 
+/** Resolve a table row's description — the manually-written one, falling back to the referenced type's own `description` from the tree map (exact-match only). */
+function _getRowDescription(map: ReadonlyMap<string, TreeElement>, type: string, description?: string | undefined): string {
+	return description || map.get(type)?.props.description || "";
+}
+
 /** Documentation `kind`s grouped into card sections, in display order — pluralised, sentence-case headings. */
 const KIND_SECTIONS = {
 	component: "Components",
@@ -72,7 +77,7 @@ function DocumentationChildren({ elements }: { readonly elements?: TreeElements 
 /**
  * Page renderer for a `tree-documentation` element — the full detail page for a documented symbol.
  * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`), signatures (one per overload), content, parameters, returns, throws, referenced types, and examples.
- * - In the Parameters / Returns / Throws tables the `Type` column links each type to its documented page via `TreeLink` (exact-match only; compound or builtin types stay plain text).
+ * - In the Parameters / Returns / Throws tables the `Type` column links each type to its documented page via `TreeLink` (exact-match only; compound or builtin types stay plain text), and a row with no hand-written description falls back to the referenced type's own `description`.
  * - An options-bag parameter whose type resolves to a documented interface/object type is flattened into indented child rows (one per property), so readers see the individual fields inline.
  * - A `type` alias's referenced type names render as a linked `Type` table, each row carrying the resolved element's `description` (exact-match only).
  * - Child symbols are grouped by `kind` into card sections (Functions, Classes, Methods, Properties, …), each under its own heading.
@@ -130,9 +135,9 @@ export function DocumentationPage({
 											</tr>
 										</thead>
 										<tbody>
-											{params.map(({ name, type = DEFAULT_TYPE, description = "", default: def }) => {
+											{params.map(({ name, type = DEFAULT_TYPE, description, default: def }) => {
 												// An options-bag param whose type resolves to a documented interface/object type is flattened into its individual fields as indented child rows.
-												const properties = (map.get(type)?.props as DocumentationElementProps | undefined)?.properties;
+												const resolved = map.get(type)?.props as DocumentationElementProps | undefined;
 												return (
 													<Fragment key={`${name}-${type}`}>
 														<tr>
@@ -143,9 +148,9 @@ export function DocumentationPage({
 																<TreeLink name={type} />
 															</td>
 															<td>{def ? <Code>{def}</Code> : "-"}</td>
-															<td>{description}</td>
+															<td>{description || resolved?.description || ""}</td>
 														</tr>
-														{properties?.map(prop => (
+														{resolved?.properties?.map(prop => (
 															<tr key={`${name}.${prop.name}`}>
 																<td>
 																	<Code>{`.${prop.name}`}</Code>
@@ -154,7 +159,7 @@ export function DocumentationPage({
 																	<TreeLink name={prop.type ?? DEFAULT_TYPE} />
 																</td>
 																<td>{prop.default ? <Code>{prop.default}</Code> : "-"}</td>
-																<td>{prop.description ?? ""}</td>
+																<td>{_getRowDescription(map, prop.type ?? DEFAULT_TYPE, prop.description)}</td>
 															</tr>
 														))}
 													</Fragment>
@@ -175,12 +180,12 @@ export function DocumentationPage({
 											</tr>
 										</thead>
 										<tbody>
-											{returns.map(({ type = DEFAULT_TYPE, description = "" }) => (
+											{returns.map(({ type = DEFAULT_TYPE, description }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
 														<TreeLink name={type} />
 													</td>
-													<td>{description}</td>
+													<td>{_getRowDescription(map, type, description)}</td>
 												</tr>
 											))}
 										</tbody>
@@ -198,12 +203,12 @@ export function DocumentationPage({
 											</tr>
 										</thead>
 										<tbody>
-											{throws.map(({ type = DEFAULT_TYPE, description = "" }) => (
+											{throws.map(({ type = DEFAULT_TYPE, description }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
 														<TreeLink name={type} />
 													</td>
-													<td>{description}</td>
+													<td>{_getRowDescription(map, type, description)}</td>
 												</tr>
 											))}
 										</tbody>
@@ -226,7 +231,7 @@ export function DocumentationPage({
 													<td>
 														<TreeLink name={type} />
 													</td>
-													<td>{map.get(type)?.props.description ?? ""}</td>
+													<td>{_getRowDescription(map, type)}</td>
 												</tr>
 											))}
 										</tbody>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -74,7 +74,7 @@ function DocumentationChildren({ elements }: { readonly elements?: TreeElements 
  * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`), signatures (one per overload), content, parameters, returns, throws, referenced types, and examples.
  * - In the Parameters / Returns / Throws tables the `Type` column links each type to its documented page via `TreeLink` (exact-match only; compound or builtin types stay plain text).
  * - An options-bag parameter whose type resolves to a documented interface/object type is flattened into indented child rows (one per property), so readers see the individual fields inline.
- * - A `type` alias's referenced type names render as a linked `Type` table.
+ * - A `type` alias's referenced type names render as a linked `Type` table, each row carrying the resolved element's `description` (exact-match only).
  * - Child symbols are grouped by `kind` into card sections (Functions, Classes, Methods, Properties, …), each under its own heading.
  * - All sections are conditional — only render when they have entries.
  *
@@ -127,7 +127,6 @@ export function DocumentationPage({
 												<th>Parameter</th>
 												<th>Type</th>
 												<th>Default</th>
-												<th>Description</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -173,7 +172,6 @@ export function DocumentationPage({
 										<thead>
 											<tr>
 												<th>Return</th>
-												<th>Description</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -197,7 +195,6 @@ export function DocumentationPage({
 										<thead>
 											<tr>
 												<th>Throws</th>
-												<th>Description</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -221,7 +218,6 @@ export function DocumentationPage({
 										<thead>
 											<tr>
 												<th>Type</th>
-												<th>Description</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -230,7 +226,7 @@ export function DocumentationPage({
 													<td>
 														<TreeLink name={type} />
 													</td>
-													<td />
+													<td>{map.get(type)?.props.description ?? ""}</td>
 												</tr>
 											))}
 										</tbody>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { walkElements } from "../../util/element.js";
 import type { DocumentationElementProps, TreeElement, TreeElements } from "../../util/tree.js";
 import { Block } from "../block/Block.js";
@@ -16,6 +16,8 @@ import { Row } from "../style/Flex.js";
 import { Scroll } from "../style/Scroll.js";
 import { TreeBreadcrumbs } from "../tree/TreeBreadcrumbs.js";
 import { TreeCards } from "../tree/TreeCards.js";
+import { useTreeMap } from "../tree/TreeContext.js";
+import { TreeLink } from "../tree/TreeLink.js";
 import { DocumentationButtons } from "./DocumentationButtons.js";
 import { DocumentationKind, getDocumentationKindColor } from "./DocumentationKind.js";
 import { DocumentationSignatures } from "./DocumentationSignatures.js";
@@ -69,7 +71,10 @@ function DocumentationChildren({ elements }: { readonly elements?: TreeElements 
 
 /**
  * Page renderer for a `tree-documentation` element — the full detail page for a documented symbol.
- * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`), signatures (one per overload), content, parameters, returns, throws, and examples.
+ * - Renders breadcrumbs, title (with kind + `readonly` tags), relational links (`member of`, `extends`, `implements`), signatures (one per overload), content, parameters, returns, throws, referenced types, and examples.
+ * - In the Parameters / Returns / Throws tables the `Type` column links each type to its documented page via `TreeLink` (exact-match only; compound or builtin types stay plain text).
+ * - An options-bag parameter whose type resolves to a documented interface/object type is flattened into indented child rows (one per property), so readers see the individual fields inline.
+ * - A `type` alias's referenced type names render as a linked `Type` table.
  * - Child symbols are grouped by `kind` into card sections (Functions, Classes, Methods, Properties, …), each under its own heading.
  * - All sections are conditional — only render when they have entries.
  *
@@ -89,10 +94,12 @@ export function DocumentationPage({
 	params,
 	returns,
 	throws,
+	types,
 	examples,
 	children,
 	...props
 }: DocumentationElementProps): ReactNode {
+	const map = useTreeMap();
 	return (
 		<Page title={title ?? name} description={description}>
 			<Block color={getDocumentationKindColor(kind)}>
@@ -108,7 +115,7 @@ export function DocumentationPage({
 						<DocumentationButtons {...props} />
 					</Header>
 				</Panel>
-				{signatures?.length || params?.length || returns?.length || throws?.length ? (
+				{signatures?.length || params?.length || returns?.length || throws?.length || types?.length ? (
 					<Section>
 						<DocumentationSignatures signatures={signatures} />
 						{params?.length && (
@@ -124,18 +131,36 @@ export function DocumentationPage({
 											</tr>
 										</thead>
 										<tbody>
-											{params.map(({ name, type = DEFAULT_TYPE, description = "", default: def }) => (
-												<tr key={`${name}-${type}-${description}`}>
-													<td>
-														<Code>{name}</Code>
-													</td>
-													<td>
-														<Code>{type}</Code>
-													</td>
-													<td>{def ? <Code>{def}</Code> : "-"}</td>
-													<td>{description}</td>
-												</tr>
-											))}
+											{params.map(({ name, type = DEFAULT_TYPE, description = "", default: def }) => {
+												// An options-bag param whose type resolves to a documented interface/object type is flattened into its individual fields as indented child rows.
+												const properties = (map.get(type)?.props as DocumentationElementProps | undefined)?.properties;
+												return (
+													<Fragment key={`${name}-${type}`}>
+														<tr>
+															<td>
+																<Code>{name}</Code>
+															</td>
+															<td>
+																<TreeLink name={type} />
+															</td>
+															<td>{def ? <Code>{def}</Code> : "-"}</td>
+															<td>{description}</td>
+														</tr>
+														{properties?.map(prop => (
+															<tr key={`${name}.${prop.name}`}>
+																<td>
+																	<Code>{`.${prop.name}`}</Code>
+																</td>
+																<td>
+																	<TreeLink name={prop.type ?? DEFAULT_TYPE} />
+																</td>
+																<td>{prop.default ? <Code>{prop.default}</Code> : "-"}</td>
+																<td>{prop.description ?? ""}</td>
+															</tr>
+														))}
+													</Fragment>
+												);
+											})}
 										</tbody>
 									</Table>
 								</Scroll>
@@ -155,7 +180,7 @@ export function DocumentationPage({
 											{returns.map(({ type = DEFAULT_TYPE, description = "" }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
-														<Code>{type}</Code>
+														<TreeLink name={type} />
 													</td>
 													<td>{description}</td>
 												</tr>
@@ -179,9 +204,33 @@ export function DocumentationPage({
 											{throws.map(({ type = DEFAULT_TYPE, description = "" }) => (
 												<tr key={`${type}-${description}`}>
 													<td>
-														<Code>{type}</Code>
+														<TreeLink name={type} />
 													</td>
 													<td>{description}</td>
+												</tr>
+											))}
+										</tbody>
+									</Table>
+								</Scroll>
+							</Section>
+						)}
+						{types?.length && (
+							<Section>
+								<Scroll horizontal>
+									<Table>
+										<thead>
+											<tr>
+												<th>Type</th>
+												<th>Description</th>
+											</tr>
+										</thead>
+										<tbody>
+											{types.map(type => (
+												<tr key={type}>
+													<td>
+														<TreeLink name={type} />
+													</td>
+													<td />
 												</tr>
 											))}
 										</tbody>

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -16,7 +16,7 @@ import { Row } from "../style/Flex.js";
 import { Scroll } from "../style/Scroll.js";
 import { TreeBreadcrumbs } from "../tree/TreeBreadcrumbs.js";
 import { TreeCards } from "../tree/TreeCards.js";
-import { useTreeMap } from "../tree/TreeContext.js";
+import { getTreeElement, useTreeMap } from "../tree/TreeContext.js";
 import { TreeLink } from "../tree/TreeLink.js";
 import { DocumentationButtons } from "./DocumentationButtons.js";
 import { DocumentationKind, getDocumentationKindColor } from "./DocumentationKind.js";
@@ -26,7 +26,7 @@ const DEFAULT_TYPE = "unknown";
 
 /** Resolve a table row's description — the manually-written one, falling back to the referenced type's own `description` from the tree map (exact-match only). */
 function _getRowDescription(map: ReadonlyMap<string, TreeElement>, type: string, description?: string | undefined): string {
-	return description || map.get(type)?.props.description || "";
+	return description || getTreeElement(map, type)?.props.description || "";
 }
 
 /** Documentation `kind`s grouped into card sections, in display order — pluralised, sentence-case headings. */
@@ -137,7 +137,7 @@ export function DocumentationPage({
 										<tbody>
 											{params.map(({ name, type = DEFAULT_TYPE, description, default: def }) => {
 												// An options-bag param whose type resolves to a documented interface/object type is flattened into its individual fields as indented child rows.
-												const resolved = map.get(type)?.props as DocumentationElementProps | undefined;
+												const resolved = getTreeElement(map, type)?.props as DocumentationElementProps | undefined;
 												return (
 													<Fragment key={`${name}-${type}`}>
 														<tr>

--- a/modules/ui/tree/TreeButton.test.tsx
+++ b/modules/ui/tree/TreeButton.test.tsx
@@ -60,4 +60,15 @@ describe("TreeButton", () => {
 		expect(html).toContain("Serializable"); // still reads as text
 		expect(html).not.toContain("Serializable</a>"); // but is not a link
 	});
+
+	test("links a generic reference by its bare type name", () => {
+		// `Store<T>` isn't a key, but stripping the generics resolves `Store`.
+		const html = render(<TreeButton name="Store<T>" />);
+		expect(html).toContain('href="http://x.com/Store"');
+	});
+
+	test("leaves a compound generic reference unresolved", () => {
+		const html = render(<TreeButton name="Store<T> | null" />);
+		expect(html).not.toContain("</a>"); // not `Identifier<…>`-shaped, so no link
+	});
 });

--- a/modules/ui/tree/TreeButton.tsx
+++ b/modules/ui/tree/TreeButton.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { Button, type ButtonVariants } from "../form/Button.js";
-import { useTreeMap } from "./TreeContext.js";
+import { getTreeElement, useTreeMap } from "./TreeContext.js";
 
 /**
  * Props for the `TreeButton` component — the element reference plus button variants.
@@ -17,8 +17,8 @@ export interface TreeButtonProps extends ButtonVariants {
 /**
  * Small button linking to a specific tree element, resolved by reference string.
  *
- * - Looks `name` up in the flattened tree map (`useTreeMap()`) — by flat key (`"Store"`, `"Store.get"`) or canonical path (`"/schema/BooleanSchema"`) — and links to the element's canonical `path`.
- * - A hit becomes an `<a>` link; a miss (e.g. a builtin like `Serializable`) stays a plain non-link label so it still reads as text.
+ * - Resolves `name` via `getTreeElement()` — by flat key (`"Store"`, `"Store.get"`) or canonical path (`"/schema/BooleanSchema"`), falling back to the bare name for a single generic type (`"Schema<T>"` → `"Schema"`) — and links to the element's canonical `path`.
+ * - A hit becomes an `<a>` link; a miss (e.g. a builtin like `Serializable`, or a compound type like `Foo | null`) stays a plain non-link label so it still reads as text.
  * - Defaults to `small plain` styling; pass other `ButtonVariants` to override.
  *
  * @param props The element reference `name`, optional `children` label, and button variants.
@@ -27,7 +27,7 @@ export interface TreeButtonProps extends ButtonVariants {
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeButton/TreeButton
  */
 export function TreeButton({ name, children, small = true, plain = true, ...variants }: TreeButtonProps): ReactElement {
-	const element = useTreeMap().get(name);
+	const element = getTreeElement(useTreeMap(), name);
 	const href = element?.props.path;
 	// A resolved element links via its canonical `path`; an unresolved reference is disabled (no `href`) so it renders as a non-link label rather than an empty `<a>`.
 	return (

--- a/modules/ui/tree/TreeContext.tsx
+++ b/modules/ui/tree/TreeContext.tsx
@@ -40,3 +40,23 @@ export function TreeProvider({ tree, children }: { readonly tree: TreeElement; r
 export function useTreeMap(): ReadonlyMap<string, TreeElement> {
 	return use(TreeContext);
 }
+
+/**
+ * Resolve a reference string to its tree element — by exact key first, then by the bare type name when the whole reference is a single generic type.
+ *
+ * - Exact lookup handles flat keys (`"BooleanSchema"`, `"Store.get"`) and canonical paths (`"/schema/BooleanSchema"`).
+ * - On a miss, a `Foo<…>`-shaped reference retries with the generics stripped (`"Schema<T>"` → `"Schema"`), so a generic type name still links without the extractor storing a separate un-generic'd key — the generics stay in the displayed label.
+ * - A compound reference (`"Schema<T> | null"`, `"Omit<X, 'k'>"`) only retries on the leading identifier when the whole string is `Identifier<…>`; otherwise it stays a miss and the caller falls back to plain text.
+ *
+ * @param map The flattened tree lookup map (from `useTreeMap()`).
+ * @param ref The reference string — a flat key, canonical path, or raw type expression.
+ * @returns The resolved element, or `undefined` on a miss.
+ * @example getTreeElement(useTreeMap(), "Schema<T>") // the `Schema` element
+ * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/getTreeElement
+ */
+export function getTreeElement(map: ReadonlyMap<string, TreeElement>, ref: string): TreeElement | undefined {
+	const exact = map.get(ref);
+	if (exact || !ref.includes("<")) return exact;
+	// Strip a whole-string generic wrapper (`Foo<…>` → `Foo`) and retry; leave compound expressions (unions, etc.) unresolved.
+	return map.get(ref.replace(/^([\w$.]+)<.*>$/s, "$1"));
+}

--- a/modules/ui/tree/TreeLink.tsx
+++ b/modules/ui/tree/TreeLink.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { Code } from "../inline/Code.js";
 import { Link } from "../inline/Link.js";
-import { useTreeMap } from "./TreeContext.js";
+import { getTreeElement, useTreeMap } from "./TreeContext.js";
 
 /**
  * Props for the `TreeLink` component — the element reference plus an optional label.
@@ -18,7 +18,7 @@ export interface TreeLinkProps {
 /**
  * Inline `Code` token linking to a specific tree element, resolved by reference string — the link-styled counterpart of `TreeButton`.
  *
- * - Looks `name` up in the flattened tree map (`useTreeMap()`) — by flat key or canonical path — and links to the element's canonical `path`.
+ * - Resolves `name` via `getTreeElement()` — by flat key or canonical path, falling back to the bare name for a single generic type (`Schema<T>` → `Schema`) — and links to the element's canonical `path`.
  * - A hit becomes a `<Link>` wrapping a `<Code>` token; a miss (e.g. a builtin like `string` or a compound type like `T | null` that isn't an exact token) stays a plain `<Code>` so it still reads as code.
  * - Designed for the `Type` column of the documentation Parameters / Returns / Throws / Types tables, where only exact-match type names should link.
  *
@@ -29,7 +29,7 @@ export interface TreeLinkProps {
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeLink/TreeLink
  */
 export function TreeLink({ name, children }: TreeLinkProps): ReactElement {
-	const href = useTreeMap().get(name)?.props.path;
+	const href = getTreeElement(useTreeMap(), name)?.props.path;
 	const code = <Code>{children ?? name}</Code>;
 	// A resolved reference links via its canonical `path`; an unresolved one stays a plain code token rather than an empty link.
 	return href ? <Link href={href}>{code}</Link> : code;

--- a/modules/ui/tree/TreeLink.tsx
+++ b/modules/ui/tree/TreeLink.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement, ReactNode } from "react";
+import { Code } from "../inline/Code.js";
+import { Link } from "../inline/Link.js";
+import { useTreeMap } from "./TreeContext.js";
+
+/**
+ * Props for the `TreeLink` component — the element reference plus an optional label.
+ *
+ * @see https://dhoulb.github.io/shelving/ui/tree/TreeLink/TreeLinkProps
+ */
+export interface TreeLinkProps {
+	/** Reference to an element in the tree — a flat key (`"BooleanSchema"`, `"Store.get"`) or a canonical path (`"/schema/BooleanSchema"`). */
+	readonly name: string;
+	/** Visible label — defaults to `name` (typically a raw type expression like `"SlugSchemaOptions"`). */
+	readonly children?: ReactNode | undefined;
+}
+
+/**
+ * Inline `Code` token linking to a specific tree element, resolved by reference string — the link-styled counterpart of `TreeButton`.
+ *
+ * - Looks `name` up in the flattened tree map (`useTreeMap()`) — by flat key or canonical path — and links to the element's canonical `path`.
+ * - A hit becomes a `<Link>` wrapping a `<Code>` token; a miss (e.g. a builtin like `string` or a compound type like `T | null` that isn't an exact token) stays a plain `<Code>` so it still reads as code.
+ * - Designed for the `Type` column of the documentation Parameters / Returns / Throws / Types tables, where only exact-match type names should link.
+ *
+ * @kind component
+ * @param props The element reference `name` and optional `children` label.
+ * @returns A `<Code>` token, wrapped in a `<Link>` when the reference resolves.
+ * @example <TreeLink name="BooleanSchema" />
+ * @see https://dhoulb.github.io/shelving/ui/tree/TreeLink/TreeLink
+ */
+export function TreeLink({ name, children }: TreeLinkProps): ReactElement {
+	const href = useTreeMap().get(name)?.props.path;
+	const code = <Code>{children ?? name}</Code>;
+	// A resolved reference links via its canonical `path`; an unresolved one stays a plain code token rather than an empty link.
+	return href ? <Link href={href}>{code}</Link> : code;
+}

--- a/modules/ui/tree/index.ts
+++ b/modules/ui/tree/index.ts
@@ -5,6 +5,7 @@ export * from "./TreeCard.js";
 export * from "./TreeCards.js";
 export * from "./TreeContext.js";
 export * from "./TreeIndexPage.js";
+export * from "./TreeLink.js";
 export * from "./TreeMenu.js";
 export * from "./TreePage.js";
 export * from "./TreeRouter.js";

--- a/modules/util/tree.ts
+++ b/modules/util/tree.ts
@@ -141,9 +141,9 @@ export interface DocumentationElementProps extends TreeElementProps {
 	readonly class?: string | undefined;
 	/** Whether the property is read-only — a `readonly` field, or a getter with no matching setter. */
 	readonly readonly?: boolean | undefined;
-	/** Name of the class/interface this class/interface extends (e.g. `"AbstractStore"`). Raw string — resolved to a link at render time. */
+	/** Full type text of the class/interface this extends, including any generic arguments (e.g. `"AbstractStore<string>"`, `"Omit<StringSchemaOptions, 'value'>"`). Resolved to a link at render time, trimming generics to the bare name; builtins/wrappers that don't resolve stay as text. */
 	readonly extends?: string | undefined;
-	/** Names of the interfaces this class/interface implements (e.g. `["Serializable"]`). Raw strings — resolved to links at render time; builtins simply stay as text. */
+	/** Full type text of the interfaces this implements, including generic arguments (e.g. `["Serializable<string>"]`). Resolved to links at render time (generics trimmed for lookup); builtins simply stay as text. */
 	readonly implements?: ImmutableArray<string> | undefined;
 	/**
 	 * Type names referenced by a `type` alias's body (e.g. `["OtherType"]` for `type X = string | OtherType`).

--- a/modules/util/tree.ts
+++ b/modules/util/tree.ts
@@ -145,6 +145,16 @@ export interface DocumentationElementProps extends TreeElementProps {
 	readonly extends?: string | undefined;
 	/** Names of the interfaces this class/interface implements (e.g. `["Serializable"]`). Raw strings — resolved to links at render time; builtins simply stay as text. */
 	readonly implements?: ImmutableArray<string> | undefined;
+	/**
+	 * Type names referenced by a `type` alias's body (e.g. `["OtherType"]` for `type X = string | OtherType`).
+	 * - Raw identifier strings — resolved to links at render time; the alias's own generic parameters and primitive keywords are excluded, and unresolved names stay as plain text.
+	 */
+	readonly types?: ImmutableArray<string> | undefined;
+	/**
+	 * Structured member list for an `interface` or object-literal `type` — each property's `name`, `type`, optionality, `default`, and `description`.
+	 * - Reuses the `DocumentationParam` shape so an options-bag parameter can be flattened into its individual fields at render time.
+	 */
+	readonly properties?: ImmutableArray<DocumentationParam> | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Enhances the documentation page renderer to make type references clickable and to flatten options-bag parameters into their individual fields. Adds support for type aliases to display their referenced types in a dedicated table, and improves signature formatting for interfaces and object-literal types.

## Key Changes

- **Type linking in tables**: Parameters, returns, throws, and type alias references now render as `TreeLink` components, making exact-match type names clickable while keeping compound or builtin types as plain text.

- **Options-bag flattening**: When a parameter's type resolves to a documented interface or object-literal type, its properties are extracted and rendered as indented child rows in the Parameters table, showing individual fields inline with their descriptions and defaults.

- **Type alias references**: Added `types` field to capture type names referenced in a type alias body (e.g., `OtherType` in `type X = string | OtherType`), rendered in a new Types table with fallback descriptions from the tree map.

- **Structured properties extraction**: Interfaces and object-literal type aliases now extract a `properties` list containing each member's name, type, optionality, `@default` value, and description—enabling parameter flattening and property documentation.

- **Improved signature formatting**: Object-type signatures (interfaces and object-literal aliases) now pretty-print as multi-line `{ … }` blocks with one member per line, while other type bodies remain verbatim.

- **Description fallback**: Rows in Parameters/Returns/Throws/Types tables with no hand-written description now fall back to the referenced type's own `description` from the tree map (exact-match only).

- **New `TreeLink` component**: Renders an inline code token that links to a tree element when the reference resolves, staying plain text for unresolved names.

## Implementation Details

- Added `_getReferencedTypes()` to walk type alias bodies and collect referenced type names, filtering out primitives and the alias's own generic parameters.
- Added `_getProperties()` to extract structured property lists from interfaces and object-literal types, including JSDoc descriptions and `@default` values.
- Added `_formatObjectSignature()` to pretty-print object-type members as indented multi-line blocks.
- Extended JSDoc parsing to capture `@default` tags on properties.
- Updated `DocumentationPage` to use `useTreeMap()` for type resolution and render flattened properties as child rows with `TreeLink` for type columns.

https://claude.ai/code/session_01APwhi8QapKSAR5Qe7bNr3E