### PR TITLE
docs: tag UI components with @kind component

### DIFF
--- a/modules/ui/block/Address.tsx
+++ b/modules/ui/block/Address.tsx
@@ -64,6 +64,7 @@ export function Address({ children, ...props }: AddressProps) {
  * Show an optional [`AddressData`](/util/geo/AddressData) object correctly on screen.
  * - Renders an optional `name` in bold, followed by the formatted address; shows "No address" when `address` is empty.
  *
+ * @kind component
  * @example <PhysicalAddress name="Acme" address={addressData} />
  * @see https://dhoulb.github.io/shelving/ui/block/Address/PhysicalAddress
  */
@@ -81,6 +82,7 @@ export function PhysicalAddress({ name, address }: PhysicalAddressProps): ReactE
  * Show an optional email address string correctly on screen.
  * - Renders an optional `name` in bold, followed by a `mailto:` link; shows "No email" when `email` is empty.
  *
+ * @kind component
  * @example <EmailAddress name="Acme" email="hi@example.com" />
  * @see https://dhoulb.github.io/shelving/ui/block/Address/EmailAddress
  */

--- a/modules/ui/block/Block.tsx
+++ b/modules/ui/block/Block.tsx
@@ -49,6 +49,7 @@ export function getBlockClass(variants: BlockProps): string {
  * Plain `<div>` block with block-level spacing.
  * - Pass `as` to render a different semantic element (`section`, `header`, `footer`, `nav`, `aside`, `figure`).
  *
+ * @kind component
  * @example <Block><Paragraph>Hello</Paragraph></Block>
  * @example <Block as="aside" width="narrow"><Paragraph>Sidebar</Paragraph></Block>
  * @see https://dhoulb.github.io/shelving/ui/block/Block/Block

--- a/modules/ui/block/Blockquote.tsx
+++ b/modules/ui/block/Blockquote.tsx
@@ -18,6 +18,7 @@ export interface BlockquoteProps extends ColorVariants, SpaceVariants, Typograph
 /**
  * Quoted block of text — rendered as `<blockquote>`.
  *
+ * @kind component
  * @example <Blockquote>To be or not to be.</Blockquote>
  * @see https://dhoulb.github.io/shelving/ui/block/Blockquote/Blockquote
  */

--- a/modules/ui/block/Caption.tsx
+++ b/modules/ui/block/Caption.tsx
@@ -18,6 +18,7 @@ export interface CaptionProps extends ColorVariants, SpaceVariants, TypographyVa
 /**
  * `<figcaption>` block — caption text for a `<Figure>`.
  *
+ * @kind component
  * @example <Figure><Image src="/cat.jpg" /><Caption>A cat</Caption></Figure>
  * @see https://dhoulb.github.io/shelving/ui/block/Caption/Caption
  */

--- a/modules/ui/block/Definitions.tsx
+++ b/modules/ui/block/Definitions.tsx
@@ -21,6 +21,7 @@ export interface DefinitionsProps extends ColorVariants, GapVariants, SpaceVaria
  * - Children are raw `<dt>` / `<dd>` elements — `<dt>` is the term label, `<dd>` the value, stacked term-above-value.
  * - The spacing between pairs is overridable via the `--definitions-gap` hook.
  *
+ * @kind component
  * @example <Definitions><dt>Name</dt><dd>Acme</dd></Definitions>
  * @see https://dhoulb.github.io/shelving/ui/block/Definitions/Definitions
  */

--- a/modules/ui/block/Image.tsx
+++ b/modules/ui/block/Image.tsx
@@ -20,6 +20,7 @@ export interface ImageProps extends SpaceVariants, WidthVariants {
  * Image block — renders an `<img>` with space and width variants applied.
  *
  * @returns Rendered `<img>` element.
+ * @kind component
  * @example <Image src="/logo.png" alt="Logo" width="narrow" />
  * @see https://dhoulb.github.io/shelving/ui/block/Image/Image
  */

--- a/modules/ui/block/Label.tsx
+++ b/modules/ui/block/Label.tsx
@@ -21,6 +21,7 @@ export interface LabelProps extends SubheadingProps {}
  * - Default text properties for all of these can be controlled with global variables: `--size-label`, `--font-label`, `--case-label`.
  *
  * @returns Rendered `<h3>` label heading element.
+ * @kind component
  * @example <Label>Email address</Label>
  * @see https://dhoulb.github.io/shelving/ui/block/Label/Label
  */

--- a/modules/ui/block/Preformatted.tsx
+++ b/modules/ui/block/Preformatted.tsx
@@ -30,6 +30,7 @@ export interface PreformattedProps
  * - Pass `wrap` to wrap long lines instead; newlines and indentation are preserved either way.
  *
  * @returns Rendered `<pre>` element.
+ * @kind component
  * @example <Preformatted>{"line one\nline two"}</Preformatted>
  * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/Preformatted
  */

--- a/modules/ui/block/Video.tsx
+++ b/modules/ui/block/Video.tsx
@@ -40,6 +40,7 @@ export interface VideoButtonProps extends ChildProps {
  * - Shows its contents (i.e. a `<video>` element or a `<TwilioRoom>`.
  *
  * @returns Rendered `<figure>` video container.
+ * @kind component
  * @example <Video><video src="/clip.mp4" /></Video>
  * @see https://dhoulb.github.io/shelving/ui/block/Video/Video
  */
@@ -68,6 +69,7 @@ export function VideoButtons({ children, ...variants }: VideoButtonsProps) {
  * Individual video button over a video — renders a `<button>`.
  *
  * @returns Rendered `<button>` element overlaid on the video.
+ * @kind component
  * @example <VideoButton title="Play" onClick={play}><PlayIcon /></VideoButton>
  * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoButton
  */
@@ -96,6 +98,7 @@ export interface FullscreenVideoButtonProps {
  * - Tracks fullscreen state so the icon and title flip between enter/exit.
  *
  * @returns Rendered fullscreen toggle button, or `null` when fullscreen is unavailable.
+ * @kind component
  * @example <Video><video src="/clip.mp4" /><VideoButtons><FullscreenVideoButton /></VideoButtons></Video>
  * @see https://dhoulb.github.io/shelving/ui/block/Video/FullscreenVideoButton
  */

--- a/modules/ui/dialog/Dialog.tsx
+++ b/modules/ui/dialog/Dialog.tsx
@@ -67,6 +67,7 @@ export interface DialogCloseButtonProps extends ButtonVariants, OptionalChildPro
  * @param children Optional button content (defaults to an X icon).
  * @param variants Button styling variants.
  * @returns The close button element.
+ * @kind component
  * @example <DialogCloseButton plain />
  * @see https://dhoulb.github.io/shelving/ui/dialog/Dialog/DialogCloseButton
  */

--- a/modules/ui/dialog/Dialogs.tsx
+++ b/modules/ui/dialog/Dialogs.tsx
@@ -90,6 +90,7 @@ export interface DialogsProps {
  *
  * @param children The subtree that can open dialogs via `requireDialogs()`.
  * @returns The dialogs context provider wrapping `children`.
+ * @kind component
  * @example <DialogsContext><App /></DialogsContext>
  * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsContext
  */
@@ -101,6 +102,7 @@ export function DialogsContext({ children }: DialogsContextProps): ReactElement 
  * Render the open dialogs from the current `DialogsContext`.
  *
  * @returns The list of open dialog elements, or `null` when there are none.
+ * @kind component
  * @example <DialogsContext><App /><Dialogs /></DialogsContext>
  * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/Dialogs
  */

--- a/modules/ui/docs/DocumentationKind.tsx
+++ b/modules/ui/docs/DocumentationKind.tsx
@@ -49,6 +49,7 @@ export function getDocumentationKindColor(kind: string): ColorVariant | undefine
  * - Thin wrapper over [`<Tag>`](/ui/Tag) that maps the kind string to a raw colour variant.
  *
  * @returns A `<Tag>` showing the kind, tinted by its colour.
+ * @kind component
  * @example <DocumentationKind kind="function" />
  * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKind
  */

--- a/modules/ui/docs/DocumentationSignatures.tsx
+++ b/modules/ui/docs/DocumentationSignatures.tsx
@@ -19,6 +19,7 @@ export interface DocumentationSignaturesProps {
  * - Renders nothing when there are no signatures.
  *
  * @returns One [`<Preformatted>`](/ui/Preformatted) block per signature, or `null` when there are none.
+ * @kind component
  * @example <DocumentationSignatures signatures={["getArray<T>(arr: T[]): T"]} />
  * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationSignatures/DocumentationSignatures
  */

--- a/modules/ui/form/ArrayInput.tsx
+++ b/modules/ui/form/ArrayInput.tsx
@@ -30,6 +30,7 @@ export interface ArrayInputProps<T> extends ValueInputProps<ImmutableArray<T>> {
  * - Enforces `min`/`max` length and offers add, remove, and clear controls.
  *
  * @returns Element rendering one input row per array item plus add/clear controls.
+ * @kind component
  * @example <ArrayInput name="tags" items={STRING} value={tags} onValue={setTags} />
  * @see https://dhoulb.github.io/shelving/ui/form/ArrayInput/ArrayInput
  */

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -18,6 +18,7 @@ export interface ButtonInputProps extends InputProps, ClickableProps, FlexVarian
  * - Falls back to rendering the `placeholder` when no `children`/`title` content is supplied.
  *
  * @returns A [`Clickable`](/ui/Clickable) element styled with the button-input class.
+ * @kind component
  * @example <ButtonInput name="choose" onClick={open}>Choose…</ButtonInput>
  * @see https://dhoulb.github.io/shelving/ui/form/ButtonInput/ButtonInput
  */

--- a/modules/ui/form/ChoiceRadioInputs.tsx
+++ b/modules/ui/form/ChoiceRadioInputs.tsx
@@ -28,6 +28,7 @@ export interface ChoiceRadioInputsProps<T extends string> extends ValueInputProp
  * - A `placeholder` option is shown at the bottom if `required=false`.
  *
  * @returns Element rendering one radio per option plus an optional empty placeholder radio.
+ * @kind component
  * @example <ChoiceRadioInputs name="role" options={{ admin: "Admin", user: "User" }} value={role} onValue={setRole} />
  * @see https://dhoulb.github.io/shelving/ui/form/ChoiceRadioInputs/ChoiceRadioInputs
  */

--- a/modules/ui/form/Clickable.tsx
+++ b/modules/ui/form/Clickable.tsx
@@ -55,6 +55,7 @@ export interface StylableClickableProps extends ClickableProps {
  * Render either a `<button>`, an `<a href="">`, or a plain `<span>` based on whether an `onClick` or `href` prop is provided.
  * - `href` renders a `LinkClickable`; `onClick` renders a `ButtonClickable`; neither renders a `SpanClickable`.
  *
+ * @kind component
  * @example <Clickable href="/about">About</Clickable>
  * @example <Clickable onClick={save}>Save</Clickable>
  * @see https://dhoulb.github.io/shelving/ui/form/Clickable/Clickable

--- a/modules/ui/form/DataInput.tsx
+++ b/modules/ui/form/DataInput.tsx
@@ -22,6 +22,7 @@ export interface DataInputProps<T extends Data> extends ValueInputProps<T> {
  * - Each sub-field is keyed by its property name and validated using the matching schema in `props`.
  *
  * @returns Element rendering one input per property, laid out in a row or column.
+ * @kind component
  * @example <DataInput name="address" props={addressSchemas} value={address} onValue={setAddress} />
  * @see https://dhoulb.github.io/shelving/ui/form/DataInput/DataInput
  */

--- a/modules/ui/form/DictionaryInput.tsx
+++ b/modules/ui/form/DictionaryInput.tsx
@@ -33,6 +33,7 @@ export interface DictionaryInputProps<T> extends ValueInputProps<ImmutableDictio
  * - Enforces `min`/`max` entry count and offers add, remove, and clear controls.
  *
  * @returns Element rendering one key/value row per entry plus add/clear controls.
+ * @kind component
  * @example <DictionaryInput name="meta" items={STRING} value={meta} onValue={setMeta} />
  * @see https://dhoulb.github.io/shelving/ui/form/DictionaryInput/DictionaryInput
  */

--- a/modules/ui/form/FormFields.tsx
+++ b/modules/ui/form/FormFields.tsx
@@ -9,6 +9,7 @@ import { SchemaInput } from "./SchemaInput.js";
  * Show a [`<Field>`](/ui/Field) (label, input, and message) for a single named property of the current form.
  *
  * @returns A `<Field>` wrapping a [`SchemaInput`](/ui/SchemaInput) bound to the named field.
+ * @kind component
  * @example <FormField name="email" />
  * @see https://dhoulb.github.io/shelving/ui/form/FormFields/FormField
  */
@@ -27,6 +28,7 @@ export function FormField({ name, ...props }: InputProps): ReactElement {
  * Show a [`<Field>`](/ui/Field) for every property in the current form's schema.
  *
  * @returns A fragment of `FormField` elements, one per schema property.
+ * @kind component
  * @example <FormFields />
  * @see https://dhoulb.github.io/shelving/ui/form/FormFields/FormFields
  */

--- a/modules/ui/form/FormFooter.tsx
+++ b/modules/ui/form/FormFooter.tsx
@@ -20,6 +20,7 @@ export interface FormFooterProps extends OptionalChildProps {
  * - Renders a [`<FormMessage>`](/ui/FormMessage) beneath the buttons showing any error set on the form.
  *
  * @returns A footer element with the submit row and form message.
+ * @kind component
  * @example <FormFooter submit="Save" />
  * @see https://dhoulb.github.io/shelving/ui/form/FormFooter/FormFooter
  */

--- a/modules/ui/form/FormInput.tsx
+++ b/modules/ui/form/FormInput.tsx
@@ -15,6 +15,7 @@ export interface FormInputProps extends InputProps {}
  * - Reads the field's value, schema, and message from the form context via [`useField()`](/ui/useField).
  *
  * @returns A `SchemaInput` bound to the named field.
+ * @kind component
  * @example <FormInput name="email" />
  * @see https://dhoulb.github.io/shelving/ui/form/FormInput/FormInput
  */
@@ -27,6 +28,7 @@ export function FormInput({ name, ...props }: FormInputProps): ReactElement {
  * Show a [`SchemaInput`](/ui/SchemaInput) for every property in the current form's schema.
  *
  * @returns A fragment of `FormInput` elements, one per schema property.
+ * @kind component
  * @example <FormInputs />
  * @see https://dhoulb.github.io/shelving/ui/form/FormInput/FormInputs
  */

--- a/modules/ui/form/FormMessage.tsx
+++ b/modules/ui/form/FormMessage.tsx
@@ -8,6 +8,7 @@ import { requireForm } from "./FormContext.js";
  *
  * @param props Message props (excluding `children`) forwarded to the underlying `<Message>`.
  * @returns A `<Message status="error">` containing the message, or `null` when empty.
+ * @kind component
  * @example <FormMessage />
  * @see https://dhoulb.github.io/shelving/ui/form/FormMessage/FormMessage
  */

--- a/modules/ui/form/FormNotice.tsx
+++ b/modules/ui/form/FormNotice.tsx
@@ -8,6 +8,7 @@ import { requireForm } from "./FormContext.js";
  *
  * @param props Notice props (excluding `children`) forwarded to the underlying `<Notice>`.
  * @returns A `<Notice status="error">` containing the message, or `null` when empty.
+ * @kind component
  * @example <FormNotice />
  * @see https://dhoulb.github.io/shelving/ui/form/FormNotice/FormNotice
  */

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -60,6 +60,7 @@ export const LOADING_INPUT = <div className={getClass(getInputClass({}), getFlex
 /**
  * Wraps an input with support for absolutely-positioned `data-slot` icon elements on either side.
  * - This is so you can put an icon before or after an input.
+ * @kind component
  */
 export function InputWrapper({ children }: ChildProps): ReactElement {
 	return <div className={getClass(getInputClass({}), getModuleClass(INPUT_CSS, "wrapper"))}>{children}</div>;

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -17,6 +17,7 @@ export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVa
  * Show static read-only content styled as an input, falling back to `placeholder` when empty.
  *
  * @returns An `<output>` element styled like an input.
+ * @kind component
  * @example <OutputInput title="Status">Active</OutputInput>
  * @see https://dhoulb.github.io/shelving/ui/form/OutputInput/OutputInput
  */

--- a/modules/ui/form/Progress.tsx
+++ b/modules/ui/form/Progress.tsx
@@ -18,6 +18,7 @@ export interface ProgressProps {
  * Show progress as a single continuous horizontal bar, filled to `value` clamped between `0` and `1`.
  *
  * @returns A progress bar element.
+ * @kind component
  * @example <Progress value={0.5} />
  * @see https://dhoulb.github.io/shelving/ui/form/Progress/Progress
  */
@@ -57,6 +58,7 @@ export interface SegmentedProgressProps {
  * Show step progress as a horizontal bar of `total` segments, of which `current + 1` are filled.
  *
  * @returns A segmented progress bar element, or `null` when `total` is not positive.
+ * @kind component
  * @example <SegmentedProgress total={4} current={1} />
  * @see https://dhoulb.github.io/shelving/ui/form/Progress/SegmentedProgress
  */

--- a/modules/ui/form/SchemaInput.tsx
+++ b/modules/ui/form/SchemaInput.tsx
@@ -115,6 +115,7 @@ export interface DateSchemaInputProps extends SchemaInputProps<DateSchema, unkno
  * Show a [`DateInput`](/ui/DateInput) for a [`DateSchema`](/schema/DateSchema).
  *
  * @returns A `DateInput` element bound to the schema.
+ * @kind component
  * @example <DateSchemaInput name="dob" schema={DATE} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DateSchemaInput
  */
@@ -133,6 +134,7 @@ export interface NumberSchemaInputProps extends SchemaInputProps<NumberSchema, u
  * Show a [`NumberInput`](/ui/NumberInput) for a [`NumberSchema`](/schema/NumberSchema), formatting values with the schema's `format()`.
  *
  * @returns A `NumberInput` element bound to the schema.
+ * @kind component
  * @example <NumberSchemaInput name="age" schema={NUMBER} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/NumberSchemaInput
  */
@@ -151,6 +153,7 @@ export interface ChoiceSchemaInputProps extends SchemaInputProps<ChoiceSchema<st
  * Show a choice input for a [`ChoiceSchema`](/schema/ChoiceSchema) — radio inputs for up to 8 options, otherwise a select.
  *
  * @returns A [`ChoiceRadioInputs`](/ui/ChoiceRadioInputs) or [`SelectInput`](/ui/SelectInput) element bound to the schema.
+ * @kind component
  * @example <ChoiceSchemaInput name="role" schema={ROLE} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ChoiceSchemaInput
  */
@@ -171,6 +174,7 @@ export interface BooleanSchemaInputProps extends SchemaInputProps<BooleanSchema,
  * Show a [`CheckboxInput`](/ui/CheckboxInput) for a [`BooleanSchema`](/schema/BooleanSchema).
  *
  * @returns A `CheckboxInput` element bound to the schema.
+ * @kind component
  * @example <BooleanSchemaInput name="agree" schema={BOOLEAN} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/BooleanSchemaInput
  */
@@ -189,6 +193,7 @@ export interface StringSchemaInputProps extends SchemaInputProps<StringSchema, u
  * Show a [`TextInput`](/ui/TextInput) for a [`StringSchema`](/schema/StringSchema), sanitising and formatting values with the schema.
  *
  * @returns A `TextInput` element bound to the schema.
+ * @kind component
  * @example <StringSchemaInput name="email" schema={EMAIL} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/StringSchemaInput
  */
@@ -207,6 +212,7 @@ export interface ArraySchemaInputProps extends SchemaInputProps<ArraySchema<unkn
  * Show an [`ArrayInput`](/ui/ArrayInput) for an [`ArraySchema`](/schema/ArraySchema).
  *
  * @returns An `ArrayInput` element bound to the schema.
+ * @kind component
  * @example <ArraySchemaInput name="tags" schema={TAGS} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ArraySchemaInput
  */
@@ -225,6 +231,7 @@ export interface DictionarySchemaInputProps extends SchemaInputProps<DictionaryS
  * Show a [`DictionaryInput`](/ui/DictionaryInput) for a [`DictionarySchema`](/schema/DictionarySchema).
  *
  * @returns A `DictionaryInput` element bound to the schema.
+ * @kind component
  * @example <DictionarySchemaInput name="meta" schema={META} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DictionarySchemaInput
  */
@@ -243,6 +250,7 @@ export interface DataSchemaInputProps extends SchemaInputProps<DataSchema<Data>,
  * Show a [`DataInput`](/ui/DataInput) for a nested [`DataSchema`](/schema/DataSchema).
  *
  * @returns A `DataInput` element bound to the schema.
+ * @kind component
  * @example <DataSchemaInput name="address" schema={ADDRESS} />
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DataSchemaInput
  */
@@ -262,6 +270,7 @@ export interface SchemaFieldProps extends SchemaInputProps<Schema, unknown>, Opt
  * - Renders custom `children` inside the field, or a `SchemaInput` when none are provided.
  *
  * @returns A `<Field>` wrapping the schema's input.
+ * @kind component
  * @example <SchemaField name="email" schema={EMAIL} /> // Outputs a `<Field>` wrapping a `<TextInput>`.
  * @example <SchemaField name="age" schema={AGE} /> // Outputs a `<Field>` wrapping a `<NumberInput>`.
  * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/SchemaField

--- a/modules/ui/form/SelectInput.tsx
+++ b/modules/ui/form/SelectInput.tsx
@@ -20,6 +20,7 @@ export interface SelectProps<T extends string> extends ValueInputProps<T>, Input
  * - Shows a placeholder empty option unless the field is required and already has a value.
  *
  * @returns A `<select>` element.
+ * @kind component
  * @example <SelectInput name="role" options={ROLES} value={role} onValue={setRole} />
  * @see https://dhoulb.github.io/shelving/ui/form/SelectInput/SelectInput
  */

--- a/modules/ui/inline/Deleted.tsx
+++ b/modules/ui/inline/Deleted.tsx
@@ -16,6 +16,7 @@ export interface DeletedProps extends OptionalChildProps {}
  * Deleted text — renders a `<del>` element to mark content removed from a document.
  *
  * @returns Rendered `<del>` element.
+ * @kind component
  * @example <Deleted>old price</Deleted>
  * @see https://dhoulb.github.io/shelving/ui/inline/Deleted/Deleted
  */

--- a/modules/ui/inline/Emphasis.tsx
+++ b/modules/ui/inline/Emphasis.tsx
@@ -16,6 +16,7 @@ export interface EmphasisProps extends OptionalChildProps {}
  * Emphasised text — renders an `<em>` element for stress emphasis (typically italic).
  *
  * @returns Rendered `<em>` element.
+ * @kind component
  * @example <Emphasis>really</Emphasis>
  * @see https://dhoulb.github.io/shelving/ui/inline/Emphasis/Emphasis
  */

--- a/modules/ui/inline/Inserted.tsx
+++ b/modules/ui/inline/Inserted.tsx
@@ -16,6 +16,7 @@ export interface InsertedProps extends OptionalChildProps {}
  * Inserted text — renders an `<ins>` element to mark content added to a document.
  *
  * @returns Rendered `<ins>` element.
+ * @kind component
  * @example <Inserted>new price</Inserted>
  * @see https://dhoulb.github.io/shelving/ui/inline/Inserted/Inserted
  */

--- a/modules/ui/inline/Small.tsx
+++ b/modules/ui/inline/Small.tsx
@@ -16,6 +16,7 @@ export interface SmallProps extends OptionalChildProps {}
  * Small print — renders a `<small>` element for side comments and fine print.
  *
  * @returns Rendered `<small>` element.
+ * @kind component
  * @example <Small>Terms apply.</Small>
  * @see https://dhoulb.github.io/shelving/ui/inline/Small/Small
  */

--- a/modules/ui/inline/Subscript.tsx
+++ b/modules/ui/inline/Subscript.tsx
@@ -16,6 +16,7 @@ export interface SubscriptProps extends OptionalChildProps {}
  * Subscript text — renders a `<sub>` element for typographically lowered text (e.g. chemical formulae).
  *
  * @returns Rendered `<sub>` element.
+ * @kind component
  * @example <>H<Subscript>2</Subscript>O</>
  * @see https://dhoulb.github.io/shelving/ui/inline/Subscript/Subscript
  */

--- a/modules/ui/inline/Superscript.tsx
+++ b/modules/ui/inline/Superscript.tsx
@@ -16,6 +16,7 @@ export interface SuperscriptProps extends OptionalChildProps {}
  * Superscript text — renders a `<sup>` element for typographically raised text (e.g. exponents, footnote markers).
  *
  * @returns Rendered `<sup>` element.
+ * @kind component
  * @example <>E = mc<Superscript>2</Superscript></>
  * @see https://dhoulb.github.io/shelving/ui/inline/Superscript/Superscript
  */

--- a/modules/ui/inline/When.tsx
+++ b/modules/ui/inline/When.tsx
@@ -41,6 +41,7 @@ export interface WhenProps extends OptionalChildProps {
  *
  * @returns Rendered `<time>` element showing the relative time.
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
+ * @kind component
  * @example <When target="2030-01-01" />
  * @see https://dhoulb.github.io/shelving/ui/inline/When/When
  */
@@ -60,6 +61,7 @@ export interface AgoProps extends WhenProps {}
  *
  * @returns Rendered `<time>` element showing the elapsed time.
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
+ * @kind component
  * @example <Ago target="2020-01-01" />
  * @see https://dhoulb.github.io/shelving/ui/inline/When/Ago
  */
@@ -79,6 +81,7 @@ export interface UntilProps extends WhenProps {}
  *
  * @returns Rendered `<time>` element showing the remaining time.
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
+ * @kind component
  * @example <Until target="2030-01-01" />
  * @see https://dhoulb.github.io/shelving/ui/inline/When/Until
  */

--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -36,6 +36,7 @@ const RETRY_CHILDREN = (
  * - Defaults to an "Retry" label with a refresh icon; pass `children` to override.
  *
  * @returns The retry button, or `null` when not inside a `<Catcher>`.
+ * @kind component
  * @example <RetryButton small />
  * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/RetryButton
  */
@@ -122,6 +123,7 @@ export interface PageCatcherProps extends ChildProps {}
  *
  * @param children The page content to guard.
  * @returns A `<Catcher>` configured to render `<ErrorPage>` on error.
+ * @kind component
  * @example <PageCatcher><SettingsPage /></PageCatcher>
  * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/PageCatcher
  */
@@ -143,6 +145,7 @@ export interface ErrorNoticeProps extends ErrorComponentProps {}
  *
  * @param reason The caught error to display.
  * @returns An error `<Notice>` containing the message and a `<RetryButton>`.
+ * @kind component
  * @example <ErrorNotice reason={thrown} />
  * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorNotice
  */
@@ -170,6 +173,7 @@ export interface ErrorPageProps extends ErrorComponentProps {}
  *
  * @param reason The caught error to display.
  * @returns A centered error page containing the message and a `<RetryButton>`.
+ * @kind component
  * @example <ErrorPage reason={thrown} />
  * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorPage
  */

--- a/modules/ui/style/Flex.tsx
+++ b/modules/ui/style/Flex.tsx
@@ -96,6 +96,7 @@ export interface RowProps extends FlexVariants, OptionalChildProps {}
  *
  * @param variants
  * @returns A `<div>` element with the computed flex class.
+ * @kind component
  * @example <Row gap="small" center>{items}</Row>
  * @see https://dhoulb.github.io/shelving/ui/style/Flex/Row
  */
@@ -115,6 +116,7 @@ export interface ColumnProps extends FlexVariants, OptionalChildProps {}
  *
  * @param variants
  * @returns A `<div>` element with the computed flex class.
+ * @kind component
  * @example <Column gap="small">{items}</Column>
  * @see https://dhoulb.github.io/shelving/ui/style/Flex/Column
  */

--- a/modules/ui/style/Scroll.tsx
+++ b/modules/ui/style/Scroll.tsx
@@ -44,6 +44,7 @@ export interface ScrollComponentProps extends ChildProps, ScrollVariants {}
  * Wrap children in a scrollable container with horizontal and/or vertical scrolling enabled.
  *
  * @returns A `<div>` element with the computed scroll class.
+ * @kind component
  * @example <Scroll horizontal>{wideContent}</Scroll>
  * @see https://dhoulb.github.io/shelving/ui/style/Scroll/Scroll
  */

--- a/modules/ui/tree/TreeBreadcrumbs.tsx
+++ b/modules/ui/tree/TreeBreadcrumbs.tsx
@@ -27,6 +27,7 @@ export interface TreeBreadcrumbsProps extends TypographyVariants, SpaceVariants,
  * - Renders nothing at the tree root (no ancestors) or when there's no [`<TreeProvider>`](/ui/TreeProvider) to resolve labels from.
  *
  * @returns A `<nav>` of breadcrumb links, or `null` at the tree root.
+ * @kind component
  * @example <TreeBreadcrumbs />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeBreadcrumbs/TreeBreadcrumbs
  */

--- a/modules/ui/tree/TreeButton.tsx
+++ b/modules/ui/tree/TreeButton.tsx
@@ -22,6 +22,7 @@ export interface TreeButtonProps extends ButtonVariants {
  * - Defaults to `small plain` styling; pass other [`ButtonVariants`](/ui/ButtonVariants) to override.
  *
  * @returns A [`<Button>`](/ui/Button) element linking to the resolved element, or a plain label on a miss.
+ * @kind component
  * @example <TreeButton name="Store.get">Store.get()</TreeButton>
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeButton/TreeButton
  */

--- a/modules/ui/tree/TreeCard.tsx
+++ b/modules/ui/tree/TreeCard.tsx
@@ -8,6 +8,7 @@ import { Subheading } from "../block/Subheading.js";
  * Card renderer for a generic `tree-element` (a directory or file) — a summary card showing the heading and description.
  *
  * @returns A [`<Card>`](/ui/Card) linking to the element's canonical `path`.
+ * @kind component
  * @example <TreeCard {...element.props} />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeCard/TreeCard
  */

--- a/modules/ui/tree/TreeCards.tsx
+++ b/modules/ui/tree/TreeCards.tsx
@@ -32,6 +32,7 @@ export interface TreeCardsProps {
  * - To override the renderer for a specific element type, wrap in `<TreeCardMapping mapping={…}>`.
  *
  * @returns A `<TreeCardMapper>` rendering each element as a card.
+ * @kind component
  * @example <TreeCards>{element.props.children}</TreeCards>
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeCards/TreeCards
  */

--- a/modules/ui/tree/TreeContext.tsx
+++ b/modules/ui/tree/TreeContext.tsx
@@ -19,6 +19,7 @@ TreeContext.displayName = "TreeContext";
  *
  * @param props The `tree` to flatten and provide, plus `children`.
  * @returns A [`<TreeContext>`](/ui/TreeContext) provider wrapping the children with the flattened map.
+ * @kind component
  * @example <TreeProvider tree={tree}>{children}</TreeProvider>
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/TreeProvider
  */

--- a/modules/ui/tree/TreeMenu.tsx
+++ b/modules/ui/tree/TreeMenu.tsx
@@ -37,6 +37,7 @@ interface TreeMenuExtras {
  *
  * @param props The tree element props plus the parent's `path`.
  * @returns A `<MenuItem>` for the element, with a nested [`<Menu>`](/ui/Menu) when it has menu-eligible children.
+ * @kind component
  * @example <TreeMenuItem {...element.props} path="/" />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/TreeMenuItem
  */

--- a/modules/ui/tree/TreePage.tsx
+++ b/modules/ui/tree/TreePage.tsx
@@ -14,6 +14,7 @@ import { TreeCards } from "./TreeCards.js";
  * - Child cards cover both nested directories/files and the code symbols of a source file.
  *
  * @returns A [`<Page>`](/ui/Page) with the title, prose content, and a stack of child cards.
+ * @kind component
  * @example <TreePage {...element.props} />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreePage/TreePage
  */

--- a/modules/ui/tree/TreeRouter.tsx
+++ b/modules/ui/tree/TreeRouter.tsx
@@ -45,6 +45,7 @@ export interface TreeRouterProps extends PossibleMeta {
  *
  * @returns The resolved element rendered as a page, or the `fallback`.
  * @throws [`NotFoundError`](/error/NotFoundError) When no element matches the URL and no `fallback` is given.
+ * @kind component
  * @example <TreeRouter tree={tree} />
  * @see https://dhoulb.github.io/shelving/ui/tree/TreeRouter/TreeRouter
  */


### PR DESCRIPTION
Follow-up to #198. The link/style audit surfaced a source-level conformance gap: many reusable React components are missing the `@kind component` docblock tag, so the docs extractor classified them as plain **functions** rather than **components** (wrong grouping/colour on the docs site).

## What this does

Adds `@kind component` to **68 component exports** across the `ui` module that were missing it. Every tagged symbol is a PascalCase function returning `ReactElement` / `ReactNode` and used as JSX. Helper functions that happen to share a component file (e.g. `getButtonClass`, `getFlexClass`) are deliberately left untagged, per the rule in `AGENTS.md`:

> Every reusable component carries a `@kind component` tag in its docblock so the docs extractor labels it as a `component` rather than a `function`… Helper functions that happen to live in a component file stay plain functions — no `@kind`.

After this change, an audit of the whole `ui` module reports **124/124 components tagged, 0 missing**.

## Scope

Comment-only change — **68 insertions, 0 deletions, no code touched**. The tag is placed just before the first `@example` (or `@see`) in each docblock, matching the existing convention (`Button`, `Tag`, `Section`, etc.). `component` is already a documented kind, so no `DocumentationKind` / `KIND_SECTIONS` changes are needed.

Components tagged, by folder:

- **block**: `Block`, `Blockquote`, `Caption`, `Definitions`, `Image`, `Label`, `Preformatted`, `Video`, `VideoButton`, `FullscreenVideoButton`, `PhysicalAddress`, `EmailAddress`
- **inline**: `Deleted`, `Emphasis`, `Inserted`, `Small`, `Subscript`, `Superscript`, `When`, `Ago`, `Until`
- **form**: `ArrayInput`, `ButtonInput`, `ChoiceRadioInputs`, `Clickable`, `DataInput`, `DictionaryInput`, `FormField`, `FormFields`, `FormFooter`, `FormInput`, `FormInputs`, `FormMessage`, `FormNotice`, `InputWrapper`, `OutputInput`, `Progress`, `SegmentedProgress`, `SelectInput`, the `*SchemaInput` family, `SchemaField`
- **dialog**: `DialogCloseButton`, `DialogsContext`, `Dialogs`
- **docs**: `DocumentationKind`, `DocumentationSignatures`
- **misc**: `RetryButton`, `PageCatcher`, `ErrorNotice`, `ErrorPage`
- **style**: `Row`, `Column`, `Scroll`
- **tree**: `TreeBreadcrumbs`, `TreeButton`, `TreeCard`, `TreeCards`, `TreeProvider`, `TreeMenuItem`, `TreePage`, `TreeRouter`

A docs-site preview will be generated by the `docs.yaml` workflow so the recategorised symbols can be eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxvN5noUD8DHtz3dC7qQvc)_