### PR TITLE
docs: fix dead links and inconsistent cross-reference styling across pages

### DIFF
--- a/modules/api/endpoint/README.md
+++ b/modules/api/endpoint/README.md
@@ -66,4 +66,4 @@ type EndpointCallback<P, R, C = void> =
   (payload: P, request: Request, context: C) => R | Response | Promise<R | Response>
 ```
 
-Return `R` to let [`handleEndpoints`](/api/handleEndpoints) validate and serialise the result, or return a raw `Response` to bypass serialisation entirely.
+Return `R` to let [`handleEndpoints()`](/api/handleEndpoints) validate and serialise the result, or return a raw `Response` to bypass serialisation entirely.

--- a/modules/api/provider/ClientAPIProvider.md
+++ b/modules/api/provider/ClientAPIProvider.md
@@ -17,4 +17,4 @@ const provider = new ClientAPIProvider({
 const user = await provider.call(getUser, { id: "u_123" })
 ```
 
-In practice you wrap it — e.g. `new ValidationAPIProvider(new ClientAPIProvider({ url }))` — so payloads and results are validated. See [building a provider chain](/api).
+In practice you wrap it — e.g. `new ValidationAPIProvider(new ClientAPIProvider({ url }))` — so payloads and results are validated. See [`shelving/api`](/api) for building a provider chain.

--- a/modules/error/RequiredError.md
+++ b/modules/error/RequiredError.md
@@ -1,6 +1,6 @@
 # RequiredError
 
-Thrown when something required was absent — a missing argument, an empty lookup result, or an unset value. The `require*()` helpers in [util](/util) throw this class.
+Thrown when something required was absent — a missing argument, an empty lookup result, or an unset value. The `require*()` helpers — e.g. [`requireString()`](/util/string/requireString) — throw this class.
 
 ## Usage
 

--- a/modules/react/useLazy.md
+++ b/modules/react/useLazy.md
@@ -2,7 +2,7 @@
 
 Compute a value once and recompute it only when its arguments change (by deep equality of the argument list). If the first argument is a function it is called with the remaining arguments; otherwise the value is returned as-is.
 
-`useLazy` is the factory-call counterpart to [`useInstance`](/react/useInstance) — use it when you have a plain function rather than a class constructor.
+`useLazy` is the factory-call counterpart to [`useInstance()`](/react/useInstance) — use it when you have a plain function rather than a class constructor.
 
 ## Usage
 

--- a/modules/react/useSequence.md
+++ b/modules/react/useSequence.md
@@ -15,4 +15,4 @@ function LiveCounter({ counter }: { counter: AsyncIterable<number> }) {
 }
 ```
 
-Because the subscription resets when the iterable reference changes, pass a stable reference — hoist it, or memoise it with [`useLazy`](/react/useLazy) / [`useInstance`](/react/useInstance) — to avoid resubscribing on every render.
+Because the subscription resets when the iterable reference changes, pass a stable reference — hoist it, or memoise it with [`useLazy()`](/react/useLazy) / [`useInstance()`](/react/useInstance) — to avoid resubscribing on every render.

--- a/modules/schema/DataSchema.md
+++ b/modules/schema/DataSchema.md
@@ -33,7 +33,7 @@ const NameOnly = PRODUCT.pick("name");
 
 ### `ITEM` — add a typed `id` field
 
-`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the [`Item`](/util/item/Item) type in [util](/util).
+`ITEM` wraps a `DataSchema` to add a typed `id` field, matching the [`Item`](/util/item/Item) type in [`shelving/util/item`](/util/item).
 
 ```ts
 import { ITEM, STRING, INTEGER, NUMBER } from "shelving/schema";

--- a/modules/ui/app/App.md
+++ b/modules/ui/app/App.md
@@ -2,7 +2,7 @@
 
 Root component for a client-side Shelving app. `<App>` applies the theme CSS class to `document.body` and provides a [`Meta`](/ui/Meta) context so every descendant can read or update page metadata.
 
-Use `<App>` when mounting into an existing HTML page on the client. For server-side rendering where you need the full `<html>` document shell, use [`HTML`](/ui/HTML) instead.
+Use `<App>` when mounting into an existing HTML page on the client. For server-side rendering where you need the full `<html>` document shell, use [`<HTML>`](/ui/HTML) instead.
 
 ## A minimal app
 
@@ -27,7 +27,7 @@ function HelloApp() {
 
 ## A routed app
 
-For a multi-page app, wrap the routes in [`Navigation`](/ui/Navigation) and [`Router`](/ui/Router):
+For a multi-page app, wrap the routes in [`<Navigation>`](/ui/Navigation) and [`<Router>`](/ui/Router):
 
 ```tsx
 import { App, Navigation, Router } from "shelving/ui";
@@ -48,4 +48,4 @@ export function MyApp() {
 
 `<App>` accepts all [`PossibleMeta`](/ui/PossibleMeta) props (`app`, `root`, `url`, `title`, `language`, `tags`, etc.) and merges them into the context it provides to children. On mount it adds the theme class to `document.body`, which activates the CSS custom property tokens defined in `App.module.css`; on unmount it removes it.
 
-For a documentation site, hand an extracted tree to [`TreeApp`](/ui/TreeApp) instead — see the [`shelving/extract`](/extract) guide.
+For a documentation site, hand an extracted tree to [`<TreeApp>`](/ui/TreeApp) instead — see the [`shelving/extract`](/extract) guide.

--- a/modules/ui/block/List.md
+++ b/modules/ui/block/List.md
@@ -8,7 +8,7 @@ A bulleted or numbered list. Renders a `<ul>` by default (or an `<ol>` when `ord
 - Each child becomes one list item — give it plain content, not an `<li>`.
 - Items are laid out as a flex column; tune the spacing between them with the `gap` variant (`<List gap="small">`).
 - Like the other block components it carries its own outer block margin and collapses it when it is the first or last child of its container.
-- Inside [`Prose`](/ui/Prose) a raw `<ul>` / `<ol>` picks up the same styling, so Markdown-rendered lists match component ones.
+- Inside [`<Prose>`](/ui/Prose) a raw `<ul>` / `<ol>` picks up the same styling, so Markdown-rendered lists match component ones.
 
 ## Usage
 

--- a/modules/ui/block/Panel.md
+++ b/modules/ui/block/Panel.md
@@ -4,7 +4,7 @@ A full-width vertical region that paints the current surface colour. Use panels 
 
 **Things to know:**
 
-- A panel always spans the full width of its container. To constrain the content inside, compose a [`Block`](/ui/Block) `width="narrow"` (or `width="wide"`) within it.
+- A panel always spans the full width of its container. To constrain the content inside, compose a [`<Block>`](/ui/Block) `width="narrow"` (or `width="wide"`) within it.
 - Block margin is always zero so panels stack flush; control the vertical breathing room with the `padding` variant (`<Panel padding="large">`, `<Panel padding="none">`). Inline padding is fixed.
 - `color=` / `status=` move the tint anchor for the whole panel scope, so the surface, border, and text re-derive together and cascade into nested content.
 - The top and bottom borders are dropped on the first and last panel so the page doesn't gain stray edge lines.

--- a/modules/ui/block/Paragraph.md
+++ b/modules/ui/block/Paragraph.md
@@ -6,8 +6,8 @@ A block of body text — renders a `<p>`. The default container for running pros
 
 - Carries its own outer block margin and collapses it when it is the first or last child of its container, so stacked paragraphs space evenly without doubling up at the edges.
 - Accepts `color=` and the typography variants (`size`, `serif`, `center`, …) to retint or restyle the text.
-- Fill it with inline annotations such as [`Strong`](/ui/Strong), [`Emphasis`](/ui/Emphasis), [`Code`](/ui/Code), [`Mark`](/ui/Mark), and [`Link`](/ui/Link).
-- Inside [`Prose`](/ui/Prose) a raw `<p>` picks up the same styling, so Markdown-rendered paragraphs match component ones.
+- Fill it with inline annotations such as [`<Strong>`](/ui/Strong), [`<Emphasis>`](/ui/Emphasis), [`<Code>`](/ui/Code), [`<Mark>`](/ui/Mark), and [`<Link>`](/ui/Link).
+- Inside [`<Prose>`](/ui/Prose) a raw `<p>` picks up the same styling, so Markdown-rendered paragraphs match component ones.
 
 ## Usage
 

--- a/modules/ui/block/Prose.md
+++ b/modules/ui/block/Prose.md
@@ -4,7 +4,7 @@ A wrapper that applies cohesive longform typography to a subtree of mixed HTML c
 
 **Things to know:**
 
-- `Prose` applies the "prose" variant of *every* block and inline component as a single compound class, so raw `<p>`, `<ul>`, `<h2>`, `<code>`, `<a>`, etc. are styled to match their component counterparts ([`Paragraph`](/ui/Paragraph), [`List`](/ui/List), [`Heading`](/ui/Heading), [`Code`](/ui/Code), [`Link`](/ui/Link), …).
+- `Prose` applies the "prose" variant of *every* block and inline component as a single compound class, so raw `<p>`, `<ul>`, `<h2>`, `<code>`, `<a>`, etc. are styled to match their component counterparts ([`<Paragraph>`](/ui/Paragraph), [`<List>`](/ui/List), [`<Heading>`](/ui/Heading), [`<Code>`](/ui/Code), [`<Link>`](/ui/Link), …).
 - This is the bridge for markup: wrap [`shelving/markup`](/markup) output (or anything that emits raw HTML) in `<Prose>` and it just works — no per-element component wrapping needed.
 - It only sets up typography and its own outer margin; it paints no colour and adds no box of its own.
 

--- a/modules/ui/block/Section.md
+++ b/modules/ui/block/Section.md
@@ -4,10 +4,10 @@ A landmark content region — renders a `<section>` with block-level spacing and
 
 **Things to know:**
 
-- Pick the component whose HTML element matches the semantic meaning rather than reaching for a generic [`Block`](/ui/Block). `<Section>` is a `<section>`, `<Nav>` a `<nav>`, `<Figure>` a `<figure>`, and so on.
+- Pick the component whose HTML element matches the semantic meaning rather than reaching for a generic [`<Block>`](/ui/Block). `<Section>` is a `<section>`, `<Nav>` a `<nav>`, `<Figure>` a `<figure>`, and so on.
 - Every section centres its content and caps the line length so text never touches the viewport edges. Nested sections relax that cap so they can fill their parent.
 - Sections default to the `--width-normal` content width, so most of the time you set no width at all. Pass `width="narrow"` / `"wide"` / `"full"` (or `"fit"`) to change that, and the usual `color` / `space` / typography variants to retint and respace.
-- Pair [`Figure`](/ui/Section) with [`Caption`](/ui/Caption) for a `<figure>` / `<figcaption>` pair.
+- Pair [`Figure`](/ui/Section) with [`<Caption>`](/ui/Caption) for a `<figure>` / `<figcaption>` pair.
 
 ## Usage
 

--- a/modules/ui/block/Subheading.md
+++ b/modules/ui/block/Subheading.md
@@ -1,6 +1,6 @@
 # Subheading
 
-A subsection heading — renders an `<h3>`. It is the smallest member of the three-level heading family: [`Title`](/ui/Title) (`<h1>`), [`Heading`](/ui/Heading) (`<h2>`), `Subheading` (`<h3>`). Use it for card titles, in-section labels, and panel titles.
+A subsection heading — renders an `<h3>`. It is the smallest member of the three-level heading family: [`<Title>`](/ui/Title) (`<h1>`), [`<Heading>`](/ui/Heading) (`<h2>`), `Subheading` (`<h3>`). Use it for card titles, in-section labels, and panel titles.
 
 **Things to know:**
 
@@ -8,7 +8,7 @@ A subsection heading — renders an `<h3>`. It is the smallest member of the thr
 - Pick the component that matches the level rather than overriding `level` — that keeps the visual size and the document outline in step.
 - The `level` prop (`1`–`6`) is an escape hatch for the rare case where the outline level must differ from the visual size — avoid it in normal use.
 - Inherits text colour by default so it picks up the surrounding tint; accepts `color=` and the typography variants.
-- Inside [`Prose`](/ui/Prose) raw `<h3>`–`<h6>` are styled by the same rules, so Markdown-rendered subheadings match component ones.
+- Inside [`<Prose>`](/ui/Prose) raw `<h3>`–`<h6>` are styled by the same rules, so Markdown-rendered subheadings match component ones.
 
 ## Usage
 

--- a/modules/ui/block/Title.md
+++ b/modules/ui/block/Title.md
@@ -1,13 +1,13 @@
 # Title
 
-The top-level page heading — renders an `<h1>`. It is the most prominent member of the three-level heading family: `Title` (`<h1>`), [`Heading`](/ui/Heading) (`<h2>`), [`Subheading`](/ui/Subheading) (`<h3>`). There should normally be exactly one `Title` per page.
+The top-level page heading — renders an `<h1>`. It is the most prominent member of the three-level heading family: `Title` (`<h1>`), [`<Heading>`](/ui/Heading) (`<h2>`), [`<Subheading>`](/ui/Subheading) (`<h3>`). There should normally be exactly one `Title` per page.
 
 **Things to know:**
 
 - Pick the component that matches the level rather than overriding `level`. Choosing `Title` / [`<Heading>`](/ui/Heading) / [`<Subheading>`](/ui/Subheading) keeps the visual size and the document outline in step.
 - The `level` prop (`1`–`6`) is an escape hatch for the rare case where the outline level must differ from the visual size — avoid it in normal use.
 - Inherits text colour by default so it picks up the surrounding tint; accepts `color=` and the typography variants.
-- Inside [`Prose`](/ui/Prose) a raw `<h1>` is styled by the same rules, so Markdown-rendered titles match component ones.
+- Inside [`<Prose>`](/ui/Prose) a raw `<h1>` is styled by the same rules, so Markdown-rendered titles match component ones.
 
 ## Usage
 

--- a/modules/ui/dialog/Dialog.md
+++ b/modules/ui/dialog/Dialog.md
@@ -4,10 +4,10 @@ A native `<dialog>` element opened in modal mode. It opens via `showModal()` whe
 
 **Things to know:**
 
-- Closes on a backdrop click, on any link or `<nav>` button clicked inside it, or via the built-in [`DialogCloseButton`](/ui/DialogCloseButton) (an X icon, top-right).
+- Closes on a backdrop click, on any link or `<nav>` button clicked inside it, or via the built-in [`<DialogCloseButton>`](/ui/DialogCloseButton) (an X icon, top-right).
 - Children render inside a `<Suspense>` boundary, so lazy content can stream in.
 - `onClose` fires when the dialog closes — use it to clear the React state that mounts the dialog, or (when pushed via a store) to remove it from the list.
-- Pair with [`DialogsStore`](/ui/DialogsStore), [`DialogsContext`](/ui/DialogsContext), and [`Dialogs`](/ui/Dialogs) to open dialogs imperatively from anywhere in the app. For a non-blocking persistent overlay, reach for [`Modal`](/ui/Modal) instead.
+- Pair with [`DialogsStore`](/ui/DialogsStore), [`<DialogsContext>`](/ui/DialogsContext), and [`<Dialogs>`](/ui/Dialogs) to open dialogs imperatively from anywhere in the app. For a non-blocking persistent overlay, reach for [`<Modal>`](/ui/Modal) instead.
 
 ## Usage
 
@@ -34,7 +34,7 @@ function ConfirmDelete({ onConfirm, onClose }: { onConfirm: () => void; onClose:
 
 ### Imperative
 
-Set up the context once near the app root (see [`DialogsContext`](/ui/DialogsContext) and [`Dialogs`](/ui/Dialogs)), then push a `<Dialog>` from anywhere with [`requireDialogs()`](/ui/requireDialogs).
+Set up the context once near the app root (see [`<DialogsContext>`](/ui/DialogsContext) and [`<Dialogs>`](/ui/Dialogs)), then push a `<Dialog>` from anywhere with [`requireDialogs()`](/ui/requireDialogs).
 
 ```tsx
 import { requireDialogs } from "shelving/ui";

--- a/modules/ui/dialog/Modal.md
+++ b/modules/ui/dialog/Modal.md
@@ -1,10 +1,10 @@
 # Modal
 
-A non-blocking `<aside>` overlay for persistent panels — drawers, toasts, and side-sheets that coexist with the page rather than blocking interaction with it. Unlike [`Dialog`](/ui/Dialog), it is not a native `<dialog>` and does not trap focus or dim the page.
+A non-blocking `<aside>` overlay for persistent panels — drawers, toasts, and side-sheets that coexist with the page rather than blocking interaction with it. Unlike [`<Dialog>`](/ui/Dialog), it is not a native `<dialog>` and does not trap focus or dim the page.
 
 **Things to know:**
 
-- Reach for `Modal` when the overlay should sit alongside the page (a notification panel, a side drawer); reach for [`Dialog`](/ui/Dialog) when it should block interaction until dismissed.
+- Reach for `Modal` when the overlay should sit alongside the page (a notification panel, a side drawer); reach for [`<Dialog>`](/ui/Dialog) when it should block interaction until dismissed.
 - It only styles the box — lay out its contents with the usual block components.
 
 ## Usage

--- a/modules/ui/docs/DocumentationButtons.md
+++ b/modules/ui/docs/DocumentationButtons.md
@@ -1,10 +1,10 @@
 # DocumentationButtons
 
-Renders a documented symbol's relational metadata as a `<nav>` column of labelled links — `extends AbstractStore`, `implements Serializable`, `member of Store`. Used by both [`DocumentationPage`](/ui/DocumentationPage) (below the title) and [`DocumentationCard`](/ui/DocumentationCard).
+Renders a documented symbol's relational metadata as a `<nav>` column of labelled links — `extends AbstractStore`, `implements Serializable`, `member of Store`. Used by both [`<DocumentationPage>`](/ui/DocumentationPage) (below the title) and [`<DocumentationCard>`](/ui/DocumentationCard).
 
 **Things to know:**
 
-- Each relation reads as `"{label} {Target}"`. The target is a [`TreeButton`](/ui/TreeButton), so it resolves the reference against the flattened tree map from [`TreeProvider`](/ui/TreeProvider): a hit becomes a link, a miss (e.g. a builtin like `Serializable`) renders as a plain non-linking label so the text still reads.
+- Each relation reads as `"{label} {Target}"`. The target is a [`<TreeButton>`](/ui/TreeButton), so it resolves the reference against the flattened tree map from [`<TreeProvider>`](/ui/TreeProvider): a hit becomes a link, a miss (e.g. a builtin like `Serializable`) renders as a plain non-linking label so the text still reads.
 - Relations come from the raw metadata the extractor records — `extends` and `implements` first, then the broader `member of` (the `class` relation) last.
 - It renders nothing when the symbol has no relations.
 - Block spacing defaults to paragraph spacing (it composes [`getParagraphClass()`](/ui/getParagraphClass)); pass `space` to override. Inner spacing is the flex gap.
@@ -12,7 +12,7 @@ Renders a documented symbol's relational metadata as a `<nav>` column of labelle
 
 ## Usage
 
-Used automatically by [`DocumentationPage`](/ui/DocumentationPage) and [`DocumentationCard`](/ui/DocumentationCard). To render relations directly, pass the symbol's relational props.
+Used automatically by [`<DocumentationPage>`](/ui/DocumentationPage) and [`<DocumentationCard>`](/ui/DocumentationCard). To render relations directly, pass the symbol's relational props.
 
 ```tsx
 import { DocumentationButtons } from "shelving/ui";
@@ -28,4 +28,4 @@ Drop a relation by omitting it, or tighten spacing with `space`.
 
 ## Styling
 
-`DocumentationButtons` has no own CSS hooks — it composes [`getParagraphClass()`](/ui/getParagraphClass) for block spacing and the flex utilities for layout, and renders its links as [`TreeButton`](/ui/TreeButton)s. Retheme through those.
+`DocumentationButtons` has no own CSS hooks — it composes [`getParagraphClass()`](/ui/getParagraphClass) for block spacing and the flex utilities for layout, and renders its links as [`<TreeButton>`](/ui/TreeButton)s. Retheme through those.

--- a/modules/ui/docs/DocumentationCard.md
+++ b/modules/ui/docs/DocumentationCard.md
@@ -1,16 +1,16 @@
 # DocumentationCard
 
-A compact link tile summarising a documented symbol — the default card renderer for `tree-documentation` elements in [`TreeCards`](/ui/TreeCards) directory listings. Each card links straight to the symbol's own page.
+A compact link tile summarising a documented symbol — the default card renderer for `tree-documentation` elements in [`<TreeCards>`](/ui/TreeCards) directory listings. Each card links straight to the symbol's own page.
 
 **Things to know:**
 
-- It leads with the symbol's signature(s) via [`DocumentationSignatures`](/ui/DocumentationSignatures) (the same calm code blocks as [`DocumentationPage`](/ui/DocumentationPage)). The signature already carries the name (and `readonly` for properties), so there is no separate title or kind tag — the card's *colour* carries the kind. Symbols with no signature (classes, interfaces, modules) fall back to a plain-name heading.
-- Below the heading it renders the symbol's [`DocumentationButtons`](/ui/DocumentationButtons) relations, then a prose lead-in. The `member of` relation is dropped — a member card almost always sits on its own class's page already.
-- The card links to the element's stamped `path` (the canonical URL set by `flattenTree()` — see [`TreeProvider`](/ui/TreeProvider)).
+- It leads with the symbol's signature(s) via [`<DocumentationSignatures>`](/ui/DocumentationSignatures) (the same calm code blocks as [`<DocumentationPage>`](/ui/DocumentationPage)). The signature already carries the name (and `readonly` for properties), so there is no separate title or kind tag — the card's *colour* carries the kind. Symbols with no signature (classes, interfaces, modules) fall back to a plain-name heading.
+- Below the heading it renders the symbol's [`<DocumentationButtons>`](/ui/DocumentationButtons) relations, then a prose lead-in. The `member of` relation is dropped — a member card almost always sits on its own class's page already.
+- The card links to the element's stamped `path` (the canonical URL set by `flattenTree()` — see [`<TreeProvider>`](/ui/TreeProvider)).
 
 ## Usage
 
-Used automatically via [`TreeCards`](/ui/TreeCards) (which [`DocumentationPage`](/ui/DocumentationPage) uses for its child sections). To render a single card manually, spread the element's flattened props.
+Used automatically via [`<TreeCards>`](/ui/TreeCards) (which [`<DocumentationPage>`](/ui/DocumentationPage) uses for its child sections). To render a single card manually, spread the element's flattened props.
 
 ```tsx
 import { DocumentationCard } from "shelving/ui";
@@ -23,4 +23,4 @@ To replace this renderer across the whole site, wrap the app in [`TreeCardMappin
 
 ## Styling
 
-`DocumentationCard` has no own CSS hooks — it composes [`Card`](/ui/Card), [`Subheading`](/ui/Subheading), and [`Paragraph`](/ui/Paragraph). The card is tinted by `kind` via [`DocumentationKind`](/ui/DocumentationKind)'s colour map; retheme through `Card`'s `--card-*` hooks.
+`DocumentationCard` has no own CSS hooks — it composes [`<Card>`](/ui/Card), [`<Subheading>`](/ui/Subheading), and [`<Paragraph>`](/ui/Paragraph). The card is tinted by `kind` via [`<DocumentationKind>`](/ui/DocumentationKind)'s colour map; retheme through `Card`'s `--card-*` hooks.

--- a/modules/ui/docs/DocumentationHomePage.md
+++ b/modules/ui/docs/DocumentationHomePage.md
@@ -1,13 +1,13 @@
 # DocumentationHomePage
 
-The landing page for a documentation site — a bold coloured hero panel with the package name, sitting above the listing of every module. Swap it in for the root element via [`TreeRouterMapping`](/ui/TreeRouter) so the home route (`/`) renders this instead of the generic [`TreePage`](/ui/TreePage).
+The landing page for a documentation site — a bold coloured hero panel with the package name, sitting above the listing of every module. Swap it in for the root element via [`TreeRouterMapping`](/ui/TreeRouter) so the home route (`/`) renders this instead of the generic [`<TreePage>`](/ui/TreePage).
 
 **Things to know:**
 
-- The whole page sits inside one `color="red"` [`Block`](/ui/Block), so the hero [`Panel`](/ui/Panel), prose, and child [`DocumentationCard`](/ui/DocumentationCard)s all inherit the red tint and re-derive together.
-- The hero is a `padding="5x"` [`Panel`](/ui/Panel) with the package name centred as a [`Title`](/ui/Title) (`center`).
-- Below the hero it renders any absorbed README prose, then the root's children (the modules) as a stack of cards via [`TreeCards`](/ui/TreeCards).
-- It consumes the same [`shelving/util/tree`](/util/tree) as [`TreePage`](/ui/TreePage), so it's a drop-in replacement for the `tree-element` renderer.
+- The whole page sits inside one `color="red"` [`<Block>`](/ui/Block), so the hero [`<Panel>`](/ui/Panel), prose, and child [`<DocumentationCard>`](/ui/DocumentationCard)s all inherit the red tint and re-derive together.
+- The hero is a `padding="5x"` [`<Panel>`](/ui/Panel) with the package name centred as a [`<Title>`](/ui/Title) (`center`).
+- Below the hero it renders any absorbed README prose, then the root's children (the modules) as a stack of cards via [`<TreeCards>`](/ui/TreeCards).
+- It consumes the same [`shelving/util/tree`](/util/tree) as [`<TreePage>`](/ui/TreePage), so it's a drop-in replacement for the `tree-element` renderer.
 
 ## Usage
 
@@ -31,4 +31,4 @@ import { DocumentationHomePage } from "shelving/ui";
 
 ## Styling
 
-`DocumentationHomePage` has no own CSS hooks — it composes [`Page`](/ui/Page), [`Block`](/ui/Block), [`Panel`](/ui/Panel), [`Title`](/ui/Title), [`Section`](/ui/Section), and [`TreeCards`](/ui/TreeCards), which carry their own themeable surfaces. Retheme through those, or change the hero colour via the `color=` on the wrapping `Block`.
+`DocumentationHomePage` has no own CSS hooks — it composes [`<Page>`](/ui/Page), [`<Block>`](/ui/Block), [`<Panel>`](/ui/Panel), [`<Title>`](/ui/Title), [`<Section>`](/ui/Section), and [`<TreeCards>`](/ui/TreeCards), which carry their own themeable surfaces. Retheme through those, or change the hero colour via the `color=` on the wrapping `Block`.

--- a/modules/ui/docs/DocumentationPage.md
+++ b/modules/ui/docs/DocumentationPage.md
@@ -1,17 +1,17 @@
 # DocumentationPage
 
-The full detail page for a documented symbol — the default renderer for `tree-documentation` elements dispatched by [`TreeApp`](/ui/TreeApp). It is the most detailed page renderer in the tree shell; render it directly only when you need a symbol page outside the tree, or replace it for one element type via [`TreePageMapping`](/ui/TreeRouter).
+The full detail page for a documented symbol — the default renderer for `tree-documentation` elements dispatched by [`<TreeApp>`](/ui/TreeApp). It is the most detailed page renderer in the tree shell; render it directly only when you need a symbol page outside the tree, or replace it for one element type via [`TreePageMapping`](/ui/TreeRouter).
 
 **Things to know:**
 
-- Above the title it renders an ancestor trail via [`TreeBreadcrumbs`](/ui/TreeBreadcrumbs), so it needs a [`TreeProvider`](/ui/TreeProvider) above it to resolve the ancestors.
-- The title carries a [`DocumentationKind`](/ui/DocumentationKind) tag, and below it [`DocumentationButtons`](/ui/DocumentationButtons) lists the symbol's relations (`member of`, `extends`, `implements`) as links.
-- It renders the signature(s) via [`DocumentationSignatures`](/ui/DocumentationSignatures) (one block per overload, each carrying the symbol's name), then prose content, then conditional `Parameters` / `Returns` / `Throws` / `Examples` sections — each only appears when it has entries. Parameters render as a [`Table`](/ui/Table) (`Param` / `Type` / `Default` / `Description` columns, a `-` standing in where a parameter has no default); Returns and Throws render as two-column tables (`Return` / `Throws` plus `Description`), with the type in the first column.
-- Child symbols follow, grouped by `kind` into card sections (`Components`, `Functions`, `Classes`, `Interfaces`, `Types`, `Constants`, `Methods`, `Properties`) rendered as [`DocumentationCard`](/ui/DocumentationCard)s inside a [`TreeCards`](/ui/TreeCards) listing. A new documented kind needs an entry in `KIND_SECTIONS` here (and a colour in [`DocumentationKind`](/ui/DocumentationKind)).
+- Above the title it renders an ancestor trail via [`<TreeBreadcrumbs>`](/ui/TreeBreadcrumbs), so it needs a [`<TreeProvider>`](/ui/TreeProvider) above it to resolve the ancestors.
+- The title carries a [`<DocumentationKind>`](/ui/DocumentationKind) tag, and below it [`<DocumentationButtons>`](/ui/DocumentationButtons) lists the symbol's relations (`member of`, `extends`, `implements`) as links.
+- It renders the signature(s) via [`<DocumentationSignatures>`](/ui/DocumentationSignatures) (one block per overload, each carrying the symbol's name), then prose content, then conditional `Parameters` / `Returns` / `Throws` / `Examples` sections — each only appears when it has entries. Parameters render as a [`<Table>`](/ui/Table) (`Param` / `Type` / `Default` / `Description` columns, a `-` standing in where a parameter has no default); Returns and Throws render as two-column tables (`Return` / `Throws` plus `Description`), with the type in the first column.
+- Child symbols follow, grouped by `kind` into card sections (`Components`, `Functions`, `Classes`, `Interfaces`, `Types`, `Constants`, `Methods`, `Properties`) rendered as [`<DocumentationCard>`](/ui/DocumentationCard)s inside a [`<TreeCards>`](/ui/TreeCards) listing. A new documented kind needs an entry in `KIND_SECTIONS` here (and a colour in [`<DocumentationKind>`](/ui/DocumentationKind)).
 
 ## Usage
 
-Used automatically by [`TreeApp`](/ui/TreeApp). To render a single page manually, spread the element's flattened props.
+Used automatically by [`<TreeApp>`](/ui/TreeApp). To render a single page manually, spread the element's flattened props.
 
 ```tsx
 import { DocumentationPage } from "shelving/ui";
@@ -32,4 +32,4 @@ import { TreeApp, TreePageMapping } from "shelving/ui";
 
 ## Styling
 
-`DocumentationPage` has no own CSS hooks — it composes [`Page`](/ui/Page), [`Panel`](/ui/Panel), [`Section`](/ui/Section), and the other block components, which carry their own themeable surfaces. Retheme through those.
+`DocumentationPage` has no own CSS hooks — it composes [`<Page>`](/ui/Page), [`<Panel>`](/ui/Panel), [`<Section>`](/ui/Section), and the other block components, which carry their own themeable surfaces. Retheme through those.

--- a/modules/ui/form/Button.md
+++ b/modules/ui/form/Button.md
@@ -1,6 +1,6 @@
 # Button
 
-A clickable styled as a solid button. Renders an `<a href="">` when given `href`, or a `<button>` when given `onClick` — the shared [`Clickable`](/ui/Clickable) primitive picks the element, so a button is always the right semantics for what it does.
+A clickable styled as a solid button. Renders an `<a href="">` when given `href`, or a `<button>` when given `onClick` — the shared [`<Clickable>`](/ui/Clickable) primitive picks the element, so a button is always the right semantics for what it does.
 
 **Things to know:**
 

--- a/modules/ui/form/Field.md
+++ b/modules/ui/form/Field.md
@@ -1,12 +1,12 @@
 # Field
 
-The visual wrapper for a single form control. `Field` renders a `<label>` with an optional title and description above the input, and an inline error message below it. Use it when composing inputs by hand rather than relying on the automatic fields rendered by [`Form`](/ui/Form).
+The visual wrapper for a single form control. `Field` renders a `<label>` with an optional title and description above the input, and an inline error message below it. Use it when composing inputs by hand rather than relying on the automatic fields rendered by [`<Form>`](/ui/Form).
 
 **Things to know:**
 
 - Full width by default (one field per row). Pass `half` to render at 50% so two fields sit side-by-side.
-- The `message` prop renders below the input as an error [`Message`](/ui/Message) — wire it to the field's error string.
-- [`FormInput`](/ui/FormInput) combines a field's value, error, and schema lookup from the surrounding [`FormContext`](/ui/FormContext); reach for `Field` directly when you want explicit control over the label and layout.
+- The `message` prop renders below the input as an error [`<Message>`](/ui/Message) — wire it to the field's error string.
+- [`<FormInput>`](/ui/FormInput) combines a field's value, error, and schema lookup from the surrounding [`FormContext`](/ui/FormContext); reach for `Field` directly when you want explicit control over the label and layout.
 
 ## Usage
 

--- a/modules/ui/form/Form.md
+++ b/modules/ui/form/Form.md
@@ -68,7 +68,7 @@ export function ListingForm({ listing }: { listing?: typeof LISTING_SCHEMA.type 
 
 ### Custom layout
 
-Provide explicit `children` when you need control over field order, groupings, or extra buttons. [`<FormInput>`](/ui/FormInput) uses [`useField()`](/ui/useField) to pull the current value, error, and schema from context, then delegates to [`SchemaInput`](/ui/SchemaInput) so each field renders the correct control type.
+Provide explicit `children` when you need control over field order, groupings, or extra buttons. [`<FormInput>`](/ui/FormInput) uses [`useField()`](/ui/useField) to pull the current value, error, and schema from context, then delegates to [`<SchemaInput>`](/ui/SchemaInput) so each field renders the correct control type.
 
 ```tsx
 import { Form, Field, FormInput, SubmitButton, Button, FormMessage } from "shelving/ui";

--- a/modules/ui/form/FormStore.md
+++ b/modules/ui/form/FormStore.md
@@ -1,6 +1,6 @@
 # FormStore
 
-The reactive brain behind every form. `FormStore` extends [`DataStore`](/store/DataStore) from [`shelving/store`](/store) and owns the current (partial) field values, a `messages` dictionary of per-field errors, and the validate/submit helpers that drive a [`Form`](/ui/Form).
+The reactive brain behind every form. `FormStore` extends [`DataStore`](/store/DataStore) from [`shelving/store`](/store) and owns the current (partial) field values, a `messages` dictionary of per-field errors, and the validate/submit helpers that drive a [`<Form>`](/ui/Form).
 
 **Things to know:**
 
@@ -9,7 +9,7 @@ The reactive brain behind every form. `FormStore` extends [`DataStore`](/store/D
 - `publish(name, value)` validates a single field, writes the result, and stores any per-field error (it persists the raw value even when invalid, so nothing is lost on the way to submit).
 - `submit(callback)` validates the whole form and, if valid, runs the callback.
 - Assigning a string to `reason` splits it into per-field messages (using the `"fieldName: message"` line format from [`shelving/schema`](/schema)) instead of recording a global failure; any non-string reason is surfaced as-is.
-- You rarely construct `FormStore` directly — [`Form`](/ui/Form) does it for you — but you can grab it from context with [`requireForm()`](/ui/requireForm) when you need it.
+- You rarely construct `FormStore` directly — [`<Form>`](/ui/Form) does it for you — but you can grab it from context with [`requireForm()`](/ui/requireForm) when you need it.
 
 ## Usage
 

--- a/modules/ui/form/SchemaInput.md
+++ b/modules/ui/form/SchemaInput.md
@@ -1,27 +1,27 @@
 # SchemaInput
 
-Schema-driven input dispatch. `SchemaInput` inspects a [`Schema`](/schema/Schema) instance and renders the right control automatically — the same mechanism [`Form`](/ui/Form) uses to turn a [`DataSchema`](/schema/DataSchema) into a complete set of inputs.
+Schema-driven input dispatch. `SchemaInput` inspects a [`Schema`](/schema/Schema) instance and renders the right control automatically — the same mechanism [`<Form>`](/ui/Form) uses to turn a [`DataSchema`](/schema/DataSchema) into a complete set of inputs.
 
 **Things to know:**
 
 - `required` defaults to whether the schema is required (i.e. not wrapped in an [`OptionalSchema`](/schema/OptionalSchema) or [`NullableSchema`](/schema/NullableSchema)); override it explicitly when needed.
 - It throws an [`UnexpectedError`](/error/UnexpectedError) if no input matches the schema type.
-- `SchemaField` wraps the chosen input in a [`Field`](/ui/Field) with its label and message; pass `children` to override the input while keeping the field chrome.
+- `SchemaField` wraps the chosen input in a [`<Field>`](/ui/Field) with its label and message; pass `children` to override the input while keeping the field chrome.
 - Every input it dispatches to is a standalone, controlled component extending [`ValueInputProps<O>`](/ui/ValueInputProps) — see the prop contract below.
 
 The schema-to-input mapping:
 
 | Schema type | Rendered as |
 |---|---|
-| [`StringSchema`](/schema/StringSchema) | [`TextInput`](/ui/TextInput) |
-| [`NumberSchema`](/schema/NumberSchema) | [`NumberInput`](/ui/NumberInput) (formatted on blur) |
-| [`DateSchema`](/schema/DateSchema) | [`DateInput`](/ui/DateInput) |
-| [`BooleanSchema`](/schema/BooleanSchema) | [`CheckboxInput`](/ui/CheckboxInput) |
-| [`ChoiceSchema`](/schema/ChoiceSchema) (≤ 8 options) | [`ChoiceRadioInputs`](/ui/ChoiceRadioInputs) |
-| `ChoiceSchema` (> 8 options) | [`SelectInput`](/ui/SelectInput) |
-| [`ArraySchema`](/schema/ArraySchema) | [`ArrayInput`](/ui/ArrayInput) |
-| [`DictionarySchema`](/schema/DictionarySchema) | [`DictionaryInput`](/ui/DictionaryInput) |
-| `DataSchema` | [`DataInput`](/ui/DataInput) |
+| [`StringSchema`](/schema/StringSchema) | [`<TextInput>`](/ui/TextInput) |
+| [`NumberSchema`](/schema/NumberSchema) | [`<NumberInput>`](/ui/NumberInput) (formatted on blur) |
+| [`DateSchema`](/schema/DateSchema) | [`<DateInput>`](/ui/DateInput) |
+| [`BooleanSchema`](/schema/BooleanSchema) | [`<CheckboxInput>`](/ui/CheckboxInput) |
+| [`ChoiceSchema`](/schema/ChoiceSchema) (≤ 8 options) | [`<ChoiceRadioInputs>`](/ui/ChoiceRadioInputs) |
+| `ChoiceSchema` (> 8 options) | [`<SelectInput>`](/ui/SelectInput) |
+| [`ArraySchema`](/schema/ArraySchema) | [`<ArrayInput>`](/ui/ArrayInput) |
+| [`DictionarySchema`](/schema/DictionarySchema) | [`<DictionaryInput>`](/ui/DictionaryInput) |
+| `DataSchema` | [`<DataInput>`](/ui/DataInput) |
 
 The shared value-input prop contract (`ValueInputProps<O>`):
 
@@ -34,7 +34,7 @@ The shared value-input prop contract (`ValueInputProps<O>`):
 | `disabled` | Disables the control |
 | `message` | Inline error string |
 
-[`DataInput`](/ui/DataInput) renders a row of `SchemaInput` elements for each property of a nested data object, and propagates sub-field errors from a `"key: message\n…"` formatted `message` string. `ArrayInput` and `DictionaryInput` both accept an `items` schema to render a repeatable list of sub-inputs with add/remove buttons.
+[`<DataInput>`](/ui/DataInput) renders a row of `SchemaInput` elements for each property of a nested data object, and propagates sub-field errors from a `"key: message\n…"` formatted `message` string. `ArrayInput` and `DictionaryInput` both accept an `items` schema to render a repeatable list of sub-inputs with add/remove buttons.
 
 ## Usage
 

--- a/modules/ui/inline/Code.md
+++ b/modules/ui/inline/Code.md
@@ -14,7 +14,7 @@ An inline code span — renders a `<code>` element with monospace type and a sub
 - Pick the sibling whose semantics match — they all look the same but mean different things to assistive tech and search.
 - Pass `plain` to drop the default background and inline padding (useful when the code already sits inside a tinted container).
 - Painted from the [tint ladder](/ui/TINT_CLASS): the background is [`--tint-90`](/ui/TINT_CLASS) and the text [`--tint-00`](/ui/TINT_CLASS), so it re-tints with its surrounding scope.
-- Inside [`Prose`](/ui/Prose) raw `<code>` / `<kbd>` / `<samp>` / `<var>` pick up the same styling, and code inside a `<pre>` drops the inline box automatically.
+- Inside [`<Prose>`](/ui/Prose) raw `<code>` / `<kbd>` / `<samp>` / `<var>` pick up the same styling, and code inside a `<pre>` drops the inline box automatically.
 
 ## Usage
 

--- a/modules/ui/inline/Link.md
+++ b/modules/ui/inline/Link.md
@@ -1,13 +1,13 @@
 # Link
 
-An inline link or action. Delegates to [`Clickable`](/ui/Clickable), rendering an `<a>` when `href` is provided or a `<button>` when `onClick` is provided — so the same component covers both navigation and in-page actions. Prefer it over a raw `<a>` inside React components.
+An inline link or action. Delegates to [`<Clickable>`](/ui/Clickable), rendering an `<a>` when `href` is provided or a `<button>` when `onClick` is provided — so the same component covers both navigation and in-page actions. Prefer it over a raw `<a>` inside React components.
 
 **Things to know:**
 
 - It handles busy state, URL resolution, and active-page highlighting automatically via the shared [`<Clickable>`](/ui/Clickable) helper.
 - An `<a>` (any actual link) shows an underline that disappears on hover; a `<button>` variant carries no underline.
 - Reach for `Link` for inline text links; for standalone calls to action use a button-styled component instead.
-- Inside [`Prose`](/ui/Prose) a raw `<a>` picks up the same styling, so Markdown-rendered links match component ones.
+- Inside [`<Prose>`](/ui/Prose) a raw `<a>` picks up the same styling, so Markdown-rendered links match component ones.
 
 ## Usage
 

--- a/modules/ui/inline/Mark.md
+++ b/modules/ui/inline/Mark.md
@@ -4,9 +4,9 @@ Highlighted text — renders a `<mark>` element to call attention to a run of te
 
 **Things to know:**
 
-- Use it for relevance highlighting (search hits, the current match), not for general emphasis — reach for [`Strong`](/ui/Strong) or [`Emphasis`](/ui/Emphasis) for that.
+- Use it for relevance highlighting (search hits, the current match), not for general emphasis — reach for [`<Strong>`](/ui/Strong) or [`<Emphasis>`](/ui/Emphasis) for that.
 - It is a self-contained inline pill: it adds its own inline padding and rounded corners.
-- Inside [`Prose`](/ui/Prose) a raw `<mark>` picks up the same styling, so Markdown-rendered highlights match component ones.
+- Inside [`<Prose>`](/ui/Prose) a raw `<mark>` picks up the same styling, so Markdown-rendered highlights match component ones.
 
 ## Usage
 

--- a/modules/ui/inline/Strong.md
+++ b/modules/ui/inline/Strong.md
@@ -4,9 +4,9 @@ Strong importance — renders a `<strong>` element for text that carries strong 
 
 **Things to know:**
 
-- Use `Strong` for importance, [`Emphasis`](/ui/Emphasis) for stress emphasis (italic), and [`Mark`](/ui/Mark) for relevance highlighting — they are not interchangeable.
+- Use `Strong` for importance, [`<Emphasis>`](/ui/Emphasis) for stress emphasis (italic), and [`<Mark>`](/ui/Mark) for relevance highlighting — they are not interchangeable.
 - It only sets the font weight; it inherits colour and size from the surrounding text.
-- Inside [`Prose`](/ui/Prose) raw `<strong>` / `<b>` pick up the same styling, so Markdown-rendered bold text matches component ones.
+- Inside [`<Prose>`](/ui/Prose) raw `<strong>` / `<b>` pick up the same styling, so Markdown-rendered bold text matches component ones.
 
 ## Usage
 

--- a/modules/ui/layout/CenteredLayout.md
+++ b/modules/ui/layout/CenteredLayout.md
@@ -23,7 +23,7 @@ function LoginPage() {
 }
 ```
 
-Layouts compose naturally as [`Router`](/ui/Router) route values — wrap a group of routes in a shared layout, then route further inside it.
+Layouts compose naturally as [`<Router>`](/ui/Router) route values — wrap a group of routes in a shared layout, then route further inside it.
 
 ## Styling
 

--- a/modules/ui/layout/SidebarLayout.md
+++ b/modules/ui/layout/SidebarLayout.md
@@ -5,9 +5,9 @@ A full-viewport layout with a fixed-width side column next to a scrollable main 
 **Things to know:**
 
 - Pass `right` to place the sidebar on the right rather than the left.
-- The sidebar renders as `<nav>`, so it is a navigation landmark without extra markup — drop a [`Menu`](/ui/Menu) inside it.
+- The sidebar renders as `<nav>`, so it is a navigation landmark without extra markup — drop a [`<Menu>`](/ui/Menu) inside it.
 - While the drawer is open an overlay dims the page; clicking the overlay closes it.
-- Inside a [`Navigation`](/ui/Navigation) context the drawer closes itself whenever the route changes (e.g. tapping a sidebar link).
+- Inside a [`<Navigation>`](/ui/Navigation) context the drawer closes itself whenever the route changes (e.g. tapping a sidebar link).
 - The layout owns scroll, padding, and safe-area insets so individual pages don't have to.
 
 ## Usage
@@ -31,7 +31,7 @@ function AppShell() {
 }
 ```
 
-Layouts compose naturally as [`Router`](/ui/Router) route values — wrap a group of routes in a shared layout, then route further inside it.
+Layouts compose naturally as [`<Router>`](/ui/Router) route values — wrap a group of routes in a shared layout, then route further inside it.
 
 ### Keyboard-aware safe area
 

--- a/modules/ui/menu/Menu.md
+++ b/modules/ui/menu/Menu.md
@@ -1,11 +1,11 @@
 # Menu
 
-A `<menu>` list of [`MenuItem`](/ui/MenuItem) children — the container for URL-aware navigation in sidebars, dropdowns, and any other list of links.
+A `<menu>` list of [`<MenuItem>`](/ui/MenuItem) children — the container for URL-aware navigation in sidebars, dropdowns, and any other list of links.
 
 **Things to know:**
 
-- Renders as a bare `<menu>` element (semantically equivalent to `<ul>` but more meaningful for menus). Place it inside a `<nav>` — or a [`SidebarLayout`](/ui/SidebarLayout) sidebar, which is already a `<nav>` landmark — if a navigation landmark is needed.
-- Nesting a `<Menu>` inside a [`MenuItem`](/ui/MenuItem) gets indented automatically via the `.menu .menu` descendant rule.
+- Renders as a bare `<menu>` element (semantically equivalent to `<ul>` but more meaningful for menus). Place it inside a `<nav>` — or a [`<SidebarLayout>`](/ui/SidebarLayout) sidebar, which is already a `<nav>` landmark — if a navigation landmark is needed.
+- Nesting a `<Menu>` inside a [`<MenuItem>`](/ui/MenuItem) gets indented automatically via the `.menu .menu` descendant rule.
 
 ## Usage
 
@@ -40,6 +40,6 @@ import { Menu, MenuItem } from "shelving/ui";
 | `--menu-nested-color-border` | Nested submenu left-border colour | `var(--tint-50)` |
 | `--menu-nested-indent` | Nested submenu left padding | `var(--space-xsmall)` |
 
-Item-state hooks (`--menu-hover-*`, `--menu-proud-*`, `--menu-active-*`, `--menu-radius`, `--menu-focus-border`) are documented on [`MenuItem`](/ui/MenuItem).
+Item-state hooks (`--menu-hover-*`, `--menu-proud-*`, `--menu-active-*`, `--menu-radius`, `--menu-focus-border`) are documented on [`<MenuItem>`](/ui/MenuItem).
 
 **Global tokens it reads** — the tint ladder [`--tint-00`](/ui/TINT_CLASS) / [`--tint-50`](/ui/TINT_CLASS), plus [`--space-xxsmall`](/ui/getSpaceClass) / [`--space-xsmall`](/ui/getSpaceClass), [`--font-body`](/ui/getFontClass), [`--size-normal`](/ui/getSizeClass), [`--leading`](/ui/getSizeClass), and [`--stroke-focus`](/ui/getStrokeClass).

--- a/modules/ui/menu/MenuItem.md
+++ b/modules/ui/menu/MenuItem.md
@@ -1,12 +1,12 @@
 # MenuItem
 
-A single `<li>` link entry inside a [`Menu`](/ui/Menu). It reads the current page URL from the [`Meta`](/ui/Meta) context and automatically marks itself `active` (exact match) or `proud` (an ancestor of the current page) — and when proud, reveals its submenu children.
+A single `<li>` link entry inside a [`<Menu>`](/ui/Menu). It reads the current page URL from the [`Meta`](/ui/Meta) context and automatically marks itself `active` (exact match) or `proud` (an ancestor of the current page) — and when proud, reveals its submenu children.
 
 **Things to know:**
 
-- The first child is the link label (rendered inside the `<a>`). Any additional children form the submenu and are rendered only when the item is proud (the current URL starts with the item's `href`). Wrap that submenu in a nested [`Menu`](/ui/Menu) to get the `.menu .menu` indentation.
-- It forwards all [`ClickableProps`](/ui/ClickableProps) — `href`, `onClick`, `disabled`, and so on — to the underlying [`Clickable`](/ui/Clickable).
-- `active` and `proud` are computed against the URL from [`Router`](/ui/Router) / [`Navigation`](/ui/Navigation) context.
+- The first child is the link label (rendered inside the `<a>`). Any additional children form the submenu and are rendered only when the item is proud (the current URL starts with the item's `href`). Wrap that submenu in a nested [`<Menu>`](/ui/Menu) to get the `.menu .menu` indentation.
+- It forwards all [`ClickableProps`](/ui/ClickableProps) — `href`, `onClick`, `disabled`, and so on — to the underlying [`<Clickable>`](/ui/Clickable).
+- `active` and `proud` are computed against the URL from [`<Router>`](/ui/Router) / [`<Navigation>`](/ui/Navigation) context.
 
 ## Usage
 
@@ -43,6 +43,6 @@ The item link's hooks (defined in `Menu.module.css`):
 | `--menu-active-color` | Text colour when active | `var(--tint-00)` |
 | `--menu-active-weight` | Font weight when active | `var(--weight-strong)` |
 
-List-level hooks (`--menu-gap`, `--menu-color`, the nested-submenu hooks, etc.) are documented on [`Menu`](/ui/Menu).
+List-level hooks (`--menu-gap`, `--menu-color`, the nested-submenu hooks, etc.) are documented on [`<Menu>`](/ui/Menu).
 
 **Global tokens it reads** — the tint ladder [`--tint-00`](/ui/TINT_CLASS) / [`--tint-90`](/ui/TINT_CLASS) / [`--tint-100`](/ui/TINT_CLASS), plus [`--space-xxsmall`](/ui/getSpaceClass), [`--radius-xxsmall`](/ui/getRadiusClass), [`--stroke-focus`](/ui/getStrokeClass), [`--stroke-normal`](/ui/getStrokeClass), [`--color-focus`](/ui/getColorClass), and [`--weight-strong`](/ui/getWeightClass).

--- a/modules/ui/notice/Notices.md
+++ b/modules/ui/notice/Notices.md
@@ -1,6 +1,6 @@
 # Notices
 
-Renders the global list of active notices and subscribes to incoming `"notice"` events. It listens for `"notice"` events on `window` (dispatched by the [`notify`](/ui/notify) helpers) and shows each one as a [`<Notice>`](/ui/Notice) — this is how components like [`<Button>`](/ui/Button) and [`<FormNotify>`](/ui/FormNotify) send notices into the global list.
+Renders the global list of active notices and subscribes to incoming `"notice"` events. It listens for `"notice"` events on `window` (dispatched by the [`notify()`](/ui/notify) helpers) and shows each one as a [`<Notice>`](/ui/Notice) — this is how components like [`<Button>`](/ui/Button) and [`<FormNotify>`](/ui/FormNotify) send notices into the global list.
 
 **Things to know:**
 

--- a/modules/ui/page/HTML.md
+++ b/modules/ui/page/HTML.md
@@ -1,11 +1,11 @@
 # HTML
 
-The full `<html>` document shell, wrapping `<head>` and `<body>`. Use it as the outermost wrapper for server-side rendering — it owns the literal `<head>` (charset, `<base>`, app `<title>`) while per-page hoistable tags come from [`Page`](/ui/Page).
+The full `<html>` document shell, wrapping `<head>` and `<body>`. Use it as the outermost wrapper for server-side rendering — it owns the literal `<head>` (charset, `<base>`, app `<title>`) while per-page hoistable tags come from [`<Page>`](/ui/Page).
 
 **Things to know:**
 
 - Accepts [`PossibleMeta`](/ui/PossibleMeta) props (`app`, `root`, `url`, `title`, `description`, `language`, `tags`, `links`, `stylesheets`, `modules`, `scripts`) and merges them into the [`Meta`](/ui/Meta) context it provides to children.
-- `<base>` lives only here — it is not a hoistable element, unlike the title/meta/link/script tags that [`Page`](/ui/Page) emits and React 19 lifts into this `<head>`.
+- `<base>` lives only here — it is not a hoistable element, unlike the title/meta/link/script tags that [`<Page>`](/ui/Page) emits and React 19 lifts into this `<head>`.
 - Pass the request URL so the tree can match routes during SSR.
 
 ## Usage

--- a/modules/ui/page/Head.md
+++ b/modules/ui/page/Head.md
@@ -4,8 +4,8 @@ Low-level emitter of hoistable head metadata from the current [`Meta`](/ui/Meta)
 
 **Things to know:**
 
-- [`Page`](/ui/Page) renders `<Head>` automatically — you rarely need it directly.
-- It does not render `<base>`, which is not hoistable; that lives in the [`HTML`](/ui/HTML) shell.
+- [`<Page>`](/ui/Page) renders `<Head>` automatically — you rarely need it directly.
+- It does not render `<base>`, which is not hoistable; that lives in the [`<HTML>`](/ui/HTML) shell.
 - The composed title combines the page `title` with the app name from context.
 
 ## Usage

--- a/modules/ui/page/Page.md
+++ b/modules/ui/page/Page.md
@@ -6,7 +6,7 @@ Wraps one page (or screen) inside an app, applying its per-page metadata. It mer
 
 - Accepts [`PossibleMeta`](/ui/PossibleMeta) props (`app`, `root`, `url`, `title`, `description`, `language`, `tags`, `links`, `stylesheets`, `modules`, `scripts`) and merges them with the surrounding [`Meta`](/ui/Meta) context.
 - The page title is composed with the app name from context — `title="User profile"` under `app="My App"` renders `"User profile - My App"`.
-- It renders [`Head`](/ui/Head) inline; React 19 hoists each `<title>`, `<meta>`, `<link>`, and `<script>` into `<head>`, so no portal is needed. `<base>` is the exception — that lives in [`HTML`](/ui/HTML).
+- It renders [`<Head>`](/ui/Head) inline; React 19 hoists each `<title>`, `<meta>`, `<link>`, and `<script>` into `<head>`, so no portal is needed. `<base>` is the exception — that lives in [`<HTML>`](/ui/HTML).
 
 ## Usage
 

--- a/modules/ui/router/Navigation.md
+++ b/modules/ui/router/Navigation.md
@@ -1,13 +1,13 @@
 # Navigation
 
-The top-level navigation provider for a client-side app. It owns a single [`NavigationStore`](/ui/NavigationStore), publishes the live URL into the `<Meta>` context so descendant [`Router`](/ui/Router)s re-render on navigation, and wires up browser history. Use exactly one `<Navigation>` per app — nested routers all share its single store.
+The top-level navigation provider for a client-side app. It owns a single [`NavigationStore`](/ui/NavigationStore), publishes the live URL into the `<Meta>` context so descendant [`<Router>`](/ui/Router)s re-render on navigation, and wires up browser history. Use exactly one `<Navigation>` per app — nested routers all share its single store.
 
 **Things to know:**
 
 - Same-origin anchor clicks are intercepted automatically and turned into `forward()` calls. Add a `download` attribute to an anchor to opt out.
 - It listens for `popstate` so the store stays in sync with browser back/forward.
-- It initialises the store from the surrounding `<Meta>` url/base, so set those on an ancestor [`HTML`](/ui/HTML) / [`Page`](/ui/Page).
-- [`Router`](/ui/Router) works with no `<Navigation>` at all (SSR, static rendering, tests) — `<Navigation>` is only what makes the URL *live* on the client.
+- It initialises the store from the surrounding `<Meta>` url/base, so set those on an ancestor [`<HTML>`](/ui/HTML) / [`<Page>`](/ui/Page).
+- [`<Router>`](/ui/Router) works with no `<Navigation>` at all (SSR, static rendering, tests) — `<Navigation>` is only what makes the URL *live* on the client.
 
 ## Usage
 

--- a/modules/ui/router/NavigationStore.md
+++ b/modules/ui/router/NavigationStore.md
@@ -1,6 +1,6 @@
 # NavigationStore
 
-The store holding the current navigation URL and driving browser history. It extends [`URLStore`](/store/URLStore) — the current location is its `value` — and is owned by [`Navigation`](/ui/Navigation). Reach for it via [`requireNavigation()`](/ui/Navigation) rather than constructing your own.
+The store holding the current navigation URL and driving browser history. It extends [`URLStore`](/store/URLStore) — the current location is its `value` — and is owned by [`<Navigation>`](/ui/Navigation). Reach for it via [`requireNavigation()`](/ui/Navigation) rather than constructing your own.
 
 **Things to know:**
 

--- a/modules/ui/router/RouteCache.md
+++ b/modules/ui/router/RouteCache.md
@@ -2,7 +2,7 @@
 
 A keep-alive page cache. Drop it into a layout around its scrolling content region: it reads the current URL from the surrounding [`<Meta>`](/ui/MetaContext) context and keeps a handful of recently-visited pages mounted but *hidden* (using React's [`<Activity>`](https://react.dev/reference/react/Activity)), so navigating back or forward to a page restores its entire DOM and component state — scroll position of every scroll container, open/closed toggles, in-progress searches, form inputs, focus — instead of remounting it fresh at the top.
 
-Shelving's [`SidebarLayout`](/ui/SidebarLayout) and [`CenteredLayout`](/ui/CenteredLayout) already wrap their scrollable content column in one for you, so pages rendered inside them keep their state across navigation automatically. Reach for it by hand only when building a custom layout.
+Shelving's [`<SidebarLayout>`](/ui/SidebarLayout) and [`<CenteredLayout>`](/ui/CenteredLayout) already wrap their scrollable content column in one for you, so pages rendered inside them keep their state across navigation automatically. Reach for it by hand only when building a custom layout.
 
 **Things to know:**
 

--- a/modules/ui/router/Router.md
+++ b/modules/ui/router/Router.md
@@ -1,6 +1,6 @@
 # Router
 
-A pure URL matcher: it reads the current URL from the surrounding `<Meta>` context, matches it against a `routes` table, and renders the matched element. It has no client requirements, so it works for SSR, static rendering, and tests with no [`Navigation`](/ui/Navigation) at all — wrap it in [`Navigation`](/ui/Navigation) on the client to get live URL updates.
+A pure URL matcher: it reads the current URL from the surrounding `<Meta>` context, matches it against a `routes` table, and renders the matched element. It has no client requirements, so it works for SSR, static rendering, and tests with no [`<Navigation>`](/ui/Navigation) at all — wrap it in [`<Navigation>`](/ui/Navigation) on the client to get live URL updates.
 
 **Things to know:**
 

--- a/modules/ui/style/TINT_CLASS.md
+++ b/modules/ui/style/TINT_CLASS.md
@@ -20,7 +20,7 @@ The ladder is computed at `:root` and *recomputed* under `TINT_CLASS` (the `.tin
 }
 ```
 
-[`getColorClass`](/ui/getColorClass) and [`getStatusClass`](/ui/getStatusClass) compose `TINT_CLASS` automatically, so `<Card color="red">` is: move the anchor to red, rebuild the ladder, and let the card paint from the same steps it always paints from. Descendants inherit the rebuilt ladder, which is why a [`Tag`](/ui/Tag) or [`Preformatted`](/ui/Preformatted) nested in a red card tints to match it.
+[`getColorClass()`](/ui/getColorClass) and [`getStatusClass()`](/ui/getStatusClass) compose `TINT_CLASS` automatically, so `<Card color="red">` is: move the anchor to red, rebuild the ladder, and let the card paint from the same steps it always paints from. Descendants inherit the rebuilt ladder, which is why a [`<Tag>`](/ui/Tag) or [`<Preformatted>`](/ui/Preformatted) nested in a red card tints to match it.
 
 ## How components paint from the ladder
 
@@ -31,7 +31,7 @@ Components paint from the ladder by convention:
 | `--tint-00` | Body text, headings — maximum contrast |
 | `--tint-50` | The hue itself — accents, labels, `Tag` backgrounds, `strong` button backgrounds |
 | `--tint-80` | Borders |
-| `--tint-90` | Surfaces — [`Card`](/ui/Card), `Preformatted`, [`Button`](/ui/Button) backgrounds |
+| `--tint-90` | Surfaces — [`<Card>`](/ui/Card), `Preformatted`, [`<Button>`](/ui/Button) backgrounds |
 | `--tint-95` | Hover state of those surfaces |
 | `--tint-100` | The page background; text on `--tint-50` backgrounds |
 

--- a/modules/ui/style/getDurationClass.md
+++ b/modules/ui/style/getDurationClass.md
@@ -1,6 +1,6 @@
 # getDurationClass
 
-This module's main job is to **define and document the transition/animation timing tokens**. Components and [transitions](/ui/Transition) read these tokens directly; `getDurationClass({ duration })` exists as a utility (e.g. `duration="fast"` → `duration-fast`) and as the home for this documentation.
+This module's main job is to **define and document the transition/animation timing tokens**. Components and [`<Transition>`](/ui/Transition) components read these tokens directly; `getDurationClass({ duration })` exists as a utility (e.g. `duration="fast"` → `duration-fast`) and as the home for this documentation.
 
 ## Theme variables
 

--- a/modules/ui/style/getSpaceClass.md
+++ b/modules/ui/style/getSpaceClass.md
@@ -2,7 +2,7 @@
 
 The `space` variant prop sets a block-level element's `margin-block` (top + bottom) from the spacing scale — `<Section space="large">`, `<Paragraph space="none">`. It's an **override** for one-off spacing; for an app-wide change, retune the spacing variables below in a theme file.
 
-`getSpaceClass({ space })` maps the prop to a margin class (e.g. `space="large"` → `large`). The same scale also backs [`getPaddingClass`](/ui/getPaddingClass) and [`getGapClass`](/ui/getGapClass), so all three move together when you change `--space`.
+`getSpaceClass({ space })` maps the prop to a margin class (e.g. `space="large"` → `large`). The same scale also backs [`getPaddingClass()`](/ui/getPaddingClass) and [`getGapClass()`](/ui/getGapClass), so all three move together when you change `--space`.
 
 Alongside the named scale, `space` and `padding` also accept numeric multiples of `--space-normal` — `1x` … `10x` (e.g. `padding="5x"` → `calc(var(--space-normal) * 5)`) — for larger one-off blocks like hero panels.
 

--- a/modules/ui/style/getWidthClass.md
+++ b/modules/ui/style/getWidthClass.md
@@ -1,6 +1,6 @@
 # getWidthClass
 
-The `width` variant prop sets a component's inline-size — `<Card width="narrow">`, `<Block width="wide">`, `<Cell width="xxnarrow">`. It's an **override** for one-off layout; for an app-wide change, retune the width variables below in a theme file. [`Section`](/ui/Section) already defaults to the `--width-normal` width, so most pages never set `width` at all.
+The `width` variant prop sets a component's inline-size — `<Card width="narrow">`, `<Block width="wide">`, `<Cell width="xxnarrow">`. It's an **override** for one-off layout; for an app-wide change, retune the width variables below in a theme file. [`<Section>`](/ui/Section) already defaults to the `--width-normal` width, so most pages never set `width` at all.
 
 `getWidthClass({ width, grow })` maps the props to a width class. Every value is capped at 100% of the container.
 
@@ -10,7 +10,7 @@ The `width` variant prop sets a component's inline-size — `<Card width="narrow
 - `full` — the full available width.
 - `fit` — shrink to the content's intrinsic width (`fit-content`).
 
-**The `grow` flag** turns the chosen `width` into a floor rather than an exact size: it applies the value as `min-inline-size` and adds `flex-grow: 1`, so the element expands to fill the available space when it's a flex item. Set it on a [`TableHeader`](/ui/TableHeader) or [`Cell`](/ui/Cell) (`width="12x" grow`) to give that column a 192px minimum that absorbs the remaining width and keeps the table from collapsing the column on a narrow viewport — cells honour `min-width`, so the table scrolls instead.
+**The `grow` flag** turns the chosen `width` into a floor rather than an exact size: it applies the value as `min-inline-size` and adds `flex-grow: 1`, so the element expands to fill the available space when it's a flex item. Set it on a [`<Cell>`](/ui/Cell) (`width="12x" grow`) to give that column a 192px minimum that absorbs the remaining width and keeps the table from collapsing the column on a narrow viewport — cells honour `min-width`, so the table scrolls instead.
 
 ## Theme variables
 

--- a/modules/ui/table/Table.md
+++ b/modules/ui/table/Table.md
@@ -9,8 +9,8 @@ A data table — renders a `<table>`. Compose the usual `<thead>` / `<tbody>` / 
 - Wrap a wide table in a horizontally scrollable container if it may exceed the content width on small screens.
 - Like the other block components it collapses its outer block margin when it is the first or last child.
 - Spans the full width of its container by default; set the `width` variant (`narrow` / `normal` / `wide` / `full` / `fit`) to constrain it.
-- Size columns with [`<TableHeader>`](/ui/TableHeader) / [`<Cell>`](/ui/Cell) and the `width` variant — `width="fit"` hugs the content, and `width="12x" grow` gives a column a hard minimum it can grow past (cells honour `min-width`, so the table scrolls rather than collapsing the column on a narrow screen). A column's width is the widest of its cells.
-- Inside [`Prose`](/ui/Prose) a raw `<table>` picks up the same styling, so Markdown-rendered tables match component ones.
+- Size columns with [`<Cell>`](/ui/Cell) and the `width` variant — `width="fit"` hugs the content, and `width="12x" grow` gives a column a hard minimum it can grow past (cells honour `min-width`, so the table scrolls rather than collapsing the column on a narrow screen). A column's width is the widest of its cells.
+- Inside [`<Prose>`](/ui/Prose) a raw `<table>` picks up the same styling, so Markdown-rendered tables match component ones.
 
 ## Usage
 

--- a/modules/ui/transition/CollapseTransition.md
+++ b/modules/ui/transition/CollapseTransition.md
@@ -1,6 +1,6 @@
 # CollapseTransition
 
-A [`Transition`](/ui/Transition) preset that collapses its children in and out by animating their size, clipping the overflow during the animation.
+A [`<Transition>`](/ui/Transition) preset that collapses its children in and out by animating their size, clipping the overflow during the animation.
 
 **Things to know:**
 

--- a/modules/ui/transition/FadeTransition.md
+++ b/modules/ui/transition/FadeTransition.md
@@ -1,6 +1,6 @@
 # FadeTransition
 
-A [`Transition`](/ui/Transition) preset that fades its children in and out by animating opacity. Wrap any content that should animate when it mounts or unmounts.
+A [`<Transition>`](/ui/Transition) preset that fades its children in and out by animating opacity. Wrap any content that should animate when it mounts or unmounts.
 
 **Things to know:**
 

--- a/modules/ui/transition/HorizontalTransition.md
+++ b/modules/ui/transition/HorizontalTransition.md
@@ -1,11 +1,11 @@
 # HorizontalTransition
 
-A direction-aware [`Transition`](/ui/Transition) preset that slides its children horizontally — right when moving forward, left when moving back. It reads the active transition type so the slide direction matches the navigation direction.
+A direction-aware [`<Transition>`](/ui/Transition) preset that slides its children horizontally — right when moving forward, left when moving back. It reads the active transition type so the slide direction matches the navigation direction.
 
 **Things to know:**
 
 - Defaults to `slideRight`; with the type set to `"forward"` it slides right (`slideRight`), and to `"back"` it slides left (`slideLeft`).
-- Set the direction with `setTransitionType("forward" | "back")` inside a `startTransition()` callback before navigating — see [`Transition`](/ui/Transition).
+- Set the direction with `setTransitionType("forward" | "back")` inside a `startTransition()` callback before navigating — see [`<Transition>`](/ui/Transition).
 - Pass `overlay` to raise the transition group above surrounding content during the animation (`z-index: 100`).
 
 ## Usage

--- a/modules/ui/transition/Transition.md
+++ b/modules/ui/transition/Transition.md
@@ -1,6 +1,6 @@
 # Transition
 
-The base View Transition wrapper. It wraps its children in React 19's `<ViewTransition>` and applies named CSS transition classes, so swapping content between renders produces a smooth animation. Use it directly to specify any transition class names, or reach for a preset variant — [`FadeTransition`](/ui/FadeTransition), [`CollapseTransition`](/ui/CollapseTransition), [`VerticalTransition`](/ui/VerticalTransition), [`HorizontalTransition`](/ui/HorizontalTransition).
+The base View Transition wrapper. It wraps its children in React 19's `<ViewTransition>` and applies named CSS transition classes, so swapping content between renders produces a smooth animation. Use it directly to specify any transition class names, or reach for a preset variant — [`<FadeTransition>`](/ui/FadeTransition), [`<CollapseTransition>`](/ui/CollapseTransition), [`<VerticalTransition>`](/ui/VerticalTransition), [`<HorizontalTransition>`](/ui/HorizontalTransition).
 
 **Things to know:**
 

--- a/modules/ui/transition/VerticalTransition.md
+++ b/modules/ui/transition/VerticalTransition.md
@@ -1,11 +1,11 @@
 # VerticalTransition
 
-A direction-aware [`Transition`](/ui/Transition) preset that slides its children vertically — down when moving forward, up when moving back. It reads the active transition type so the slide direction matches the navigation direction.
+A direction-aware [`<Transition>`](/ui/Transition) preset that slides its children vertically — down when moving forward, up when moving back. It reads the active transition type so the slide direction matches the navigation direction.
 
 **Things to know:**
 
 - Defaults to `slideDown`; with the type set to `"forward"` it slides down (`slideDown`), and to `"back"` it slides up (`slideUp`).
-- Set the direction with `setTransitionType("forward" | "back")` inside a `startTransition()` callback before navigating — see [`Transition`](/ui/Transition).
+- Set the direction with `setTransitionType("forward" | "back")` inside a `startTransition()` callback before navigating — see [`<Transition>`](/ui/Transition).
 - Pass `overlay` to raise the transition group above surrounding content during the animation (`z-index: 100`).
 
 ## Usage

--- a/modules/ui/tree/TreeApp.md
+++ b/modules/ui/tree/TreeApp.md
@@ -4,16 +4,16 @@ The entry point for a tree-based documentation site. Given a [`TreeElement`](/ut
 
 **Things to know:**
 
-- It wraps [`<App>`](/ui/App) with error catching and a sidebar layout, then wires a [`TreeRouter`](/ui/TreeRouter) inside. The sidebar is always a [`TreeSidebar`](/ui/TreeSidebar) built from the root.
-- The router covers the whole tree: `/` renders the root, and every deeper path resolves the matching descendant — both rendered via the default page renderers ([`TreePage`](/ui/TreePage) for directories/files, [`DocumentationPage`](/ui/DocumentationPage) for symbols).
+- It wraps [`<App>`](/ui/App) with error catching and a sidebar layout, then wires a [`<TreeRouter>`](/ui/TreeRouter) inside. The sidebar is always a [`<TreeSidebar>`](/ui/TreeSidebar) built from the root.
+- The router covers the whole tree: `/` renders the root, and every deeper path resolves the matching descendant — both rendered via the default page renderers ([`<TreePage>`](/ui/TreePage) for directories/files, [`<DocumentationPage>`](/ui/DocumentationPage) for symbols).
 - Only directories and files (plus `kind: "module"` symbols) appear in the navigation — code symbols are kept off the sidebar but still get their own pages.
 - Every renderer is overridable. Each dispatch layer is a `[Mapping, Mapper]` pair built by [`createMapper()`](/ui/createMapper); wrap the app (or any subtree) in the matching `*Mapping` component to swap a renderer for one element type without touching anything else:
 
   | Mapping pair | Overrides |
   |---|---|
-  | [`TreePageMapping`](/ui/TreeRouter) / [`TreeRouterMapper`](/ui/TreeRouterMapper) | Full-page renderer (dispatched by [`TreeRouter`](/ui/TreeRouter)) |
-  | [`TreeMenuMapping`](/ui/TreeMenu) / [`TreeMenuMapper`](/ui/TreeMenuMapper) | Sidebar menu item |
-  | [`TreeCardMapping`](/ui/TreeCards) / [`TreeCardMapper`](/ui/TreeCardMapper) | Card in a listing |
+  | [`TreePageMapping`](/ui/TreeRouter) / [`TreeRouterMapper`](/ui/TreeRouter) | Full-page renderer (dispatched by [`<TreeRouter>`](/ui/TreeRouter)) |
+  | [`TreeMenuMapping`](/ui/TreeMenu) / [`TreeMenuMapper`](/ui/TreeMenu) | Sidebar menu item |
+  | [`TreeCardMapping`](/ui/TreeCards) / [`TreeCardMapper`](/ui/TreeCards) | Card in a listing |
 
 ## Usage
 

--- a/modules/ui/tree/TreeMenu.md
+++ b/modules/ui/tree/TreeMenu.md
@@ -4,10 +4,10 @@ A sidebar navigation menu built from the children of a root tree element. Each c
 
 **Things to know:**
 
-- Only directories and files appear, plus documentation symbols of `kind: "module"` — functions, classes, methods, properties, etc. are kept off the navigation (they still get their own pages via [`TreeApp`](/ui/TreeApp)).
+- Only directories and files appear, plus documentation symbols of `kind: "module"` — functions, classes, methods, properties, etc. are kept off the navigation (they still get their own pages via [`<TreeApp>`](/ui/TreeApp)).
 - Each item computes its own href by appending its `name` to the parent `path` (defaulting to `/`).
-- It is a `[Mapping, Mapper]` pair: wrap any subtree in `<TreeMenuMapping mapping={…}>` to swap the per-type menu-item renderer without touching the rest of the site. [`TreeSidebar`](/ui/TreeSidebar) shares this same mapper.
-- Use it directly for finer layout control; otherwise [`TreeApp`](/ui/TreeApp) wires a [`TreeSidebar`](/ui/TreeSidebar) (a home link plus this menu) for you.
+- It is a `[Mapping, Mapper]` pair: wrap any subtree in `<TreeMenuMapping mapping={…}>` to swap the per-type menu-item renderer without touching the rest of the site. [`<TreeSidebar>`](/ui/TreeSidebar) shares this same mapper.
+- Use it directly for finer layout control; otherwise [`<TreeApp>`](/ui/TreeApp) wires a [`<TreeSidebar>`](/ui/TreeSidebar) (a home link plus this menu) for you.
 
 ## Usage
 

--- a/modules/ui/tree/TreeSidebar.md
+++ b/modules/ui/tree/TreeSidebar.md
@@ -1,13 +1,13 @@
 # TreeSidebar
 
-The default sidebar for a tree-based site: a single "home" link for the root element, followed by the root's children as a navigation menu. [`TreeApp`](/ui/TreeApp) mounts one of these automatically.
+The default sidebar for a tree-based site: a single "home" link for the root element, followed by the root's children as a navigation menu. [`<TreeApp>`](/ui/TreeApp) mounts one of these automatically.
 
 **Things to know:**
 
 - The home link uses `path` as its href (defaulting to `/`); children's hrefs are computed by appending their `name` to the root path.
-- The children render through the same mapper as [`TreeMenu`](/ui/TreeMenu), so customise them by wrapping in `<TreeMenuMapping mapping={…}>`.
+- The children render through the same mapper as [`<TreeMenu>`](/ui/TreeMenu), so customise them by wrapping in `<TreeMenuMapping mapping={…}>`.
 - Only directories, files, and `kind: "module"` symbols appear — code symbols are kept off the navigation.
-- Use it directly for finer layout control outside [`TreeApp`](/ui/TreeApp).
+- Use it directly for finer layout control outside [`<TreeApp>`](/ui/TreeApp).
 
 ## Usage
 


### PR DESCRIPTION
Audit of all 226 markdown documentation pages against the cross-reference
rules in AGENTS.md, validated against the authoritative set of resolvable
page paths from the docs extractor.

- Fix 7 dead links: bare /util module links (no such page), a non-existent
  <TableHeader> component (header cells are <Cell header>), and the
  Tree*Mapper links that pointed at pages the destructured createMapper
  exports never produce.
- Restyle component cross-references to angle brackets (<Foo>) per the
  token-display rules; this was already the established house style.
- Add trailing parens to function references (useInstance(), notify(),
  getColorClass(), handleEndpoints(), ...) and use the shelving/ package
  subpath as the text for module-page links.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JxvN5noUD8DHtz3dC7qQvc