### PR TITLE
fix: normalise trailing slash in matchURLPrefix so `/foo/` matches the same route as `/foo`

### DIFF
--- a/modules/ui/misc/MetaContext.test.tsx
+++ b/modules/ui/misc/MetaContext.test.tsx
@@ -29,6 +29,16 @@ describe("requireMetaURL", () => {
 		expect(html).toBe("/");
 	});
 
+	test("normalizes a trailing slash on the url away", () => {
+		// `/enquiry/loan/` resolves to the same path as `/enquiry/loan`, so trailing-slash URLs match the same route.
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/", url: "http://x.com/enquiry/loan/" })}>
+				<Probe />
+			</MetaContext>,
+		);
+		expect(html).toBe("/enquiry/loan");
+	});
+
 	test("throws RequiredError when url is unset", () => {
 		expect(() => renderToStaticMarkup(<Probe />)).toThrow(RequiredError);
 	});

--- a/modules/ui/router/Router.test.tsx
+++ b/modules/ui/router/Router.test.tsx
@@ -3,10 +3,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MetaContext } from "../misc/MetaContext.js";
 import { createMeta } from "../util/meta.js";
 import { Router } from "./Router.js";
+import type { RouteProps } from "./Routes.js";
 
 const ROUTES = {
 	"/": () => <main>Home</main>,
 	"/about": () => <main>About</main>,
+	"/enquiry/{form}": ({ form }: RouteProps) => <main>Enquiry {form}</main>,
 } as const;
 
 function render(url: string) {
@@ -24,5 +26,12 @@ describe("Router", () => {
 
 	test("throws when no route matches and no fallback is given", () => {
 		expect(() => render("./missing")).toThrow();
+	});
+
+	test("matches a route when the url has a trailing slash", () => {
+		// A trailing slash on the url resolves to the same route as the slash-less form.
+		expect(render("http://x.com/about/")).toContain("About");
+		expect(render("http://x.com/enquiry/loan")).toContain("Enquiry loan");
+		expect(render("http://x.com/enquiry/loan/")).toContain("Enquiry loan");
 	});
 });

--- a/modules/util/url.md
+++ b/modules/util/url.md
@@ -44,6 +44,9 @@ import { matchURLPrefix } from "shelving/util";
 matchURLPrefix("https://example.com/app/page", "https://example.com/app");
 // "/page"  (path after the base)
 
+matchURLPrefix("https://example.com/app/page/", "https://example.com/app");
+// "/page"  (trailing slash normalised away, so `/page` and `/page/` resolve the same)
+
 matchURLPrefix("https://example.com/other", "https://example.com/app");
 // undefined  (no match)
 

--- a/modules/util/url.test.ts
+++ b/modules/util/url.test.ts
@@ -96,6 +96,15 @@ describe("matchURLPrefix()", () => {
 		expect(matchURLPrefix("def", "https://x.com/abc")).toBe("/def");
 		expect(matchURLPrefix("https://x.com/abc", "https://x.com/abc")).toBe("/");
 	});
+
+	test("normalizes a trailing slash on the target away", () => {
+		// A trailing slash on the target resolves to the same path as the slash-less form.
+		expect(matchURLPrefix("https://x.com/enquiry/loan/", "https://x.com/")).toBe("/enquiry/loan");
+		expect(matchURLPrefix("https://x.com/enquiry/loan", "https://x.com/")).toBe("/enquiry/loan");
+		expect(matchURLPrefix("https://x.com/abc/def/", "https://x.com/abc/")).toBe("/def");
+		// The root `/` is preserved (it doesn't collapse to an empty string).
+		expect(matchURLPrefix("https://x.com/", "https://x.com/")).toBe("/");
+	});
 });
 describe("isURLActive()", () => {
 	test("true when target equals base (after resolution)", () => {

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -1,7 +1,7 @@
 import { RequiredError } from "../error/RequiredError.js";
 import type { AnyCaller } from "./function.js";
 import type { Nullish } from "./null.js";
-import type { AbsolutePath } from "./path.js";
+import { type AbsolutePath, cleanPath } from "./path.js";
 import type { ImmutableURI } from "./uri.js";
 
 /**
@@ -166,6 +166,7 @@ export function requireURL(target: PossibleURL, base?: PossibleURL, caller: AnyC
  * - Need to be valid _URLs_ not just _URIs_, i.e. needs to have `protocol://` at the start.
  * - Origins need to match, i.e. `http://localhost` !== `http://localhost:4020`
  * - Relative targets are resolved against the normalized base URL.
+ * - The resolved target pathname is normalised with `cleanPath()` — runs of slashes are collapsed and a trailing slash is stripped (the root `/` is preserved) — so `/foo` and `/foo/` resolve to the same path. This mirrors the path-based sibling `matchPathPrefix()`.
  *
  * @param target URL to match against `base` — if this is a relative path it will be resolved against `base`
  * @param base Base URL the `target` is matched against.
@@ -175,6 +176,7 @@ export function requireURL(target: PossibleURL, base?: PossibleURL, caller: AnyC
  * @throws RequiredError If `target` or `base` cannot be resolved to a true URL.
  *
  * @example matchURLPrefix("http://x.com/a/b", "http://x.com/a/"); // `/b`
+ * @example matchURLPrefix("http://x.com/a/b/", "http://x.com/a/"); // `/b` (trailing slash normalised away)
  *
  * @see https://dhoulb.github.io/shelving/util/url/matchURLPrefix
  */
@@ -188,7 +190,7 @@ export function matchURLPrefix(
 	const targetURL = requireURL(target, baseURL, caller);
 	if (targetURL.origin !== baseURL.origin) return;
 	const basePath = baseURL.pathname;
-	const targetPath = targetURL.pathname;
+	const targetPath = cleanPath(targetURL.pathname);
 	if (basePath === "/") return targetPath;
 	// `basePath` may or may not have a trailing slash, so strip it and re-assert the directory boundary explicitly.
 	const bareBase = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;


### PR DESCRIPTION
`matchURLPrefix()` returned the target pathname verbatim, so a trailing
slash leaked through to `matchPathTemplate()` where it is significant: a
URL like `/enquiry/loan/` failed to match the route `/enquiry/{form}`
(the `{form}` placeholder captured `loan/`, which spans a separator) and
`<Router>` threw `NotFoundError`. The same latent bug affected API
endpoint routing via `handleEndpoints()`.

Normalise the resolved target pathname with the existing `cleanPath()`
helper (strips a trailing slash, preserves the root `/`, collapses
runs of slashes), bringing `matchURLPrefix()` in line with its
path-based sibling `matchPathPrefix()`, which already normalises via
`requirePath()`. Fixing it once at the URL → path boundary means
`/foo` and `/foo/` resolve identically for every consumer — the UI
`<Router>`, API endpoints, and `isURLActive()` / `isURLProud()` — and
route tables stay simple.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BPmHVTZBySGxcu3Toh9swU