### PR TITLE
Default Navigation initial URL to window.location in the browser

### DIFF
--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -16,7 +16,7 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
 
 /**
  * Top-level navigation provider.
- * - Owns a single `NavigationStore` initialised from the surrounding `<Meta>` url/base, falling back to `window.location` in the browser when no url is set.
+ * - Owns a single `NavigationStore` initialised from the surrounding `<Meta>` url/base.
  * - Intercepts same-origin anchor clicks (excluding `download` anchors) and turns them into `forward()` calls.
  * - Listens for `popstate` to sync the store with browser back/forward.
  * - Publishes the live URL via `<Meta url={…} params={…}>` so descendant `<Router>`s re-render on navigation.
@@ -34,10 +34,7 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
  */
 export function Navigation({ children, ...meta }: NavigationProps): ReactElement {
 	const { url, root, ...merged } = requireMeta(meta);
-	// Fall back to the browser's current location when no `url` is supplied by the surrounding `<Meta>`.
-	// Guarded with `typeof window` so server rendering (where there is no `window`) keeps the `NavigationStore` default of `"/"`.
-	const initial = url ?? (typeof window === "undefined" ? undefined : window.location.href);
-	const nav = useInstance(NavigationStore, initial, root);
+	const nav = useInstance(NavigationStore, url, root);
 	useStore(nav);
 
 	useEffect(() => {

--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -16,7 +16,7 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
 
 /**
  * Top-level navigation provider.
- * - Owns a single `NavigationStore` initialised from the surrounding `<Meta>` url/base.
+ * - Owns a single `NavigationStore` initialised from the surrounding `<Meta>` url/base, falling back to `window.location` in the browser when no url is set.
  * - Intercepts same-origin anchor clicks (excluding `download` anchors) and turns them into `forward()` calls.
  * - Listens for `popstate` to sync the store with browser back/forward.
  * - Publishes the live URL via `<Meta url={…} params={…}>` so descendant `<Router>`s re-render on navigation.
@@ -34,7 +34,10 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
  */
 export function Navigation({ children, ...meta }: NavigationProps): ReactElement {
 	const { url, root, ...merged } = requireMeta(meta);
-	const nav = useInstance(NavigationStore, url, root);
+	// Fall back to the browser's current location when no `url` is supplied by the surrounding `<Meta>`.
+	// Guarded with `typeof window` so server rendering (where there is no `window`) keeps the `NavigationStore` default of `"/"`.
+	const initial = url ?? (typeof window === "undefined" ? undefined : window.location.href);
+	const nav = useInstance(NavigationStore, initial, root);
 	useStore(nav);
 
 	useEffect(() => {

--- a/modules/ui/router/NavigationStore.tsx
+++ b/modules/ui/router/NavigationStore.tsx
@@ -15,10 +15,10 @@ export class NavigationStore extends URLStore {
 	/**
 	 * Create a new `NavigationStore`.
 	 *
-	 * @param url The initial URL (defaults to `"/"`).
+	 * @param url The initial URL (defaults to the browser's `window.location.href`, or `"/"` when there is no `window`, e.g. during server rendering).
 	 * @param base Optional base URL that relative navigations resolve against.
 	 */
-	constructor(url: PossibleURL = "/", base?: PossibleURL) {
+	constructor(url: PossibleURL = typeof window === "undefined" ? "/" : window.location.href, base?: PossibleURL) {
 		super(url, base);
 	}
 


### PR DESCRIPTION
## What

`NavigationStore`'s constructor now defaults its initial `url` to the browser's `window.location.href` (falling back to `"/"` when there is no `window`), instead of unconditionally defaulting to `"/"`.

```ts
constructor(url: PossibleURL = typeof window === "undefined" ? "/" : window.location.href, base?: PossibleURL) {
	super(url, base);
}
```

## Why

Previously, when no `url` was supplied, the store defaulted to `"/"` regardless of where the app was actually mounted — so a client-only app had to plumb the current URL through `<Meta>` itself just to start routing from the right place.

The fallback lives in the constructor's `=` default param rather than in `<Navigation>` on purpose: a default param is only evaluated once, at construction, when `url` is `undefined`. Computing `window.location.href` in the component render and passing it to `useInstance` would instead hand it a concrete string that could reconstruct the store on later renders.

## Notes on SSR / hydration

The `typeof window` guard means server rendering keeps the `"/"` default. SSR flows like the docs site always supply `url` explicitly (the server embeds page meta as JSON in `#docs-data`, `docs/client.tsx` parses it into `<Meta>`, and `<Navigation>` reads `url` from there), so the `window.location` fallback never fires during hydration and the server/client trees stay identical. The new behaviour only affects standalone client-only apps that don't provide a `url`.

## Testing

- `bun run test:type` — passes
- `bun test modules/ui/router modules/ui/docs` — 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2y2YBm4WDuiB3oa57ArBA