### PR TITLE
docs: bring schema options docblocks up to standard

### DIFF
--- a/modules/schema/AddressSchema.ts
+++ b/modules/schema/AddressSchema.ts
@@ -18,7 +18,9 @@ const ADDRESS_PROPS: Schemas<AddressData> = {
 };
 
 /**
- * Allowed options for `AddressSchema`.
+ * Options for an [`AddressSchema`](/schema/AddressSchema).
+ *
+ * Inherits [`DataSchemaOptions`](/schema/DataSchema/DataSchemaOptions) except `props`, which is fixed to the postal-address fields.
  *
  * @see https://dhoulb.github.io/shelving/schema/AddressSchema/AddressSchemaOptions
  */

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -6,27 +6,37 @@ import type { SchemaOptions } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Options for `ArraySchema`.
- *
- * - `items` — schema every item in the array must conform to.
- * - `min`/`max` — minimum and maximum number of items.
- * - `unique` — deduplicate the items when set.
- * - `separator` — string or `RegExp` used to split a string input into items.
+ * Options for an [`ArraySchema`](/schema/ArraySchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ArraySchemaOptions
  */
 export interface ArraySchemaOptions<T> extends SchemaOptions {
-	/** The default value */
+	/**
+	 * Default array used when the input is `undefined`.
+	 * @default []
+	 */
 	readonly value?: ImmutableArray;
-	/** A schema all the array items in the value must conform to */
+	/** Schema every item in the array must conform to. */
 	readonly items: Schema<T>;
-	/** Minimum number of items. */
+	/**
+	 * Minimum number of items.
+	 * @default 0
+	 */
 	readonly min?: number;
-	/** Maximum number of items. */
+	/**
+	 * Maximum number of items.
+	 * @default Number.POSITIVE_INFINITY
+	 */
 	readonly max?: number;
-	/** Whether to deduplicate the items. */
+	/**
+	 * Deduplicate the items when set.
+	 * @default false
+	 */
 	readonly unique?: boolean;
-	/** Separator is used */
+	/**
+	 * String or `RegExp` used to split a string input into items.
+	 * @default ","
+	 */
 	readonly separator?: string | RegExp;
 }
 

--- a/modules/schema/BooleanSchema.ts
+++ b/modules/schema/BooleanSchema.ts
@@ -3,15 +3,20 @@ import type { SchemaOptions } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Allowed options for `BooleanSchema`.
- *
- * - `value` — default boolean value used when the input is `undefined`.
- * - `required` — when `true`, a falsy result is rejected as invalid.
+ * Options for a [`BooleanSchema`](/schema/BooleanSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchemaOptions
  */
 export interface BooleanSchemaOptions extends SchemaOptions {
+	/**
+	 * Default boolean value used when the input is `undefined`.
+	 * @default false
+	 */
 	readonly value?: boolean | undefined;
+	/**
+	 * When `true`, a falsy result is rejected as invalid.
+	 * @default false
+	 */
 	readonly required?: boolean | undefined;
 }
 

--- a/modules/schema/ChoiceSchema.ts
+++ b/modules/schema/ChoiceSchema.ts
@@ -29,17 +29,17 @@ function _getChoiceOption<K extends string>(k: K): readonly [title: K, title: st
 }
 
 /**
- * Options for `ChoiceSchema`.
- *
- * - `options` — the allowed choices, as a `{ key: title }` dictionary or an array of keys.
- * - `value` — default option used when the input is `undefined`.
+ * Options for a [`ChoiceSchema`](/schema/ChoiceSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceSchemaOptions
  */
 export interface ChoiceSchemaOptions<O extends string, I = never> extends Omit<SchemaOptions, "value"> {
-	/** Specify correct options using a dictionary of entries. */
+	/** Allowed choices, as a `{ key: title }` dictionary or an array of keys. */
 	readonly options: PossibleChoiceOptions<O>;
-	/** Default option for the value. */
+	/**
+	 * Default option used when the input is `undefined`.
+	 * @default undefined
+	 */
 	readonly value?: O | I;
 }
 

--- a/modules/schema/ColorSchema.ts
+++ b/modules/schema/ColorSchema.ts
@@ -5,7 +5,9 @@ const COLOR_REGEXP = /^#[0-9A-F]{6}$/;
 const NOT_HEX_REGEXP = /[^0-9A-F]/g;
 
 /**
- * Options for a `ColorSchema`.
+ * Options for a [`ColorSchema`](/schema/ColorSchema).
+ *
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min`, `match`, and `rows`, which are fixed because the `#RRGGBB` hex format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/ColorSchema/ColorSchemaOptions
  */

--- a/modules/schema/CountrySchema.ts
+++ b/modules/schema/CountrySchema.ts
@@ -4,12 +4,15 @@ import { NULLABLE } from "./NullableSchema.js";
 import type { SchemaOptions } from "./Schema.js";
 
 /**
- * Options for `CountrySchema`.
+ * Options for a [`CountrySchema`](/schema/CountrySchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/CountrySchema/CountrySchemaOptions
  */
 export interface CountrySchemaOptions extends SchemaOptions {
-	/** Country value, or `"detect"` to resolve from browser language. */
+	/**
+	 * Default country value, or `"detect"` to resolve from the browser language.
+	 * @default "detect"
+	 */
 	readonly value?: PossibleCountry;
 }
 

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -5,15 +5,19 @@ import { NULLABLE } from "./NullableSchema.js";
 import { NumberSchema, type NumberSchemaOptions } from "./NumberSchema.js";
 
 /**
- * Options for `CurrencyAmountSchema`.
+ * Options for a [`CurrencyAmountSchema`](/schema/CurrencyAmountSchema).
  *
- * - `currency` — ISO 4217 currency code that determines the step and symbol.
- * - `symbol` — override the currency symbol used when formatting.
+ * Inherits [`NumberSchemaOptions`](/schema/NumberSchema/NumberSchemaOptions), but `step` defaults to the currency's minor units rather than being unset.
  *
  * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchemaOptions
  */
 export interface CurrencyAmountSchemaOptions extends NumberSchemaOptions {
+	/**
+	 * Override the currency symbol used when formatting.
+	 * @default The symbol inferred from `currency`.
+	 */
 	readonly symbol?: string | undefined;
+	/** ISO 4217 currency code that determines the step and symbol. */
 	readonly currency: CurrencyCode;
 }
 

--- a/modules/schema/CurrencyCodeSchema.ts
+++ b/modules/schema/CurrencyCodeSchema.ts
@@ -5,13 +5,17 @@ import type { StringSchemaOptions } from "./StringSchema.js";
 import { StringSchema } from "./StringSchema.js";
 
 /**
- * Options for `CurrencyCodeSchema`.
+ * Options for a [`CurrencyCodeSchema`](/schema/CurrencyCodeSchema).
  *
- * - `currencies` — set of allowed ISO 4217 currency codes (defaults to all known codes).
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min`, `match`, and `rows`, which are fixed because the ISO 4217 code format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchemaOptions
  */
 export interface CurrencyCodeSchemaOptions extends Omit<StringSchemaOptions, "min" | "match" | "rows"> {
+	/**
+	 * Set of allowed ISO 4217 currency codes.
+	 * @default CURRENCY_CODES All known ISO 4217 codes.
+	 */
 	currencies?: ImmutableArray<CurrencyCode>;
 }
 

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -12,15 +12,17 @@ import type { SchemaOptions, Schemas } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Options for `DataSchema`.
- *
- * - `props` — a named schema for each property the data object must have.
- * - `value` — partial default value merged over the per-prop defaults.
+ * Options for a [`DataSchema`](/schema/DataSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchemaOptions
  */
 export interface DataSchemaOptions<T extends Data> extends SchemaOptions {
+	/** Named schema for each property the data object must have. */
 	readonly props: Schemas<T>;
+	/**
+	 * Partial default value merged over the per-prop defaults.
+	 * @default undefined
+	 */
 	readonly value?: Partial<T> | undefined;
 }
 

--- a/modules/schema/DateSchema.ts
+++ b/modules/schema/DateSchema.ts
@@ -15,24 +15,36 @@ import { Schema } from "./Schema.js";
 export type DateInputType = "time" | "date" | "datetime-local";
 
 /**
- * Options for `DateSchema`.
- *
- * - `value` — default date used when the input is `undefined`.
- * - `min`/`max` — earliest and latest allowed dates (`null` for no bound).
- * - `input` — HTML `<input />` `type=""` hint for downstream UIs.
- * - `step` — rounding step in milliseconds.
+ * Options for a [`DateSchema`](/schema/DateSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchemaOptions
  */
 export interface DateSchemaOptions extends SchemaOptions {
+	/**
+	 * Default date used when the input is `undefined`.
+	 * @default undefined
+	 */
 	readonly value?: PossibleDate | undefined;
+	/**
+	 * Earliest allowed date (`null` for no bound).
+	 * @default undefined
+	 */
 	readonly min?: Nullish<PossibleDate>;
+	/**
+	 * Latest allowed date (`null` for no bound).
+	 * @default undefined
+	 */
 	readonly max?: Nullish<PossibleDate>;
+	/**
+	 * HTML `<input />` `type=""` hint for downstream UIs.
+	 * @default "date"
+	 */
 	readonly input?: DateInputType | undefined;
 	/**
 	 * Rounding step (in milliseconds, because that's the base unit for time).
 	 * - E.g. `1000 * 60` will round to the nearest minute.
 	 * - Note: HTML `<input>` `step` attributes are in _seconds_, so you may need to convert units.
+	 * @default undefined
 	 */
 	readonly step?: number | undefined;
 }

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -6,18 +6,27 @@ import type { SchemaOptions } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Options for `DictionarySchema`.
- *
- * - `items` — schema every entry value in the dictionary must conform to.
- * - `value` — default dictionary used when the input is `undefined`.
- * - `min`/`max` — minimum and maximum number of entries.
+ * Options for a [`DictionarySchema`](/schema/DictionarySchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DictionarySchemaOptions
  */
 export interface DictionarySchemaOptions<T> extends SchemaOptions {
+	/** Schema every entry value in the dictionary must conform to. */
 	readonly items: Schema<T>;
+	/**
+	 * Default dictionary used when the input is `undefined`.
+	 * @default {}
+	 */
 	readonly value?: ImmutableDictionary | undefined;
+	/**
+	 * Minimum number of entries.
+	 * @default 0
+	 */
 	readonly min?: number | undefined;
+	/**
+	 * Maximum number of entries.
+	 * @default Number.POSITIVE_INFINITY
+	 */
 	readonly max?: number | undefined;
 }
 

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -7,7 +7,9 @@ const R_MATCH =
 	/^[a-z0-9](?:[a-zA-Z0-9._+-]{0,62}[a-zA-Z0-9])?@(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){1,3}(?:[a-z]{2,63}|xn--[a-z0-9-]{0,58}[a-z0-9])$/;
 
 /**
- * Options for an `EmailSchema`.
+ * Options for an [`EmailSchema`](/schema/EmailSchema).
+ *
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min`, `match`, and `rows`, which are fixed because the email format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchemaOptions
  */

--- a/modules/schema/EntitySchema.ts
+++ b/modules/schema/EntitySchema.ts
@@ -4,13 +4,17 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
- * Options for `EntitySchema`.
+ * Options for an [`EntitySchema`](/schema/EntitySchema).
  *
- * - `types` — restrict the allowed entity types; any other type is rejected.
+ * Inherits all [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions), plus a `types` allow-list.
  *
  * @see https://dhoulb.github.io/shelving/schema/EntitySchema/EntitySchemaOptions
  */
 export interface EntitySchemaOptions<T extends string> extends StringSchemaOptions {
+	/**
+	 * Restrict the allowed entity types; any other type is rejected.
+	 * @default undefined
+	 */
 	readonly types?: ImmutableArray<T> | undefined;
 }
 

--- a/modules/schema/FileSchema.ts
+++ b/modules/schema/FileSchema.ts
@@ -5,12 +5,17 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
- * Allowed options for `FileSchema`.
+ * Options for a [`FileSchema`](/schema/FileSchema).
+ *
+ * Inherits all [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions), plus a `types` allow-list.
  *
  * @see https://dhoulb.github.io/shelving/schema/FileSchema/FileSchemaOptions
  */
 export interface FileSchemaOptions extends StringSchemaOptions {
-	/** Set of allowed file extensions; when set, the file name's extension must be one of these. */
+	/**
+	 * Set of allowed file extensions; when set, the file name's extension must be one of these.
+	 * @default undefined
+	 */
 	readonly types?: FileTypes | undefined;
 }
 

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -2,14 +2,15 @@ import type { Schema } from "./Schema.js";
 import { ThroughSchema, type ThroughSchemaOptions } from "./ThroughSchema.js";
 
 /**
- * Allowed options for `NullableSchema`.
- *
- * - `value` — default value used when the input is `undefined` (defaults to `null`).
+ * Options for a [`NullableSchema`](/schema/NullableSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NullableSchemaOptions
  */
 export interface NullableSchemaOptions<T> extends ThroughSchemaOptions<T | null> {
-	/** Default value (defaults to `null`). */
+	/**
+	 * Default value used when the input is `undefined`.
+	 * @default null
+	 */
 	readonly value?: T | null;
 }
 

--- a/modules/schema/NumberSchema.ts
+++ b/modules/schema/NumberSchema.ts
@@ -5,21 +5,35 @@ import type { SchemaOptions } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Allowed options for `NumberSchema`.
- *
- * - `value` — default number value used when the input is `undefined`.
- * - `min`/`max` — minimum and maximum allowed value.
- * - `step` — rounding step the value is snapped to (e.g. `1` for integers).
- * - `format` — function used to render the number for display in downstream UIs.
+ * Options for a [`NumberSchema`](/schema/NumberSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NumberSchemaOptions
  */
 export interface NumberSchemaOptions extends SchemaOptions {
+	/**
+	 * Default number value used when the input is `undefined`.
+	 * @default undefined
+	 */
 	readonly value?: number | undefined;
+	/**
+	 * Minimum allowed value.
+	 * @default Number.NEGATIVE_INFINITY
+	 */
 	readonly min?: number | undefined;
+	/**
+	 * Maximum allowed value.
+	 * @default Number.POSITIVE_INFINITY
+	 */
 	readonly max?: number | undefined;
+	/**
+	 * Rounding step the value is snapped to (e.g. `1` for integers).
+	 * @default undefined
+	 */
 	readonly step?: number | undefined;
-	/** Format the number for display in downstream UIs. */
+	/**
+	 * Function used to render the number for display in downstream UIs.
+	 * @default formatNumber
+	 */
 	readonly format?: typeof formatNumber | undefined;
 }
 

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -2,14 +2,15 @@ import type { Schema } from "./Schema.js";
 import { ThroughSchema, type ThroughSchemaOptions } from "./ThroughSchema.js";
 
 /**
- * Allowed options for `OptionalSchema`.
- *
- * - `value` — default value is always `undefined` (the default is only used when a value is `undefined`, so otherwise `undefined` could never be returned).
+ * Options for an [`OptionalSchema`](/schema/OptionalSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OptionalSchemaOptions
  */
 export interface OptionalSchemaOptions<T> extends ThroughSchemaOptions<T | undefined> {
-	/** Default value for an `OptionalSchema` can always `undefined` */
+	/**
+	 * Default value is always `undefined` — the default is only used when the input is `undefined`, so otherwise `undefined` could never be returned.
+	 * @default undefined
+	 */
 	readonly value?: undefined;
 }
 

--- a/modules/schema/PhoneSchema.ts
+++ b/modules/schema/PhoneSchema.ts
@@ -3,7 +3,9 @@ import type { StringSchemaOptions } from "./StringSchema.js";
 import { StringSchema } from "./StringSchema.js";
 
 /**
- * Options for a `PhoneSchema`.
+ * Options for a [`PhoneSchema`](/schema/PhoneSchema).
+ *
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min`, `match`, and `rows`, which are fixed because the E.164 phone format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PhoneSchemaOptions
  */

--- a/modules/schema/Schema.ts
+++ b/modules/schema/Schema.ts
@@ -6,22 +6,40 @@ import { getUndefined } from "../util/undefined.js";
 import type { Validator } from "../util/validate.js";
 
 /**
- * Options allowed by a `Schema` instance.
+ * Base options shared by every [`Schema`](/schema/Schema) subclass.
  *
  * @see https://dhoulb.github.io/shelving/schema/Schema/SchemaOptions
  */
 export type SchemaOptions = {
-	/** String for one of this thing, e.g. `product` or `item` or `sheep` */
+	/**
+	 * Singular noun for one of this thing, e.g. `product` or `item` or `sheep`.
+	 * @default "value"
+	 */
 	readonly one?: string;
-	/** String for several of this thing, e.g. `products` or `items` or `sheep` (defaults to `one` + "s") */
+	/**
+	 * Plural noun for several of this thing, e.g. `products` or `items` or `sheep`.
+	 * @default `${one}s`
+	 */
 	readonly many?: string;
-	/** Title of the schema, e.g. for using as the title of a corresponding field. */
+	/**
+	 * Title of the schema, e.g. for use as the title of a corresponding field.
+	 * @default undefined
+	 */
 	readonly title?: string | undefined;
-	/** Description of the schema, e.g. for using as a description in a corresponding field. */
+	/**
+	 * Description of the schema, e.g. for use as a description in a corresponding field.
+	 * @default undefined
+	 */
 	readonly description?: string | undefined;
-	/** Placeholder of the schema, e.g. for using as a placeholder in a corresponding field. */
+	/**
+	 * Placeholder of the schema, e.g. for use as a placeholder in a corresponding field.
+	 * @default undefined
+	 */
 	readonly placeholder?: string | undefined;
-	/** Default value for the schema if `validate()` is called with an `undefined` value. */
+	/**
+	 * Default value used when `validate()` is called with an `undefined` value.
+	 * @default undefined
+	 */
 	readonly value?: unknown;
 };
 

--- a/modules/schema/SlugSchema.ts
+++ b/modules/schema/SlugSchema.ts
@@ -3,7 +3,9 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
- * Options for a `SlugSchema`.
+ * Options for a [`SlugSchema`](/schema/SlugSchema).
+ *
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min` and `rows`, which are fixed because the slug format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchemaOptions
  */

--- a/modules/schema/StringSchema.ts
+++ b/modules/schema/StringSchema.ts
@@ -11,24 +11,45 @@ import { Schema } from "./Schema.js";
 export type StringInputType = "text" | "password" | "color" | "email" | "number" | "tel" | "search" | "url";
 
 /**
- * Options for `StringSchema`.
- *
- * - `value` — default string value used when the input is `undefined`.
- * - `min`/`max` — minimum and maximum allowed character length.
- * - `rows` — number of rows (more than one enables multiline sanitization).
- * - `match` — regular expression the sanitized string must match.
- * - `case` — force the result to `"upper"` or `"lower"` case.
- * - `input` — HTML `<input />` `type=""` hint for downstream UIs.
+ * Options for a [`StringSchema`](/schema/StringSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchemaOptions
  */
 export interface StringSchemaOptions extends SchemaOptions {
+	/**
+	 * Default string value used when the input is `undefined`.
+	 * @default ""
+	 */
 	readonly value?: string | undefined;
+	/**
+	 * Minimum allowed character length.
+	 * @default 0
+	 */
 	readonly min?: number | undefined;
+	/**
+	 * Maximum allowed character length.
+	 * @default Number.POSITIVE_INFINITY
+	 */
 	readonly max?: number | undefined;
+	/**
+	 * Number of rows; more than one enables multiline sanitization.
+	 * @default 1
+	 */
 	readonly rows?: number | undefined;
+	/**
+	 * Regular expression the sanitized string must match.
+	 * @default undefined
+	 */
 	readonly match?: RegExp | undefined;
+	/**
+	 * Force the result to `"upper"` or `"lower"` case.
+	 * @default undefined
+	 */
 	readonly case?: "upper" | "lower" | undefined;
+	/**
+	 * HTML `<input />` `type=""` hint for downstream UIs.
+	 * @default "text"
+	 */
 	readonly input?: StringInputType | undefined;
 }
 

--- a/modules/schema/ThroughSchema.ts
+++ b/modules/schema/ThroughSchema.ts
@@ -3,11 +3,12 @@ import type { SchemaOptions } from "./Schema.js";
 import { Schema } from "./Schema.js";
 
 /**
- * Allowed options for `ThroughSchema`.
+ * Options for a [`ThroughSchema`](/schema/ThroughSchema).
  *
  * @see https://dhoulb.github.io/shelving/schema/ThroughSchema/ThroughSchemaOptions
  */
 export interface ThroughSchemaOptions<T> extends SchemaOptions {
+	/** Source schema this schema wraps and passes through to. */
 	source: Schema<T>;
 }
 

--- a/modules/schema/URISchema.ts
+++ b/modules/schema/URISchema.ts
@@ -6,13 +6,17 @@ import type { StringSchemaOptions } from "./StringSchema.js";
 import { StringSchema } from "./StringSchema.js";
 
 /**
- * Options for `URISchema`.
+ * Options for a [`URISchema`](/schema/URISchema).
  *
- * - `schemes` — whitelist of allowed URI schemes (defaults to HTTP/HTTPS).
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min` and `rows`, which are fixed because the URI format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchemaOptions
  */
 export interface URISchemaOptions extends Omit<StringSchemaOptions, "min" | "rows"> {
+	/**
+	 * Whitelist of allowed URI schemes.
+	 * @default HTTP_SCHEMES `["https:", "http:"]`
+	 */
 	readonly schemes?: URISchemes | undefined;
 }
 

--- a/modules/schema/URLSchema.ts
+++ b/modules/schema/URLSchema.ts
@@ -7,15 +7,22 @@ import type { StringSchemaOptions } from "./StringSchema.js";
 import { StringSchema } from "./StringSchema.js";
 
 /**
- * Options for `URLSchema`.
+ * Options for a [`URLSchema`](/schema/URLSchema).
  *
- * - `base` — base URL that relative URLs are resolved against.
- * - `schemes` — whitelist of allowed URL schemes (defaults to HTTP/HTTPS).
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min` and `rows`, which are fixed because the URL format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchemaOptions
  */
 export interface URLSchemaOptions extends Omit<StringSchemaOptions, "min" | "rows"> {
+	/**
+	 * Base URL that relative URLs are resolved against.
+	 * @default undefined
+	 */
 	readonly base?: URL | URLString | undefined;
+	/**
+	 * Whitelist of allowed URL schemes.
+	 * @default HTTP_SCHEMES `["https:", "http:"]`
+	 */
 	readonly schemes?: URISchemes | undefined;
 }
 

--- a/modules/schema/UUIDSchema.ts
+++ b/modules/schema/UUIDSchema.ts
@@ -3,7 +3,9 @@ import { NULLABLE } from "./NullableSchema.js";
 import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 
 /**
- * Options for a `UUIDSchema`.
+ * Options for a [`UUIDSchema`](/schema/UUIDSchema).
+ *
+ * Inherits [`StringSchemaOptions`](/schema/StringSchema/StringSchemaOptions) except `min`, `match`, and `rows`, which are fixed because the UUID format is enforced internally.
  *
  * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchemaOptions
  */

--- a/modules/util/format.ts
+++ b/modules/util/format.ts
@@ -16,6 +16,7 @@ export interface FormatOptions {
 	/**
 	 * Override the locale for formatting (defaults to detected locale).
 	 *
+	 * @default undefined
 	 * @see https://dhoulb.github.io/shelving/util/format/FormatOptions/locale
 	 */
 	readonly locale?: Intl.Locale | undefined;
@@ -80,24 +81,24 @@ export interface UnitFormatOptions
 	/**
 	 * String for one of this thing, e.g. `product` or `item` or `sheep`
 	 * - Used for `unitDisplay: "long"` formatting.
-	 * - Defaults to unit reference, e.g. "minute"
 	 *
+	 * @default The `unit` reference, e.g. `"minute"`.
 	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/one
 	 */
 	readonly one?: string | undefined;
 	/**
 	 * String for several of this thing, e.g. `products` or `items` or `sheep`
 	 * - Used for `unitDisplay: "long"` formatting.
-	 * - Defaults to `one + "s"`
 	 *
+	 * @default `${one}s`
 	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/many
 	 */
 	readonly many?: string | undefined;
 	/**
-	 * Abbreviation for this thing, e.g. `products` or `items` or `sheep` (defaults to `one` + "s").
+	 * Abbreviation for this thing, e.g. `products` or `items` or `sheep`.
 	 * - Used for `unitDisplay: "narrow"` formatting.
-	 * - Defaults to unit reference, e.g. "minute"
 	 *
+	 * @default The `unit` reference, e.g. `"minute"`.
 	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/abbr
 	 */
 	readonly abbr?: string | undefined;
@@ -247,6 +248,7 @@ export interface DateFormatOptions extends Intl.DateTimeFormatOptions {
 	/**
 	 * Override the locale for formatting (defaults to detected locale).
 	 *
+	 * @default undefined
 	 * @see https://dhoulb.github.io/shelving/util/format/DateFormatOptions/locale
 	 */
 	readonly locale?: Intl.Locale | undefined;

--- a/modules/util/tree.ts
+++ b/modules/util/tree.ts
@@ -227,11 +227,15 @@ function _flatKey(element: TreeElement): string {
  * @see https://dhoulb.github.io/shelving/util/tree/SearchTreeOptions
  */
 export interface SearchTreeOptions {
-	/** Maximum number of results to return (defaults to `20`). */
+	/**
+	 * Maximum number of results to return.
+	 * @default 20
+	 */
 	readonly limit?: number | undefined;
 	/**
 	 * Optional `Query` narrowing the candidates by *any* prop before ranking — the same shape `queryItems()` takes.
 	 * - e.g. `{ kind: "method" }` to only rank methods, or `{ source: "…" }` to constrain by source.
+	 * @default undefined
 	 */
 	readonly filter?: Query | undefined;
 }


### PR DESCRIPTION
## Summary

First increment of the docblock-standards sweep (AGENTS.md › Documentation › **Docblock standards**), going in the issue's suggested order — starting with the `schema` module's options types, which were the clearest offenders.

This pass focuses on the two highest reader-value items from the issue:

1. **Thin / empty-looking `*SchemaOptions` first lines.** The `Omit<…>`-derived options interfaces (`Email`, `Phone`, `Slug`, `Color`, `UUID`, `Address`, `URI`, `URL`, `CurrencyCode`, `CurrencyAmount`, `File`, `Entity`) previously had a bare `Options for an X.` line and an empty body, so their docs pages looked empty. Each now opens with a strong, linked first line and a second line spelling out which inherited fields are fixed and *why* (e.g. `min`/`match`/`rows` are enforced internally for emails).
2. **`@default` on options properties.** Added per-property descriptions and `@default` tags across the options interfaces (`Schema`, `String`, `Number`, `Date`, `Boolean`, `Data`, `Array`, `Dictionary`, `Choice`, `Through`, `Nullable`, `Optional`, `Country`) so the newly-surfaced flattened-options **Default** column populates.

Also standardised the first-line wording to ``Options for a [`XSchema`](/schema/XSchema)``.

The schema module's `@example` / `@param` / `@returns` / `@throws` / `@see` coverage was already strong, so this increment leaves those as-is.

## Scope

Authoring only — no extractor or renderer changes. This covers the **`schema`** module (issue priorities 1 and 2); the broader cross-module sweep (priority 3, `util`/`db`/`store`/etc.) can follow as further increments, one module at a time.

## Testing

- `bun run fix` — no changes needed
- `bun run test` — lint ✅ (only the pre-existing Biome config-deprecation info), types ✅, **1158 unit tests pass**

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QidQ4R8cpZSPyLB8dq3oea)_