### PR TITLE
Scope docs deploy concurrency per PR

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,11 +16,19 @@ on:
     types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
-# Serialize every run onto a single queue. All runs publish to the `docs`
-# branch, so they must not race; and a PR-close cleanup run must never cancel
-# the main-branch deploy that publishes the site root.
+# Scope concurrency per PR (and per ref for branch pushes) so one PR's build — or `main`'s — never
+# supersedes another's. A single shared group meant only the newest *pending* run survived, so a PR
+# whose build was still queued got silently dropped whenever anything else pushed.
+# - `github.event.pull_request.number` keys every event of a PR (open/sync/reopen/close) to the same
+#   group; `github.ref` keys branch pushes (e.g. `main`) to their own. A PR-close cleanup therefore
+#   shares only that PR's group and can never cancel the `main` deploy.
+# - `cancel-in-progress: false` still never interrupts an in-progress publish mid-push; within a group,
+#   rapid pushes simply collapse to the latest commit.
+# Trade-off: different groups can now run concurrently, so two publishes could race on the push to the
+# shared `docs` branch. Each writes its own directory (`pr-<n>/` or the root) with `keep_files: true`,
+# so the only conflict is the git push itself — rare given build times, and recoverable by a re-run.
 concurrency:
-  group: docs
+  group: docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem

The Docs workflow used a single global concurrency group:

```yaml
concurrency:
  group: docs
  cancel-in-progress: false
```

Every PR build **and** the `main` deploy shared this one group. GitHub keeps only the **newest pending run** per group and cancels older pending ones — so a PR whose build was still queued got **silently dropped** the moment anything else pushed (another PR, a `main` merge, even a rapid follow-up push on the same PR). The result: previews that never deploy until someone pushes again. (Hit this on #200 — an intermediate commit's build was superseded and never published.)

## Fix

Key the group by PR number (and by ref for branch pushes):

```yaml
concurrency:
  group: docs-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: false
```

- Each PR gets its own group (`docs-<number>`), `main` gets `docs-refs/heads/main` — they no longer supersede each other.
- `cancel-in-progress: false` is kept, so an in-progress publish is never interrupted mid-push; within a single group, rapid pushes still collapse to the latest commit (which is what you want).
- The original shared queue existed partly so a PR-close cleanup couldn't cancel the `main` deploy. That's now handled by the grouping itself — a close event for PR N lands in `docs-<N>`, never `main`'s group.

## Trade-off

Different groups can now run concurrently, so two publishes *could* race on the `git push` to the shared `docs` branch. Each writes its own directory (`pr-<n>/` or the root) with `keep_files: true`, so the only possible conflict is the push itself — rare given ~30-60s builds, and recoverable by a re-run. If it ever bites in practice, the follow-up is to add pull-before-push retry to the publish step; happy to do that if you'd prefer the belt-and-suspenders version now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012xdzsewNHtmuQevKmD7LGM)_