### PR TITLE
feat: overloads supersede base definition, typed @param/@returns are canonical

### DIFF
--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -375,7 +375,7 @@ export class Store {
 		expect((cls?.props.children[1]?.props as { readonly?: boolean }).readonly).toBeUndefined();
 	});
 
-	test("merges overloaded function declarations into one element with multiple signatures", async () => {
+	test("merges overloaded function declarations into one element with multiple signatures, dropping the implementation", async () => {
 		const element = await extractor.extract(
 			file(`
 /** Add two values. */
@@ -386,15 +386,89 @@ export function add(a: any, b: any): any { return a + b; }
 		);
 		const children = element.props.children as unknown[];
 		expect(children).toHaveLength(1);
+		// The implementation (base definition) `add(a: any, b: any): any` is dropped — only the overload signatures survive.
 		expect(children[0]).toMatchObject({
 			type: "tree-documentation",
 			props: {
 				name: "add",
 				title: "add()",
 				kind: "function",
-				signatures: ["add(a: number, b: number): number", "add(a: string, b: string): string", "add(a: any, b: any): any"],
+				signatures: ["add(a: number, b: number): number", "add(a: string, b: string): string"],
 			},
 		});
+	});
+
+	test("documents a lone implementation when there are no overload signatures", async () => {
+		const element = await extractor.extract(
+			file(`
+/** Add two numbers. */
+export function add(a: number, b: number): number { return a + b; }
+`),
+		);
+		// With no overload signatures, the implementation is the only declaration — it stands as the definition.
+		expect(element.props.children).toMatchObject([
+			{ type: "tree-documentation", props: { name: "add", kind: "function", signatures: ["add(a: number, b: number): number"] } },
+		]);
+	});
+
+	test("drops the implementation signature, params, and returns when a single overload is present", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Make partial.
+ * @returns A partial schema.
+ */
+export function PARTIAL<T extends Data>(source: Schemas<T> | DataSchema<T>): DataSchema<PartialData<T>>;
+export function PARTIAL(source: Schemas<Data> | DataSchema<Data>): DataSchema<PartialData<Data>> { return source as any; }
+`),
+		);
+		// Only the overload's narrow signature/params/returns survive; the wider implementation (base definition) is ignored.
+		expect(element.props.children).toMatchObject([
+			{
+				props: {
+					name: "PARTIAL",
+					kind: "function",
+					signatures: ["PARTIAL(source: Schemas<T> | DataSchema<T>): DataSchema<PartialData<T>>"],
+					params: [{ name: "source", type: "Schemas<T> | DataSchema<T>" }],
+					returns: [{ type: "DataSchema<PartialData<T>>", description: "A partial schema." }],
+				},
+			},
+		]);
+	});
+
+	test("treats a typed `@param {Type}` as canonical, overriding the inferred parameter type", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Make a thing.
+ * @param props {Schemas<T>} A named schema for each property.
+ */
+export function DATA<T extends Data>(props: Schemas<Data>): DataSchema<T> { return props as any; }
+`),
+		);
+		const props = (element.props.children as { props: { params: unknown } }[])[0]?.props;
+		// The inferred \`Schemas<Data>\` is superseded by the canonical \`{Schemas<T>}\` from the \`@param\`.
+		expect(props?.params).toEqual([
+			{ name: "props", type: "Schemas<T>", description: "A named schema for each property.", optional: false, default: undefined },
+		]);
+	});
+
+	test("emits one row per `@param` when the same parameter is documented as several typed variants", async () => {
+		const element = await extractor.extract(
+			file(`
+/**
+ * Make partial.
+ * @param source {Schemas<T>} The props schemas to make partial.
+ * @param source {DataSchema<T>} An existing schema to make partial.
+ */
+export function PARTIAL<T extends Data>(source: Schemas<T> | DataSchema<T>): DataSchema<PartialData<T>> { return source as any; }
+`),
+		);
+		const props = (element.props.children as { props: { params: unknown } }[])[0]?.props;
+		expect(props?.params).toEqual([
+			{ name: "source", type: "Schemas<T>", description: "The props schemas to make partial.", optional: false, default: undefined },
+			{ name: "source", type: "DataSchema<T>", description: "An existing schema to make partial.", optional: false, default: undefined },
+		]);
 	});
 
 	test("skips `declare` members (ambient type-only re-declarations)", async () => {
@@ -482,7 +556,7 @@ export class MockAPIProvider<P, R> {
 		]);
 	});
 
-	test("emits multiple signatures for multiple constructor overloads", async () => {
+	test("emits multiple signatures for multiple constructor overloads, dropping the implementation", async () => {
 		const element = await extractor.extract(
 			file(`
 /** A range. */
@@ -494,11 +568,8 @@ export class Range {
 `),
 		);
 		const props = (element.props.children as { props: { signatures: string[] } }[])[0]?.props;
-		expect(props?.signatures).toEqual([
-			"new Range(max: number)",
-			"new Range(min: number, max: number)",
-			"new Range(min: number, max?: number)",
-		]);
+		// The implementation constructor (base definition) `new Range(min: number, max?: number)` is dropped — only the overloads survive.
+		expect(props?.signatures).toEqual(["new Range(max: number)", "new Range(min: number, max: number)"]);
 	});
 
 	test("emits `new ClassName()` with no params for a class with no explicit constructor", async () => {
@@ -878,11 +949,8 @@ export function add(a: any, b: any): any { return a + b; }
 `),
 		);
 		const props = (element.props.children as { props: { signatures: string[] } }[])[0]?.props;
-		expect(props?.signatures).toEqual([
-			"add(a: number, b: number): number",
-			"add(a: string, b: string): string",
-			"add(a: any, b: any): any",
-		]);
+		// The implementation (base definition) is dropped; the two identical overloads collapse to one.
+		expect(props?.signatures).toEqual(["add(a: number, b: number): number", "add(a: string, b: string): string"]);
 	});
 
 	test("de-duplicates identical params and returns across overloads, keeping distinct ones", async () => {
@@ -895,22 +963,22 @@ export function add(a: any, b: any): any { return a + b; }
 export function combine(a: number, b: number): number;
 /**
  * Combine values.
- * @returns {number} The combined value.
+ * @returns {string} The combined string.
  */
-export function combine(a: number, b: number): number;
-export function combine(a: number, b: number): number { return a + b; }
+export function combine(a: number, b: number): string;
+export function combine(a: number, b: number): number | string { return a + b; }
 `),
 		);
 		const props = (element.props.children as { props: { params: unknown; returns: unknown } }[])[0]?.props;
-		// All three declarations share the same params — deduped to a single (a, b) pair.
+		// Both overloads share the same params — deduped to a single (a, b) pair (the implementation is dropped).
 		expect(props?.params).toEqual([
 			{ name: "a", type: "number", description: undefined, optional: false },
 			{ name: "b", type: "number", description: undefined, optional: false },
 		]);
-		// The two documented overloads share a return; the implementation's bare `number` return differs by description and is kept.
+		// The two overloads document distinct returns — both kept; the implementation's `number | string` return is dropped.
 		expect(props?.returns).toEqual([
 			{ type: "number", description: "The combined value." },
-			{ type: "number", description: undefined },
+			{ type: "string", description: "The combined string." },
 		]);
 	});
 
@@ -930,10 +998,12 @@ export function doThing(a: number): number;
  * @example doThing(1)
  * @example doThing(2)
  */
+export function doThing(a: string): string;
 export function doThing(a: any): any { return a; }
 `),
 		);
 		const props = (element.props.children as { props: { throws: unknown; examples: unknown } }[])[0]?.props;
+		// The implementation is dropped; throws/examples are merged and deduped across the two overloads.
 		expect(props?.throws).toEqual([
 			{ type: "RangeError", description: "Bad range." },
 			{ type: "TypeError", description: "Bad type." },

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -16,7 +16,8 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * File extractor that parses a TypeScript source file into a tree element.
  * - Uses the TypeScript compiler API to parse the AST.
  * - Extracts exported, public, non-`_`-prefixed declarations as `tree-documentation` children.
- * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`.
+ * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`. When a function (or constructor) is overloaded, the implementation declaration (the "base definition") is dropped entirely — only the overload signatures are documented.
+ * - A `@param name {Type}` (or `@returns {Type}`) whose `{Type}` is given is canonical: it supersedes the inferred type from the base definition and any overloads. Multiple `@param name` tags for one parameter each emit a row, letting a single parameter be documented as several typed variants.
  * - Class declarations synthesise their `signatures`, `params`, and `returns` from the constructor — `new ClassName<…>(…)` including generics, one signature per constructor overload, with `returns` set to the class type. Param descriptions come from the constructor's `@param` first, then the class's `@param`.
  * - A `@kind` tag in a symbol's JSDoc overrides the inferred kind — e.g. `@kind component` relabels a React component (otherwise a `function`) so the docs site groups and colours it as a component. The override also drops the trailing `()` from the title, since a non-function kind reads as a bare name.
  * - Sets `description` (a plain-text summary from the first JSDoc paragraph) on every `tree-documentation` child.
@@ -47,9 +48,17 @@ export class TypescriptExtractor extends FileExtractor {
 	override extractProps(name: string, text: string): Partial<TreeElementProps> & { name: string } {
 		const source = ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);
 
+		// Names with one or more overload signatures (bodyless function declarations). When a function is overloaded, the
+		// implementation declaration (the one with a body — the "base definition") is dropped entirely; only the overloads are documented.
+		const overloaded = new Set<string>();
+		for (const statement of source.statements)
+			if (ts.isFunctionDeclaration(statement) && !statement.body && statement.name) overloaded.add(statement.name.text);
+
 		// Collect elements by key, merging overloads (same name) by appending signatures.
 		const byKey = new Map<string, DocumentationElement>();
 		for (const statement of source.statements) {
+			// Skip the implementation of an overloaded function — overloads supersede the base definition.
+			if (ts.isFunctionDeclaration(statement) && statement.body && statement.name && overloaded.has(statement.name.text)) continue;
 			const element = _extractStatement(statement, source);
 			if (!element) continue;
 			const existing = byKey.get(element.key);
@@ -316,9 +325,11 @@ function _getTypeParamNames(statement: ts.ClassDeclaration, source: ts.SourceFil
 	return `<${typeParameters.map(t => t.name.getText(source)).join(", ")}>`;
 }
 
-/** Get a class's constructor declarations (overload signatures + implementation), in source order. */
+/** Get a class's constructor declarations in source order — when overloaded, only the overload signatures (the implementation, i.e. the base definition, is dropped). */
 function _getConstructors(statement: ts.ClassDeclaration): readonly ts.ConstructorDeclaration[] {
-	return statement.members.filter(ts.isConstructorDeclaration);
+	const constructors = statement.members.filter(ts.isConstructorDeclaration);
+	// When overload signatures exist, drop the implementation constructor (the one with a body) — overloads supersede the base definition.
+	return constructors.some(c => !c.body) ? constructors.filter(c => !c.body) : constructors;
 }
 
 /**
@@ -342,15 +353,41 @@ function _getParams(
 ): readonly DocumentationParam[] | undefined {
 	if (ts.isClassDeclaration(statement)) return _getConstructorParams(statement, source, jsDocParams);
 	if (!ts.isFunctionDeclaration(statement)) return;
-	const params: DocumentationParam[] = statement.parameters.map(p => {
+	const params = _buildParams(statement.parameters, source, jsDocParams);
+	return params.length ? params : undefined;
+}
+
+/**
+ * Build documentation params from a declaration's AST parameters, applying JSDoc `@param` overrides.
+ * - A `@param name {Type}` whose `{Type}` is given is canonical: it supersedes the parameter's inferred type from the base definition and any overloads.
+ * - Multiple `@param name` tags for the same parameter each emit a row, so a single parameter can be documented as several typed variants.
+ * - A `@param name` with no `{Type}` only supplies the description; the inferred type stands.
+ * - `primaryJsDocParams` win over `fallbackJsDocParams` per name (used by constructors: the constructor's own `@param` beats the class-level `@param`).
+ */
+function _buildParams(
+	parameters: readonly ts.ParameterDeclaration[],
+	source: ts.SourceFile,
+	primaryJsDocParams: readonly DocumentationParam[] | undefined,
+	fallbackJsDocParams?: readonly DocumentationParam[] | undefined,
+): DocumentationParam[] {
+	const params: DocumentationParam[] = [];
+	for (const p of parameters) {
 		const name = p.name.getText(source);
 		const type = p.type?.getText(source);
 		const optional = !!p.questionToken || !!p.initializer;
-		const description = jsDocParams?.find(d => d.name === name)?.description;
 		const def = p.initializer?.getText(source);
-		return { name, type, description, optional, default: def };
-	});
-	return params.length ? params : undefined;
+		// JSDoc `@param` entries for this name — the declaration's own take priority over the fallback (class-level) ones.
+		const primary = primaryJsDocParams?.filter(d => d.name === name) ?? [];
+		const matched = primary.length ? primary : (fallbackJsDocParams?.filter(d => d.name === name) ?? []);
+		// A `@param` carrying a `{Type}` is canonical — emit one row per typed entry, its type overriding the inferred type.
+		const typed = matched.filter(d => d.type);
+		if (typed.length) {
+			for (const d of typed) params.push({ name, type: d.type, description: d.description, optional, default: def });
+		} else {
+			params.push({ name, type, description: matched[0]?.description, optional, default: def });
+		}
+	}
+	return params;
 }
 
 /**
@@ -366,16 +403,8 @@ function _getConstructorParams(
 	let params: readonly DocumentationParam[] | undefined;
 	for (const ctor of _getConstructors(statement)) {
 		const ctorJsDocParams = _getJSDoc(ctor, source)?.params;
-		const next: DocumentationParam[] = ctor.parameters.map(p => {
-			const name = p.name.getText(source);
-			const type = p.type?.getText(source);
-			const optional = !!p.questionToken || !!p.initializer;
-			// Constructor-level `@param` wins over the class-level `@param` on collision.
-			const description =
-				ctorJsDocParams?.find(d => d.name === name)?.description ?? classJsDocParams?.find(d => d.name === name)?.description;
-			const def = p.initializer?.getText(source);
-			return { name, type, description, optional, default: def };
-		});
+		// Constructor-level `@param` wins over the class-level `@param` on collision; a `@param {Type}` is canonical (see `_buildParams`).
+		const next = _buildParams(ctor.parameters, source, ctorJsDocParams, classJsDocParams);
 		params = _concatUnique(params, next, p => `${p.name}\0${p.type}\0${p.description}\0${p.optional}\0${p.default}`);
 	}
 	return params?.length ? params : undefined;


### PR DESCRIPTION
When a function or constructor is overloaded, drop the implementation
declaration (the "base definition") entirely — only the overload
signatures, params, and returns are documented.

A `@param name {Type}` (or `@returns {Type}`) whose `{Type}` is given is
treated as canonical: it supersedes the inferred type from the base
definition and any overloads. Multiple `@param name` tags for one
parameter each emit a row, so a single parameter can be documented as
several typed variants.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P7TUjuRXin2vT6CENQhuF9