### PR TITLE
docs: migrate @see links to shelving.cc with package-level paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Before writing new code, find what already exists. The codebase deliberately exp
 ## Pull Requests
 
 - Every PR that resolves a tracked issue **must** link it in the PR description with a [closing keyword](https://docs.github.com/articles/closing-issues-using-keywords) — `Closes #123` / `Fixes #123` — so GitHub closes the issue automatically when the PR merges. List every issue the PR resolves, one keyword each. This is mandatory: never rely on closing issues by hand after merge.
-- **Open a PR proactively** once a change is in a reviewable state — don't wait to be asked. This is the normal way work is shared here, and it's especially important for **documentation-site changes**: the `docs.yaml` workflow builds a live preview for every PR at `https://dhoulb.github.io/shelving/pr-<number>/` (and comments the link on the PR), which is the only way to eyeball the rendered docs. Any change touching `modules/ui/**`, `modules/extract/**`, `modules/markup/**`, the per-symbol `.md` pages, or docblocks should go up as a PR so the preview is generated.
+- **Open a PR proactively** once a change is in a reviewable state — don't wait to be asked. This is the normal way work is shared here, and it's especially important for **documentation-site changes**: the `docs.yaml` workflow builds a live preview for every PR at `https://shelving.cc/pr-<number>/` (and comments the link on the PR), which is the only way to eyeball the rendered docs. Any change touching `modules/ui/**`, `modules/extract/**`, `modules/markup/**`, the per-symbol `.md` pages, or docblocks should go up as a PR so the preview is generated.
 
 ## Naming
 
@@ -425,6 +425,14 @@ Checklist:
 - Each module has a `README.md` that acts as the module's guide page. It covers **purpose, key concepts, and integration examples** — how to combine the module's classes and functions to accomplish real tasks (and, for families like `error`, shared traits). When module behaviour changes, check whether the README needs updating
 - **Per-class / per-function usage examples** live in a sibling `MyClass.md` / `myFunction.md` next to the source file. `DirectoryExtractor` merges that markdown onto the symbol's own page (`MarkupExtractor` outranks `TypescriptExtractor`), so detailed usage belongs there rather than in the module README. `modules/util/template.md` is the precedent. This applies to UI components too — each reusable component gets a sibling `.md` (`Card.md` next to `Card.tsx`) with usage examples and a **Styling** section (see below)
 - Trust source and tests over README if they conflict — but fix the README rather than leaving it wrong
+
+### Docs site
+
+The public docs live at **`https://shelving.cc/`** — every public token ships as a page, and each module / per-symbol `.md` is merged onto it (see below).
+
+- The site is built by the `docs.yaml` workflow (`bun run docs:build`) and published to the `docs` branch, which GitHub Pages serves from the `shelving.cc` custom domain. The workflow writes the `CNAME` file at publish time (the `cname:` option on the deploy step), so there is no `CNAME` committed in the repo.
+- A push to `main` publishes to the site root; each PR publishes a preview under `pr-<number>/`, so `https://shelving.cc/pr-<number>/` is the live preview for that PR (linked from the PR's `docs-preview` deployment — see [Pull Requests](#pull-requests)).
+- Page URLs are **package-relative**, not source-path-relative: a token's canonical page is `https://shelving.cc/<package>/<name>`, where `<package>` is its `package.json` export subpath. This is the same scheme the `@see` block tags use — see the [docblock standards](#docblock-standards) for the exact rule.
 
 ### Cross-references and token display
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,7 +459,7 @@ This applies to **"See also" lists** and **inline references** alike. There's no
 - **Descriptive prose phrases** that point at a page but aren't a token name — e.g. linking the words "tint ladder" to a page.
 - **CSS custom properties** (`--tint-90`, `--space-paragraph`) are **not** tree tokens and never auto-link. Write them as plain backtick code (`` `--tint-90` ``); the Styling-table prose around them names the owning `get*Class` helper as an ordinary backtick reference, which does link.
 
-**`@see` block tags are unaffected** — they still carry the full `https://dhoulb.github.io/shelving/<path>/<name>` URL (see the docblock standards below), since IDE hover needs an absolute link, not a docs-site-relative one.
+**`@see` block tags are unaffected** — they still carry the full `https://shelving.cc/<package>/<name>` URL (see the docblock standards below), since IDE hover needs an absolute link, not a docs-site-relative one.
 
 ### UI component pages and CSS-variable documentation
 
@@ -490,7 +490,7 @@ For convenience the `schema` module ships **sugar** — pre-built shortcuts that
    * Sugar instance of `StringSchema` for an unconstrained string. Equivalent to `new StringSchema({})`.
    *
    * @example STRING.validate(123); // Returns "123"
-   * @see https://dhoulb.github.io/shelving/schema/StringSchema/STRING
+   * @see https://shelving.cc/schema/STRING
    */
   export const STRING = new StringSchema({});
   ```
@@ -528,10 +528,10 @@ Every public token now ships as a page on the docs site, so docblock quality dir
 - **`@see` docs-site link.** Every token published on the docs site gets a `@see` block tag pointing at its page, so VS Code hover reveals a clickable link. Prefer the `@see` block tag over inline `{@link}` — it renders better in the hover popup. The URL pattern mirrors the docs-site routing:
 
   ```
-  @see https://dhoulb.github.io/shelving/<path>/<name>
+  @see https://shelving.cc/<package>/<name>
   ```
 
-  where `<path>` is the source file's path relative to `modules/` with the extension dropped, and `<name>` is the exported symbol. So `modules/schema/BooleanSchema.ts`'s `BooleanSchema` class → `https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchema`; `modules/util/array.ts`'s `getArray` → `https://dhoulb.github.io/shelving/util/array/getArray`; a class member appends its own name → `.../schema/BooleanSchema/BooleanSchema/validate`.
+  where `<package>` is the symbol's **package export subpath** — the entry it's published under in `package.json` `exports`, which is the top-level module folder (`schema`, `db`, `store`, `ui`, …) for single-index packages, or `util/<file>` and `firestore/<client|lite|server>` for the wildcard / multi-entry exports — and `<name>` is the exported symbol. The deeper source-file path collapses to that package subpath. So `modules/schema/BooleanSchema.ts`'s `BooleanSchema` class → `https://shelving.cc/schema/BooleanSchema`; `modules/db/store/QueryStore.ts`'s `QueryStore` → `https://shelving.cc/db/QueryStore`; `modules/util/array.ts`'s `getArray` → `https://shelving.cc/util/array/getArray`; a class member appends its own name → `https://shelving.cc/schema/BooleanSchema/validate`.
 
 Example shape:
 
@@ -542,6 +542,6 @@ Example shape:
  * @param arr The array to read from.
  * @returns The first item, or `undefined` when the array is empty.
  * @example getArray(["a", "b"]) // "a"
- * @see https://dhoulb.github.io/shelving/util/array/getArray
+ * @see https://shelving.cc/util/array/getArray
  */
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TypeScript data toolkit — schema validation, database and API providers, obser
 
 ## Documentation
 
-Full documentation is published at **<https://dhoulb.github.io/shelving/>**.
+Full documentation is published at **<https://shelving.cc/>**.
 
 ```sh
 npm install shelving

--- a/modules/api/cache/APICache.ts
+++ b/modules/api/cache/APICache.ts
@@ -15,7 +15,7 @@ import { EndpointCache } from "./EndpointCache.js";
  * const cache = new APICache(provider);
  * const user = await cache.call(getUser, { id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache
+ * @see https://shelving.cc/api/APICache
  */
 export class APICache<P, R> implements AsyncDisposable {
 	private readonly _endpoints = new Map<Endpoint, EndpointCache>();
@@ -23,7 +23,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	/**
 	 * The underlying `APIProvider` that backs every cached endpoint.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/provider
+	 * @see https://shelving.cc/api/APICache/provider
 	 */
 	readonly provider: APIProvider<P, R>;
 
@@ -32,7 +32,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 *
 	 * @param provider The `APIProvider` used to fetch results for every cached endpoint.
 	 * @example new APICache(provider)
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache
+	 * @see https://shelving.cc/api/APICache
 	 */
 	constructor(provider: APIProvider<P, R>) {
 		this.provider = provider;
@@ -49,7 +49,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 * @param endpoint The endpoint whose `EndpointCache` should be returned.
 	 * @returns The existing `EndpointCache` for `endpoint`, or a newly created one.
 	 * @example cache.get(getUser).get({ id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/get
+	 * @see https://shelving.cc/api/APICache/get
 	 */
 	get<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>): EndpointCache<PP, RR>;
 	get(endpoint: Endpoint): EndpointCache {
@@ -69,7 +69,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 * @returns The cached or freshly fetched result.
 	 * @throws Whatever `APIProvider.call` throws if the fetch fails.
 	 * @example await cache.call(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/call
+	 * @see https://shelving.cc/api/APICache/call
 	 */
 	async call<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -86,7 +86,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 * @param endpoint The endpoint whose cached payload should be invalidated.
 	 * @param payload The payload identifying the specific store to invalidate.
 	 * @example cache.invalidate(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/invalidate
+	 * @see https://shelving.cc/api/APICache/invalidate
 	 */
 	invalidate<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP): void {
 		this._get(endpoint)?.invalidate(payload);
@@ -97,7 +97,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 *
 	 * @param endpoint The endpoint whose stores should all be invalidated.
 	 * @example cache.invalidateAll(getUser)
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/invalidateAll
+	 * @see https://shelving.cc/api/APICache/invalidateAll
 	 */
 	invalidateAll<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>): void {
 		this._get(endpoint)?.invalidateAll();
@@ -110,7 +110,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 * @param payload The payload identifying the specific store to refresh.
 	 * @param maxAge The maximum age in milliseconds before a refetch is triggered.
 	 * @example cache.refresh(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/refresh
+	 * @see https://shelving.cc/api/APICache/refresh
 	 */
 	refresh<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, maxAge?: number): void {
 		this._get(endpoint)?.refresh(payload, maxAge);
@@ -122,7 +122,7 @@ export class APICache<P, R> implements AsyncDisposable {
 	 * @param endpoint The endpoint whose stores should all be refreshed.
 	 * @param maxAge The maximum age in milliseconds before a refetch is triggered.
 	 * @example cache.refreshAll(getUser)
-	 * @see https://dhoulb.github.io/shelving/api/cache/APICache/APICache/refreshAll
+	 * @see https://shelving.cc/api/APICache/refreshAll
 	 */
 	refreshAll<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, maxAge?: number): void {
 		this._get(endpoint)?.refreshAll(maxAge);

--- a/modules/api/cache/EndpointCache.ts
+++ b/modules/api/cache/EndpointCache.ts
@@ -16,7 +16,7 @@ import { EndpointStore } from "../store/EndpointStore.js";
  * const cache = new EndpointCache(getUser, provider);
  * const user = await cache.call({ id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache
+ * @see https://shelving.cc/api/EndpointCache
  */
 export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable {
 	private readonly _endpoints = new Map<string, EndpointStore<P, R>>();
@@ -24,14 +24,14 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	/**
 	 * The endpoint that every store in this cache fetches from.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/endpoint
+	 * @see https://shelving.cc/api/EndpointCache/endpoint
 	 */
 	readonly endpoint: Endpoint<P, R>;
 
 	/**
 	 * The `APIProvider` used to render URLs and fetch results for this endpoint.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/provider
+	 * @see https://shelving.cc/api/EndpointCache/provider
 	 */
 	readonly provider: APIProvider<P, R>;
 
@@ -41,7 +41,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @param endpoint The endpoint that every cached store fetches from.
 	 * @param provider The `APIProvider` used to render URLs and fetch results.
 	 * @example new EndpointCache(getUser, provider)
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache
+	 * @see https://shelving.cc/api/EndpointCache
 	 */
 	constructor(endpoint: Endpoint<P, R>, provider: APIProvider<P, R>) {
 		this.endpoint = endpoint;
@@ -56,7 +56,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns The existing `EndpointStore` for `payload`, or a newly created one.
 	 * @example cache.get({ id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/get
+	 * @see https://shelving.cc/api/EndpointCache/get
 	 */
 	get(payload: P, caller: AnyCaller = this.get): EndpointStore<P, R> {
 		const url = this.provider.renderURL(this.endpoint, payload, caller).href;
@@ -75,7 +75,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @returns The cached or freshly fetched result.
 	 * @throws Whatever `APIProvider.call` throws if the fetch fails.
 	 * @example await cache.call({ id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/call
+	 * @see https://shelving.cc/api/EndpointCache/call
 	 */
 	async call(payload: P, maxAge: number = AVOID_REFRESH, caller: AnyCaller = this.call): Promise<R> {
 		const store = this.get(payload, caller);
@@ -89,7 +89,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @param payload The payload identifying the store to invalidate.
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @example cache.invalidate({ id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/invalidate
+	 * @see https://shelving.cc/api/EndpointCache/invalidate
 	 */
 	invalidate(payload: P, caller: AnyCaller = this.invalidate): void {
 		this.get(payload, caller)?.invalidate();
@@ -99,7 +99,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * Invalidate all stores so the next read of any payload refetches.
 	 *
 	 * @example cache.invalidateAll()
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/invalidateAll
+	 * @see https://shelving.cc/api/EndpointCache/invalidateAll
 	 */
 	invalidateAll(): void {
 		for (const store of this._endpoints.values()) store.invalidate();
@@ -113,7 +113,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns A promise that resolves when the refetch settles.
 	 * @example await cache.refresh({ id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/refresh
+	 * @see https://shelving.cc/api/EndpointCache/refresh
 	 */
 	async refresh(payload: P, maxAge?: number, caller: AnyCaller = this.invalidate): Promise<void> {
 		await this.get(payload, caller)?.refresh(maxAge);
@@ -125,7 +125,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @param maxAge The maximum age in milliseconds before a refetch is triggered.
 	 * @returns A promise that resolves when every refetch settles.
 	 * @example await cache.refreshAll()
-	 * @see https://dhoulb.github.io/shelving/api/cache/EndpointCache/EndpointCache/refreshAll
+	 * @see https://shelving.cc/api/EndpointCache/refreshAll
 	 */
 	async refreshAll(maxAge?: number): Promise<void> {
 		await awaitValues(...this._endpoints.values().map(store => store.refresh(maxAge)));

--- a/modules/api/endpoint/Endpoint.ts
+++ b/modules/api/endpoint/Endpoint.ts
@@ -21,41 +21,41 @@ import type { EndpointCallback, EndpointHandler } from "./util.js";
  * @example
  * const getUser = new Endpoint("GET", "/users/{id}", USER_PAYLOAD, USER_RESULT);
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint
+ * @see https://shelving.cc/api/Endpoint
  */
 export class Endpoint<P = unknown, R = unknown> {
 	/**
 	 * The HTTP method this endpoint responds to, e.g. `GET`
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/method
+	 * @see https://shelving.cc/api/Endpoint/method
 	 */
 	readonly method: RequestMethod;
 
 	/**
 	 * Endpoint path, possibly including placeholders e.g. `/users/{id}`
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/path
+	 * @see https://shelving.cc/api/Endpoint/path
 	 */
 	readonly path: AbsolutePath;
 
 	/**
 	 * The `{placeholder}` segments extracted from `path`, used to render and match URLs.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/placeholders
+	 * @see https://shelving.cc/api/Endpoint/placeholders
 	 */
 	readonly placeholders: TemplatePlaceholders;
 
 	/**
 	 * The `Schema` that request payloads are validated against.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/payload
+	 * @see https://shelving.cc/api/Endpoint/payload
 	 */
 	readonly payload: Schema<P>;
 
 	/**
 	 * The `Schema` that response results are validated against.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/result
+	 * @see https://shelving.cc/api/Endpoint/result
 	 */
 	readonly result: Schema<R>;
 
@@ -76,7 +76,7 @@ export class Endpoint<P = unknown, R = unknown> {
 	 * @returns The rendered absolute path, with any `{placeholders}` filled from `payload`.
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @example endpoint.renderPath({ id: "abc" }) // "/users/abc"
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/renderPath
+	 * @see https://shelving.cc/api/Endpoint/renderPath
 	 */
 	renderPath(payload: P, caller: AnyCaller = this.renderPath): AbsolutePath {
 		// Placeholders.
@@ -97,7 +97,7 @@ export class Endpoint<P = unknown, R = unknown> {
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns A dictionary of matched `{placeholder}` params, or `undefined` if the method or path doesn't match.
 	 * @example endpoint.match("GET", "/users/abc") // { id: "abc" }
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/match
+	 * @see https://shelving.cc/api/Endpoint/match
 	 */
 	match(method: RequestMethod, path: AbsolutePath, caller: AnyCaller = this.match): RequestParams | undefined {
 		if (method !== this.method) return undefined;
@@ -110,7 +110,7 @@ export class Endpoint<P = unknown, R = unknown> {
 	 * @param callback The callback function that implements the logic for this endpoint by receiving the payload and returning the response.
 	 * @returns An `EndpointHandler` object combining this endpoint and the callback into a single typed object.
 	 * @example endpoint.handler((payload, request) => ({ ...payload }))
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/handler
+	 * @see https://shelving.cc/api/Endpoint/handler
 	 */
 	handler<C>(callback: EndpointCallback<P, R, C>): EndpointHandler<P, R, C> {
 		return { endpoint: this, callback };
@@ -121,7 +121,7 @@ export class Endpoint<P = unknown, R = unknown> {
 	 *
 	 * @returns The method and path joined with a space, e.g. `GET /user/{id}`
 	 * @example endpoint.toString() // "GET /users/{id}"
-	 * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoint/toString
+	 * @see https://shelving.cc/api/Endpoint/toString
 	 */
 	toString(): string {
 		return `${this.method} ${this.path}`;
@@ -131,7 +131,7 @@ export class Endpoint<P = unknown, R = unknown> {
 /**
  * An `Endpoint` with any payload and result type, for use where the specific types don't matter.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/AnyEndpoint
+ * @see https://shelving.cc/api/AnyEndpoint
  */
 // biome-ignore lint/suspicious/noExplicitAny: Intentional.
 export type AnyEndpoint = Endpoint<any, any>;
@@ -139,21 +139,21 @@ export type AnyEndpoint = Endpoint<any, any>;
 /**
  * An immutable list of endpoints.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/Endpoints
+ * @see https://shelving.cc/api/Endpoints
  */
 export type Endpoints = ImmutableArray<AnyEndpoint>;
 
 /**
  * Extract the payload type from an `Endpoint`.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/PayloadType
+ * @see https://shelving.cc/api/PayloadType
  */
 export type PayloadType<X extends Endpoint<unknown, unknown>> = X extends Endpoint<infer Y, unknown> ? Y : never;
 
 /**
  * Extract the result type from an `Endpoint`.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/EndpointType
+ * @see https://shelving.cc/api/EndpointType
  */
 export type EndpointType<X extends Endpoint<unknown, unknown>> = X extends Endpoint<unknown, infer Y> ? Y : never;
 
@@ -168,7 +168,7 @@ export type EndpointType<X extends Endpoint<unknown, unknown>> = X extends Endpo
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `HEAD` method.
  * @example HEAD("/users/{id}")
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/HEAD
+ * @see https://shelving.cc/api/HEAD
  */
 export function HEAD<P extends Data, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function HEAD<P extends Data>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;
@@ -188,7 +188,7 @@ export function HEAD(path: AbsolutePath, payload = UNDEFINED, result = UNDEFINED
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `GET` method.
  * @example GET("/users/{id}", undefined, USER)
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/GET
+ * @see https://shelving.cc/api/GET
  */
 export function GET<P extends Data, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function GET<P extends Data>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;
@@ -208,7 +208,7 @@ export function GET(path: AbsolutePath, payload = UNDEFINED, result = UNDEFINED)
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `POST` method.
  * @example POST("/users", USER, USER_RESULT)
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/POST
+ * @see https://shelving.cc/api/POST
  */
 export function POST<P, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function POST<P>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;
@@ -228,7 +228,7 @@ export function POST(path: AbsolutePath, payload = UNDEFINED, result = UNDEFINED
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `PUT` method.
  * @example PUT("/users/{id}", USER)
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/PUT
+ * @see https://shelving.cc/api/PUT
  */
 export function PUT<P, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function PUT<P>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;
@@ -248,7 +248,7 @@ export function PUT(path: AbsolutePath, payload = UNDEFINED, result = UNDEFINED)
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `PATCH` method.
  * @example PATCH("/users/{id}", PARTIAL_USER)
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/PATCH
+ * @see https://shelving.cc/api/PATCH
  */
 export function PATCH<P, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function PATCH<P>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;
@@ -268,7 +268,7 @@ export function PATCH(path: AbsolutePath, payload = UNDEFINED, result = UNDEFINE
  * @param result An optional `Schema` validating the response result.
  * @returns An `Endpoint` configured for the `DELETE` method.
  * @example DELETE("/users/{id}")
- * @see https://dhoulb.github.io/shelving/api/endpoint/Endpoint/DELETE
+ * @see https://shelving.cc/api/DELETE
  */
 export function DELETE<P, R>(path: AbsolutePath, payload?: Schema<P>, result?: Schema<R>): Endpoint<P, R>;
 export function DELETE<P>(path: AbsolutePath, payload: Schema<P>): Endpoint<P, undefined>;

--- a/modules/api/endpoint/util.ts
+++ b/modules/api/endpoint/util.ts
@@ -18,7 +18,7 @@ import type { Endpoint } from "./Endpoint.js";
  * @returns {Response} Returning a `Response` object (this will pass back to the client without validation).
  * @returns {R} Returning the return type of the handler (this will be validated against the Endpoint's result schema).
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/util/EndpointCallback
+ * @see https://shelving.cc/api/EndpointCallback
  */
 export type EndpointCallback<P, R, C = void> = (payload: P, request: Request, context: C) => R | Response | Promise<R | Response>;
 
@@ -26,7 +26,7 @@ export type EndpointCallback<P, R, C = void> = (payload: P, request: Request, co
  * A typed endpoint definition paired with its implementation callback.
  * - Created with `Endpoint.handler()`; matched and invoked by `handleEndpoints()`.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/util/EndpointHandler
+ * @see https://shelving.cc/api/EndpointHandler
  */
 export interface EndpointHandler<P, R, C = void> {
 	readonly endpoint: Endpoint<P, R>;
@@ -36,7 +36,7 @@ export interface EndpointHandler<P, R, C = void> {
 /**
  * An `EndpointHandler` with any payload and result type, for use where the specific types don't matter.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/util/AnyEndpointHandler
+ * @see https://shelving.cc/api/AnyEndpointHandler
  */
 // biome-ignore lint/suspicious/noExplicitAny: Intentional.
 export type AnyEndpointHandler<C = any> = EndpointHandler<any, any, C>;
@@ -44,7 +44,7 @@ export type AnyEndpointHandler<C = any> = EndpointHandler<any, any, C>;
 /**
  * A collection of endpoint handlers that can be matched and invoked by `handleEndpoints()`.
  *
- * @see https://dhoulb.github.io/shelving/api/endpoint/util/EndpointHandlers
+ * @see https://shelving.cc/api/EndpointHandlers
  */
 export type EndpointHandlers<C = void> = Iterable<AnyEndpointHandler<C>>;
 
@@ -63,7 +63,7 @@ export type EndpointHandlers<C = void> = Iterable<AnyEndpointHandler<C>>;
  * @throws {MethodNotAllowedError} if the request method is not a supported HTTP method.
  * @throws {NotFoundError} if no base path matches, or no endpoint matches the target path.
  * @example await handleEndpoints("https://myapi.com", [getUser.handler(loadUser)], request, undefined)
- * @see https://dhoulb.github.io/shelving/api/endpoint/util/handleEndpoints
+ * @see https://shelving.cc/api/handleEndpoints
  */
 export function handleEndpoints<C>(
 	base: PossibleURL,

--- a/modules/api/provider/APIProvider.ts
+++ b/modules/api/provider/APIProvider.ts
@@ -11,13 +11,13 @@ import type { Endpoint } from "../endpoint/Endpoint.js";
  * const provider = new ClientAPIProvider({ url: "https://api.example.com" });
  * const user = await provider.call(getUser, { id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider
+ * @see https://shelving.cc/api/APIProvider
  */
 export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisposable {
 	/**
 	 * The common base URL that every endpoint request is resolved against.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/url
+	 * @see https://shelving.cc/api/APIProvider/url
 	 */
 	abstract readonly url: URL;
 
@@ -32,7 +32,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @throws {RequiredError} if this is a `HEAD` or `GET` request but `payload` is not a data object.
 	 * @example provider.renderURL(getUser, { id: "abc" }) // URL("https://api.example.com/users/abc")
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/renderURL
+	 * @see https://shelving.cc/api/APIProvider/renderURL
 	 */
 	abstract renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller?: AnyCaller): URL;
 
@@ -50,7 +50,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @throws {RequiredError} if this is a `HEAD` or `GET` request but `payload` is not a data object.
 	 * @example provider.createRequest(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/createRequest
+	 * @see https://shelving.cc/api/APIProvider/createRequest
 	 */
 	abstract createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -65,7 +65,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @param request The `Request` to send.
 	 * @returns A promise resolving to the `Response`.
 	 * @example const response = await provider.fetch(request);
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/fetch
+	 * @see https://shelving.cc/api/APIProvider/fetch
 	 */
 	abstract fetch(request: Request): Promise<Response>;
 
@@ -80,7 +80,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @returns A promise resolving to the parsed result.
 	 * @throws {ResponseError} if the response status is non-2xx.
 	 * @example const result = await provider.parseResponse(getUser, response);
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/parseResponse
+	 * @see https://shelving.cc/api/APIProvider/parseResponse
 	 */
 	abstract parseResponse<PP extends P, RR extends R>(_endpoint: Endpoint<PP, RR>, response: Response, caller?: AnyCaller): Promise<RR>;
 
@@ -95,7 +95,7 @@ export abstract class APIProvider<P = unknown, R = unknown> implements AsyncDisp
 	 * @returns A promise resolving to the parsed result.
 	 * @throws {ResponseError} if the response status is non-2xx.
 	 * @example const user = await provider.call(getUser, { id: "abc" });
-	 * @see https://dhoulb.github.io/shelving/api/provider/APIProvider/APIProvider/call
+	 * @see https://shelving.cc/api/APIProvider/call
 	 */
 	async call<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,

--- a/modules/api/provider/CachedAPIProvider.ts
+++ b/modules/api/provider/CachedAPIProvider.ts
@@ -15,13 +15,13 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
  * @example
  *  const api = new CachedAPIProvider(source);
  *  const result = await api.call(endpoint, payload);
- * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider
+ * @see https://shelving.cc/api/CachedAPIProvider
  */
 export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements AsyncDisposable {
 	/**
 	 * The maximum age used when calling `call()`, defaulting to `AVOID_REFRESH` (only refresh if invalidated or still loading).
 	 * - Not used for `refresh()` calls, which always refetch immediately.
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/maxAge
+	 * @see https://shelving.cc/api/CachedAPIProvider/maxAge
 	 */
 	readonly maxAge: number | undefined;
 	private readonly _cache: APICache<P, R>;
@@ -48,7 +48,7 @@ export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements
 	 * @param caller The calling function used for error stack traces.
 	 * @returns Promise resolving to the (possibly cached) result.
 	 * @example await api.call(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/call
+	 * @see https://shelving.cc/api/CachedAPIProvider/call
 	 */
 	override call<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -65,7 +65,7 @@ export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements
 	 * @param endpoint The endpoint whose cached result should be invalidated.
 	 * @param payload The payload identifying the cached result.
 	 * @example api.invalidate(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/invalidate
+	 * @see https://shelving.cc/api/CachedAPIProvider/invalidate
 	 */
 	invalidate<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP): void {
 		this._cache.invalidate(endpoint, payload);
@@ -76,7 +76,7 @@ export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements
 	 *
 	 * @param endpoint The endpoint whose cached results should be invalidated.
 	 * @example api.invalidateAll(endpoint)
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/invalidateAll
+	 * @see https://shelving.cc/api/CachedAPIProvider/invalidateAll
 	 */
 	invalidateAll<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>): void {
 		this._cache.invalidateAll(endpoint);
@@ -88,7 +88,7 @@ export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements
 	 * @param endpoint The endpoint whose cached result should be refreshed.
 	 * @param payload The payload identifying the cached result.
 	 * @example api.refresh(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/refresh
+	 * @see https://shelving.cc/api/CachedAPIProvider/refresh
 	 */
 	refresh<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP): void {
 		this._cache.refresh(endpoint, payload, this.maxAge);
@@ -99,7 +99,7 @@ export class CachedAPIProvider<P, R> extends ThroughAPIProvider<P, R> implements
 	 *
 	 * @param endpoint The endpoint whose cached results should be refreshed.
 	 * @example api.refreshAll(endpoint)
-	 * @see https://dhoulb.github.io/shelving/api/provider/CachedAPIProvider/CachedAPIProvider/refreshAll
+	 * @see https://shelving.cc/api/CachedAPIProvider/refreshAll
 	 */
 	refreshAll<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>): void {
 		this._cache.refreshAll(endpoint, this.maxAge);

--- a/modules/api/provider/ClientAPIProvider.ts
+++ b/modules/api/provider/ClientAPIProvider.ts
@@ -23,7 +23,7 @@ import { APIProvider } from "./APIProvider.js";
 /**
  * Options for constructing a `ClientAPIProvider`.
  *
- * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProviderOptions
+ * @see https://shelving.cc/api/ClientAPIProviderOptions
  */
 export interface ClientAPIProviderOptions {
 	/**
@@ -62,27 +62,27 @@ export interface ClientAPIProviderOptions {
  * const provider = new ClientAPIProvider({ url: "https://api.example.com" });
  * const user = await provider.call(getUser, { id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider
+ * @see https://shelving.cc/api/ClientAPIProvider
  */
 export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, R> {
 	/**
 	 * The common base URL for all rendered endpoint requests.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/url
+	 * @see https://shelving.cc/api/ClientAPIProvider/url
 	 */
 	override readonly url: URL;
 
 	/**
 	 * Default options used for HTTP requests created with `this.createRequest()` and `this.fetch()`
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/options
+	 * @see https://shelving.cc/api/ClientAPIProvider/options
 	 */
 	readonly options: RequestOptions;
 
 	/**
 	 * Timeout in milliseconds before the request is aborted, or `0` for no timeout.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/timeout
+	 * @see https://shelving.cc/api/ClientAPIProvider/timeout
 	 */
 	readonly timeout: number;
 
@@ -91,7 +91,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	 *
 	 * @throws {RequiredError} if `url` cannot be resolved to a valid base URL.
 	 * @example new ClientAPIProvider({ url: "https://api.example.com" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider
+	 * @see https://shelving.cc/api/ClientAPIProvider
 	 */
 	constructor({ url, options = {}, timeout = 20_000 }: ClientAPIProviderOptions) {
 		super();
@@ -110,7 +110,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @throws {RequiredError} if this is a `HEAD` or `GET` request but `payload` is not a data object.
 	 * @example provider.renderURL(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/renderURL
+	 * @see https://shelving.cc/api/ClientAPIProvider/renderURL
 	 */
 	override renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
 		// Construct the full URL from `this.url` and the rendered path.
@@ -144,7 +144,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	 * @throws {RequiredError} if this endpoint's path has `{placeholders}` but `payload` is not a data object.
 	 * @throws {RequiredError} if this is a `HEAD` or `GET` request but `payload` is not a data object.
 	 * @example provider.createRequest(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/createRequest
+	 * @see https://shelving.cc/api/ClientAPIProvider/createRequest
 	 */
 	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -196,7 +196,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	 * @param request The `Request` to send.
 	 * @returns A promise resolving to the `Response`.
 	 * @example await provider.fetch(request)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/fetch
+	 * @see https://shelving.cc/api/ClientAPIProvider/fetch
 	 */
 	override async fetch(request: Request): Promise<Response> {
 		return fetch(request);
@@ -211,7 +211,7 @@ export class ClientAPIProvider<P = unknown, R = unknown> extends APIProvider<P, 
 	 * @returns A promise resolving to the parsed result.
 	 * @throws {ResponseError} if the response status is non-2xx.
 	 * @example await provider.parseResponse(getUser, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ClientAPIProvider/ClientAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/ClientAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		_endpoint: Endpoint<PP, RR>,

--- a/modules/api/provider/DebugAPIProvider.ts
+++ b/modules/api/provider/DebugAPIProvider.ts
@@ -11,7 +11,7 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
  * @example
  *  const api = new DebugAPIProvider(source);
  *  await api.call(endpoint, payload); // logs request, response, and result
- * @see https://dhoulb.github.io/shelving/api/provider/DebugAPIProvider/DebugAPIProvider
+ * @see https://shelving.cc/api/DebugAPIProvider
  */
 export class DebugAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	/**
@@ -24,7 +24,7 @@ export class DebugAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns The built request.
 	 * @throws Rethrows any error thrown while building the request (after logging it).
 	 * @example api.createRequest(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/DebugAPIProvider/DebugAPIProvider/createRequest
+	 * @see https://shelving.cc/api/DebugAPIProvider/createRequest
 	 */
 	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -49,7 +49,7 @@ export class DebugAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns Promise resolving to the response.
 	 * @throws Rethrows any error thrown by the source provider (after logging it).
 	 * @example await api.fetch(request)
-	 * @see https://dhoulb.github.io/shelving/api/provider/DebugAPIProvider/DebugAPIProvider/fetch
+	 * @see https://shelving.cc/api/DebugAPIProvider/fetch
 	 */
 	override async fetch(request: Request): Promise<Response> {
 		try {
@@ -72,7 +72,7 @@ export class DebugAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns Promise resolving to the parsed result.
 	 * @throws Rethrows any error thrown while parsing (after logging it).
 	 * @example await api.parseResponse(endpoint, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/DebugAPIProvider/DebugAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/DebugAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,

--- a/modules/api/provider/JSONAPIProvider.ts
+++ b/modules/api/provider/JSONAPIProvider.ts
@@ -14,7 +14,7 @@ import { ClientAPIProvider } from "./ClientAPIProvider.js";
  * const provider = new JSONAPIProvider({ url: "https://api.example.com" });
  * const user = await provider.call(getUser, { id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/provider/JSONAPIProvider/JSONAPIProvider
+ * @see https://shelving.cc/api/JSONAPIProvider
  */
 export class JSONAPIProvider<P = unknown, R = unknown> extends ClientAPIProvider<P, R> {
 	protected override _createBodyRequest(
@@ -38,7 +38,7 @@ export class JSONAPIProvider<P = unknown, R = unknown> extends ClientAPIProvider
 	 * @returns A promise resolving to the parsed JSON result.
 	 * @throws {ResponseError} if the response status is non-2xx.
 	 * @example await provider.parseResponse(getUser, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/JSONAPIProvider/JSONAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/JSONAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		_endpoint: Endpoint<PP, RR>,

--- a/modules/api/provider/LoggingAPIProvider.ts
+++ b/modules/api/provider/LoggingAPIProvider.ts
@@ -10,7 +10,7 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
  * @example
  *  const api = new LoggingAPIProvider(source);
  *  await api.fetch(request); // logs request and response
- * @see https://dhoulb.github.io/shelving/api/provider/LoggingAPIProvider/LoggingAPIProvider
+ * @see https://shelving.cc/api/LoggingAPIProvider
  */
 export class LoggingAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	protected _logRequest: Callback<[Request]>;
@@ -48,7 +48,7 @@ export class LoggingAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns Promise resolving to the response.
 	 * @throws Rethrows any error thrown by the source provider (after logging it).
 	 * @example await api.fetch(request)
-	 * @see https://dhoulb.github.io/shelving/api/provider/LoggingAPIProvider/LoggingAPIProvider/fetch
+	 * @see https://shelving.cc/api/LoggingAPIProvider/fetch
 	 */
 	override async fetch(request: Request): Promise<Response> {
 		try {

--- a/modules/api/provider/MockAPIProvider.ts
+++ b/modules/api/provider/MockAPIProvider.ts
@@ -8,7 +8,7 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
 
 /**
  * Record of a single mocked fetch, pairing the request with the response the handler returned.
- * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIFetchCall
+ * @see https://shelving.cc/api/MockAPIFetchCall
  */
 export type MockAPIFetchCall = {
 	readonly request: Request;
@@ -17,7 +17,7 @@ export type MockAPIFetchCall = {
 
 /**
  * Record of a single request build, capturing the endpoint, payload, options, and built request.
- * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIRequestCall
+ * @see https://shelving.cc/api/MockAPIRequestCall
  */
 export type MockAPIRequestCall = {
 	readonly endpoint: AnyEndpoint;
@@ -28,7 +28,7 @@ export type MockAPIRequestCall = {
 
 /**
  * Record of a single response parse, capturing the endpoint, response, and parsed result.
- * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIResponseCall
+ * @see https://shelving.cc/api/MockAPIResponseCall
  */
 export type MockAPIResponseCall = {
 	readonly endpoint: AnyEndpoint;
@@ -51,28 +51,28 @@ async function _mockHandler(request: Request): Promise<Response> {
  *  const api = new MockAPIProvider();
  *  const result = await api.call(endpoint, payload);
  *  expect(api.fetchCalls).toHaveLength(1);
- * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider
+ * @see https://shelving.cc/api/MockAPIProvider
  */
 export class MockAPIProvider<P = unknown, R = unknown> extends ThroughAPIProvider<P, R> {
 	/**
 	 * Records of every request built by this provider.
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/requestCalls
+	 * @see https://shelving.cc/api/MockAPIProvider/requestCalls
 	 */
 	readonly requestCalls: MockAPIRequestCall[] = [];
 	/**
 	 * Records of every fetch handled by this provider.
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/fetchCalls
+	 * @see https://shelving.cc/api/MockAPIProvider/fetchCalls
 	 */
 	readonly fetchCalls: MockAPIFetchCall[] = [];
 	/**
 	 * Records of every response parsed by this provider.
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/responseCalls
+	 * @see https://shelving.cc/api/MockAPIProvider/responseCalls
 	 */
 	readonly responseCalls: MockAPIResponseCall[] = [];
 
 	/**
 	 * The request handler that serves fetches in place of the network.
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/handler
+	 * @see https://shelving.cc/api/MockAPIProvider/handler
 	 */
 	readonly handler: RequestHandler;
 
@@ -97,7 +97,7 @@ export class MockAPIProvider<P = unknown, R = unknown> extends ThroughAPIProvide
 	 * @param caller The calling function used for error stack traces.
 	 * @returns The built request.
 	 * @example api.createRequest(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/createRequest
+	 * @see https://shelving.cc/api/MockAPIProvider/createRequest
 	 */
 	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -118,7 +118,7 @@ export class MockAPIProvider<P = unknown, R = unknown> extends ThroughAPIProvide
 	 * @param caller The calling function used for error stack traces.
 	 * @returns Promise resolving to the parsed result.
 	 * @example await api.parseResponse(endpoint, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/MockAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -136,7 +136,7 @@ export class MockAPIProvider<P = unknown, R = unknown> extends ThroughAPIProvide
 	 * @param request The request to handle.
 	 * @returns Promise resolving to the handler's response.
 	 * @example await api.fetch(request)
-	 * @see https://dhoulb.github.io/shelving/api/provider/MockAPIProvider/MockAPIProvider/fetch
+	 * @see https://shelving.cc/api/MockAPIProvider/fetch
 	 */
 	override async fetch(request: Request): Promise<Response> {
 		const response = await this.handler(request);

--- a/modules/api/provider/MockEndpointAPIProvider.ts
+++ b/modules/api/provider/MockEndpointAPIProvider.ts
@@ -12,7 +12,7 @@ import { MockAPIProvider } from "./MockAPIProvider.js";
  * 	const api = new MockEnpdointAPIProvider(handlers); // Create a new mock provider.
  *  const result = await api.fetch(endpoint, 4); // Mock a call to the endpoint through the provider.
  *  expect(result).toBe(16);
- * @see https://dhoulb.github.io/shelving/api/provider/MockEndpointAPIProvider/MockEndpointAPIProvider
+ * @see https://shelving.cc/api/MockEndpointAPIProvider
  */
 export class MockEndpointAPIProvider<P, R, C> extends MockAPIProvider<P, R> {
 	/**

--- a/modules/api/provider/ThroughAPIProvider.ts
+++ b/modules/api/provider/ThroughAPIProvider.ts
@@ -17,13 +17,13 @@ import { APIProvider } from "./APIProvider.js";
  * 	}
  * }
  *
- * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider
+ * @see https://shelving.cc/api/ThroughAPIProvider
  */
 export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourceable<APIProvider<P, R>> {
 	/**
 	 * The base URL, delegated to the wrapped `source` provider.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/url
+	 * @see https://shelving.cc/api/ThroughAPIProvider/url
 	 */
 	override get url(): URL {
 		return this.source.url;
@@ -32,7 +32,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	/**
 	 * The wrapped source provider that operations delegate to.
 	 *
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/source
+	 * @see https://shelving.cc/api/ThroughAPIProvider/source
 	 */
 	readonly source: APIProvider<P, R>;
 
@@ -41,7 +41,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	 *
 	 * @param source The provider that every operation delegates to.
 	 * @example new ThroughAPIProvider(clientProvider)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider
+	 * @see https://shelving.cc/api/ThroughAPIProvider
 	 */
 	constructor(source: APIProvider<P, R>) {
 		super();
@@ -56,7 +56,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns The fully resolved request `URL`.
 	 * @example provider.renderURL(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/renderURL
+	 * @see https://shelving.cc/api/ThroughAPIProvider/renderURL
 	 */
 	override renderURL<PP extends P, RR extends R>(endpoint: Endpoint<PP, RR>, payload: PP, caller: AnyCaller = this.renderURL): URL {
 		return this.source.renderURL(endpoint, payload, caller);
@@ -71,7 +71,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns The created `Request`.
 	 * @example provider.createRequest(getUser, { id: "abc" })
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/createRequest
+	 * @see https://shelving.cc/api/ThroughAPIProvider/createRequest
 	 */
 	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -90,7 +90,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	 * @param caller The function to attribute thrown errors to (defaults to this method).
 	 * @returns A promise resolving to the parsed result.
 	 * @example await provider.parseResponse(getUser, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/ThroughAPIProvider/parseResponse
 	 */
 	override parseResponse<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -106,7 +106,7 @@ export class ThroughAPIProvider<P, R> extends APIProvider<P, R> implements Sourc
 	 * @param request The `Request` to send.
 	 * @returns A promise resolving to the `Response`.
 	 * @example await provider.fetch(request)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ThroughAPIProvider/ThroughAPIProvider/fetch
+	 * @see https://shelving.cc/api/ThroughAPIProvider/fetch
 	 */
 	override fetch(request: Request): Promise<Response> {
 		return this.source.fetch(request);

--- a/modules/api/provider/ValidationAPIProvider.ts
+++ b/modules/api/provider/ValidationAPIProvider.ts
@@ -11,7 +11,7 @@ import { ThroughAPIProvider } from "./ThroughAPIProvider.js";
  * @example
  *  const api = new ValidationAPIProvider(source);
  *  const result = await api.call(endpoint, payload); // validated payload and result
- * @see https://dhoulb.github.io/shelving/api/provider/ValidationAPIProvider/ValidationAPIProvider
+ * @see https://shelving.cc/api/ValidationAPIProvider
  */
 export class ValidationAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	/**
@@ -24,7 +24,7 @@ export class ValidationAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns The built request.
 	 * @throws {string} A user-readable validation message if the payload is invalid.
 	 * @example api.createRequest(endpoint, payload)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ValidationAPIProvider/ValidationAPIProvider/createRequest
+	 * @see https://shelving.cc/api/ValidationAPIProvider/createRequest
 	 */
 	override createRequest<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,
@@ -45,7 +45,7 @@ export class ValidationAPIProvider<P, R> extends ThroughAPIProvider<P, R> {
 	 * @returns Promise resolving to the validated result.
 	 * @throws {ResponseError} If the result fails validation (treated as a server/transport problem).
 	 * @example await api.parseResponse(endpoint, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/ValidationAPIProvider/ValidationAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/ValidationAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		endpoint: Endpoint<PP, RR>,

--- a/modules/api/provider/XMLAPIProvider.ts
+++ b/modules/api/provider/XMLAPIProvider.ts
@@ -14,7 +14,7 @@ import { ClientAPIProvider } from "./ClientAPIProvider.js";
  * const provider = new XMLAPIProvider({ url: "https://api.example.com" });
  * const xml = await provider.call(getFeed, { id: "abc" });
  *
- * @see https://dhoulb.github.io/shelving/api/provider/XMLAPIProvider/XMLAPIProvider
+ * @see https://shelving.cc/api/XMLAPIProvider
  */
 export class XMLAPIProvider<P extends Data = Data, R extends string = string> extends ClientAPIProvider<P, R> {
 	protected override _createBodyRequest(
@@ -38,7 +38,7 @@ export class XMLAPIProvider<P extends Data = Data, R extends string = string> ex
 	 * @returns A promise resolving to the raw text result.
 	 * @throws {ResponseError} if the response status is non-2xx.
 	 * @example await provider.parseResponse(getFeed, response)
-	 * @see https://dhoulb.github.io/shelving/api/provider/XMLAPIProvider/XMLAPIProvider/parseResponse
+	 * @see https://shelving.cc/api/XMLAPIProvider/parseResponse
 	 */
 	override async parseResponse<PP extends P, RR extends R>(
 		_endpoint: Endpoint<PP, RR>,

--- a/modules/api/store/EndpointStore.ts
+++ b/modules/api/store/EndpointStore.ts
@@ -9,17 +9,17 @@ import type { APIProvider } from "../provider/APIProvider.js";
  * @example
  *  const store = new EndpointStore(endpoint, payload, provider);
  *  const result = await store; // R
- * @see https://dhoulb.github.io/shelving/api/store/EndpointStore/EndpointStore
+ * @see https://shelving.cc/api/EndpointStore
  */
 export class EndpointStore<P, R> extends PayloadFetchStore<P, R> {
 	/**
 	 * The API provider this store calls the endpoint through.
-	 * @see https://dhoulb.github.io/shelving/api/store/EndpointStore/EndpointStore/provider
+	 * @see https://shelving.cc/api/EndpointStore/provider
 	 */
 	readonly provider: APIProvider<P, R>;
 	/**
 	 * The endpoint this store calls to fetch its result.
-	 * @see https://dhoulb.github.io/shelving/api/store/EndpointStore/EndpointStore/endpoint
+	 * @see https://shelving.cc/api/EndpointStore/endpoint
 	 */
 	readonly endpoint: Endpoint<P, R>;
 

--- a/modules/bun/BunPostgreSQLProvider.ts
+++ b/modules/bun/BunPostgreSQLProvider.ts
@@ -15,7 +15,7 @@ import type { Identifier } from "../util/item.js";
  * import { SQL } from "bun";
  * const provider = new BunPostgreSQLProvider(new SQL(process.env.DATABASE_URL));
  *
- * @see https://dhoulb.github.io/shelving/bun/BunPostgreSQLProvider/BunPostgreSQLProvider
+ * @see https://shelving.cc/bun/BunPostgreSQLProvider
  */
 export class BunPostgreSQLProvider<I extends Identifier = Identifier, T extends Data = Data> extends PostgreSQLProvider<I, T> {
 	private _sql: SQL;
@@ -24,7 +24,7 @@ export class BunPostgreSQLProvider<I extends Identifier = Identifier, T extends 
 	 * Create a provider wrapping an existing `Bun.SQL` connection.
 	 *
 	 * @param sql The `Bun.SQL` instance to execute queries against.
-	 * @see https://dhoulb.github.io/shelving/bun/BunPostgreSQLProvider/BunPostgreSQLProvider
+	 * @see https://shelving.cc/bun/BunPostgreSQLProvider
 	 */
 	constructor(sql: SQL) {
 		super();
@@ -38,7 +38,7 @@ export class BunPostgreSQLProvider<I extends Identifier = Identifier, T extends 
 	 * @param values The interpolated values bound as query parameters.
 	 * @returns Promise resolving to the array of result rows.
 	 * @example provider.exec`SELECT * FROM ${provider.sqlIdentifier("items")}`
-	 * @see https://dhoulb.github.io/shelving/bun/BunPostgreSQLProvider/BunPostgreSQLProvider/exec
+	 * @see https://shelving.cc/bun/BunPostgreSQLProvider/exec
 	 */
 	override exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<ImmutableArray<X>> {
 		return this._sql(strings, ...values);
@@ -52,7 +52,7 @@ export class BunPostgreSQLProvider<I extends Identifier = Identifier, T extends 
 	 * @param name The identifier (table or column name) to escape.
 	 * @returns An `SQLFragment` wrapping the escaped identifier.
 	 * @example provider.sqlIdentifier("items")
-	 * @see https://dhoulb.github.io/shelving/bun/BunPostgreSQLProvider/BunPostgreSQLProvider/sqlIdentifier
+	 * @see https://shelving.cc/bun/BunPostgreSQLProvider/sqlIdentifier
 	 */
 	override sqlIdentifier(name: string): SQLFragment {
 		return this.sql`${this._sql(name)}`;

--- a/modules/cloudflare/CloudflareD1Provider.ts
+++ b/modules/cloudflare/CloudflareD1Provider.ts
@@ -25,7 +25,7 @@ type D1Query = {
  * // `env.DB` is the D1 binding from the Worker environment.
  * const provider = new CloudflareD1Provider(env.DB);
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareD1Provider/CloudflareD1Provider
+ * @see https://shelving.cc/cloudflare/CloudflareD1Provider
  */
 export class CloudflareD1Provider<I extends Identifier = Identifier, T extends Data = Data> extends SQLiteProvider<I, T> {
 	private readonly _db: D1Database;
@@ -34,7 +34,7 @@ export class CloudflareD1Provider<I extends Identifier = Identifier, T extends D
 	 * Create a provider wrapping a Cloudflare D1 database binding.
 	 *
 	 * @param db The `D1Database` binding from the Worker environment.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareD1Provider/CloudflareD1Provider
+	 * @see https://shelving.cc/cloudflare/CloudflareD1Provider
 	 */
 	constructor(db: D1Database) {
 		super();
@@ -51,7 +51,7 @@ export class CloudflareD1Provider<I extends Identifier = Identifier, T extends D
 	 * @returns Promise resolving to the array of result rows (empty if D1 returns no results).
 	 * @throws {ValueError} If a value cannot be converted to a D1 binding.
 	 * @example provider.exec`SELECT * FROM ${provider.sqlIdentifier("items")}`
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareD1Provider/CloudflareD1Provider/exec
+	 * @see https://shelving.cc/cloudflare/CloudflareD1Provider/exec
 	 */
 	override async exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<readonly X[]> {
 		const { query, values: bindings } = _getD1Query(strings, values, this.exec);

--- a/modules/cloudflare/CloudflareKVProvider.ts
+++ b/modules/cloudflare/CloudflareKVProvider.ts
@@ -34,7 +34,7 @@ import type { KVNamespace } from "./types.js";
  * // `env.KV` is the KV namespace binding from the Worker environment.
  * const provider = new CloudflareKVProvider(env.KV);
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider
+ * @see https://shelving.cc/cloudflare/CloudflareKVProvider
  */
 export class CloudflareKVProvider<I extends string = string, T extends Data = Data> extends DBProvider<I, T> {
 	private readonly _kv: KVNamespace;
@@ -43,7 +43,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * Create a provider wrapping a Cloudflare Workers KV namespace binding.
 	 *
 	 * @param kv The `KVNamespace` binding from the Worker environment.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider
 	 */
 	constructor(kv: KVNamespace) {
 		super();
@@ -57,7 +57,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param id The ID of the item to read.
 	 * @returns Promise resolving to the item, or `undefined` if no value exists for the key.
 	 * @example await provider.getItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/getItem
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const data = (await this._kv.get(_getKey(name, id), { type: "json" })) as TT | null; // `as TT` needed: KV returns unknown from JSON parse.
@@ -71,7 +71,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param id The ID of the item to subscribe to.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support realtime subscriptions.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/getItemSequence
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError("CloudflareKVProvider does not support realtime subscriptions");
@@ -84,7 +84,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param data The data for the new item.
 	 * @returns Promise resolving to the generated ID of the new item.
 	 * @example const id = await provider.addItem(users, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/addItem
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = randomUUID() as II; // `as II` needed: TypeScript can't narrow II from string return type.
@@ -100,7 +100,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param data The data to store for the item.
 	 * @returns Promise resolving once the write completes.
 	 * @example await provider.setItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/setItem
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this._kv.put(_getKey(name, id), JSON.stringify(data));
@@ -114,7 +114,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param updates The updates to apply.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support item updates.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/updateItem
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -131,7 +131,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param id The ID of the item to delete.
 	 * @returns Promise resolving once the deletion completes.
 	 * @example await provider.deleteItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/deleteItem
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>({ name }: Collection<string, II, TT>, id: II): Promise<void> {
 		await this._kv.delete(_getKey(name, id));
@@ -144,7 +144,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param query The query to run.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support collection queries.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/getQuery
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -160,7 +160,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param query The query to subscribe to.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support realtime subscriptions.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/getQuerySequence
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -177,7 +177,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param data The data to write to each matching item.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support collection queries.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/setQuery
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -195,7 +195,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param updates The updates to apply to each matching item.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support item updates.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/updateQuery
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -212,7 +212,7 @@ export class CloudflareKVProvider<I extends string = string, T extends Data = Da
 	 * @param query The query selecting items to delete.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because KV does not support collection queries.
-	 * @see https://dhoulb.github.io/shelving/cloudflare/CloudflareKVProvider/CloudflareKVProvider/deleteQuery
+	 * @see https://shelving.cc/cloudflare/CloudflareKVProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,

--- a/modules/cloudflare/types.ts
+++ b/modules/cloudflare/types.ts
@@ -3,7 +3,7 @@
  *
  * Declares only the subset of methods `CloudflareKVProvider` uses, so the `@cloudflare/workers-types` package is not required as a dependency.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/KVNamespace
+ * @see https://shelving.cc/cloudflare/KVNamespace
  */
 export interface KVNamespace {
 	get(key: string, options: { type: "json" }): Promise<unknown>;
@@ -14,14 +14,14 @@ export interface KVNamespace {
 /**
  * Value that can be passed through the D1 Worker API as a bound parameter.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1Value
+ * @see https://shelving.cc/cloudflare/D1Value
  */
 export type D1Value = boolean | null | number | string;
 
 /**
  * Metadata returned by the D1 Worker API alongside a query result.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1Meta
+ * @see https://shelving.cc/cloudflare/D1Meta
  */
 export interface D1Meta {
 	readonly changed_db?: boolean | undefined;
@@ -34,7 +34,7 @@ export interface D1Meta {
 /**
  * Result object returned by `D1PreparedStatement.run()`.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1Result
+ * @see https://shelving.cc/cloudflare/D1Result
  */
 export interface D1Result<T extends Record<string, unknown> = Record<string, unknown>> {
 	readonly success: boolean;
@@ -45,7 +45,7 @@ export interface D1Result<T extends Record<string, unknown> = Record<string, unk
 /**
  * Result object returned by `D1Database.exec()`.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1ExecResult
+ * @see https://shelving.cc/cloudflare/D1ExecResult
  */
 export interface D1ExecResult {
 	readonly count: number;
@@ -57,7 +57,7 @@ export interface D1ExecResult {
  *
  * Declares only the subset of the D1 prepared-statement API used by `CloudflareD1Provider`.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1PreparedStatement
+ * @see https://shelving.cc/cloudflare/D1PreparedStatement
  */
 export interface D1PreparedStatement {
 	bind(...values: D1Value[]): D1PreparedStatement;
@@ -71,7 +71,7 @@ export interface D1PreparedStatement {
  *
  * Declares only the subset of the D1 binding API the provider needs, so the `@cloudflare/workers-types` package is not required as a dependency.
  *
- * @see https://dhoulb.github.io/shelving/cloudflare/types/D1Database
+ * @see https://shelving.cc/cloudflare/D1Database
  */
 export interface D1Database {
 	batch<T extends Record<string, unknown> = Record<string, unknown>>(

--- a/modules/db/cache/CollectionCache.ts
+++ b/modules/db/cache/CollectionCache.ts
@@ -18,7 +18,7 @@ import { QueryStore } from "../store/QueryStore.js";
  * @example
  *  const cache = new CollectionCache(collection, provider);
  *  const store = cache.getItem("abc");
- * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache
+ * @see https://shelving.cc/db/CollectionCache
  */
 export class CollectionCache<I extends Identifier, T extends Data> implements AsyncDisposable {
 	private readonly _items = new Map<I, ItemStore<I, T>>();
@@ -26,17 +26,17 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 
 	/**
 	 * The collection these cached stores belong to.
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/collection
+	 * @see https://shelving.cc/db/CollectionCache/collection
 	 */
 	readonly collection: Collection<string, I, T>;
 	/**
 	 * The database provider the cached stores fetch from.
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/provider
+	 * @see https://shelving.cc/db/CollectionCache/provider
 	 */
 	readonly provider: DBProvider<I>;
 	/**
 	 * Optional memory provider used to seed stores and drive realtime updates.
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/memory
+	 * @see https://shelving.cc/db/CollectionCache/memory
 	 */
 	readonly memory: MemoryDBProvider<I> | undefined;
 
@@ -60,7 +60,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param id The ID of the item to get a store for.
 	 * @returns The cached (or newly created) `ItemStore` for the id.
 	 * @example cache.getItem("abc")
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/getItem
+	 * @see https://shelving.cc/db/CollectionCache/getItem
 	 */
 	getItem(id: I): ItemStore<I, T> {
 		return this._items.get(id) || setMapItem(this._items, id, new ItemStore(this.collection, id, this.provider, this.memory));
@@ -72,7 +72,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param query The query to get a store for.
 	 * @returns The cached (or newly created) `QueryStore` for the query.
 	 * @example cache.getQuery(query)
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/getQuery
+	 * @see https://shelving.cc/db/CollectionCache/getQuery
 	 */
 	getQuery(query: Query<Item<I, T>>): QueryStore<I, T> {
 		const key = this._queryKey(query);
@@ -86,7 +86,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once the refresh has completed.
 	 * @example await cache.refreshItem("abc")
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/refreshItem
+	 * @see https://shelving.cc/db/CollectionCache/refreshItem
 	 */
 	async refreshItem(id: I, maxAge?: number): Promise<void> {
 		await this._items.get(id)?.refresh(maxAge);
@@ -98,7 +98,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every item store has refreshed.
 	 * @example await cache.refreshItems()
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/refreshItems
+	 * @see https://shelving.cc/db/CollectionCache/refreshItems
 	 */
 	async refreshItems(maxAge?: number): Promise<void> {
 		await awaitValues(...this._items.values().map(store => store.refresh(maxAge)));
@@ -111,7 +111,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once the refresh has completed.
 	 * @example await cache.refreshQuery(query)
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/refreshQuery
+	 * @see https://shelving.cc/db/CollectionCache/refreshQuery
 	 */
 	async refreshQuery(query: Query<Item<I, T>>, maxAge?: number): Promise<void> {
 		await this._queries.get(this._queryKey(query))?.refresh(maxAge);
@@ -123,7 +123,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every query store has refreshed.
 	 * @example await cache.refreshQueries()
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/refreshQueries
+	 * @see https://shelving.cc/db/CollectionCache/refreshQueries
 	 */
 	async refreshQueries(maxAge?: number): Promise<void> {
 		await awaitValues(...this._queries.values().map(store => store.refresh(maxAge)));
@@ -135,7 +135,7 @@ export class CollectionCache<I extends Identifier, T extends Data> implements As
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every store has refreshed.
 	 * @example await cache.refreshAll()
-	 * @see https://dhoulb.github.io/shelving/db/cache/CollectionCache/CollectionCache/refreshAll
+	 * @see https://shelving.cc/db/CollectionCache/refreshAll
 	 */
 	async refreshAll(maxAge?: number): Promise<void> {
 		await awaitValues(this.refreshItems(maxAge), this.refreshQueries(maxAge));

--- a/modules/db/cache/DBCache.ts
+++ b/modules/db/cache/DBCache.ts
@@ -21,19 +21,19 @@ import { CollectionCache } from "./CollectionCache.js";
  * @example
  *  const cache = new DBCache(provider);
  *  const store = cache.getItem(collection, "abc");
- * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache
+ * @see https://shelving.cc/db/DBCache
  */
 export class DBCache<I extends Identifier = Identifier, T extends Data = Data> implements AsyncDisposable {
 	private readonly _collections = new Map<Collection<string, I, T>, CollectionCache<I, T>>();
 
 	/**
 	 * The database provider the cached stores fetch from.
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/provider
+	 * @see https://shelving.cc/db/DBCache/provider
 	 */
 	readonly provider: DBProvider<I, T>;
 	/**
 	 * Memory provider reused from the provider chain to seed stores synchronously, if available.
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/memory
+	 * @see https://shelving.cc/db/DBCache/memory
 	 */
 	readonly memory: MemoryDBProvider<I, T> | undefined;
 
@@ -60,7 +60,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param collection The collection to get a cache for.
 	 * @returns The cached (or newly created) `CollectionCache` for the collection.
 	 * @example cache.get(collection)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/get
+	 * @see https://shelving.cc/db/DBCache/get
 	 */
 	get<II extends I, TT extends T>(collection: Collection<string, II, TT>): CollectionCache<II, TT>;
 	get(collection: Collection<string, I, T>): CollectionCache<I, T> {
@@ -74,7 +74,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param id The ID of the item to get a store for.
 	 * @returns The cached (or newly created) `ItemStore`.
 	 * @example cache.getItem(collection, "abc")
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/getItem
+	 * @see https://shelving.cc/db/DBCache/getItem
 	 */
 	getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): ItemStore<II, TT> {
 		return this.get(collection).getItem(id);
@@ -87,7 +87,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param query The query to get a store for.
 	 * @returns The cached (or newly created) `QueryStore`.
 	 * @example cache.getQuery(collection, query)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/getQuery
+	 * @see https://shelving.cc/db/DBCache/getQuery
 	 */
 	getQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): QueryStore<II, TT> {
 		return this.get(collection).getQuery(query);
@@ -101,7 +101,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once the refresh has completed.
 	 * @example await cache.refreshItem(collection, "abc")
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/refreshItem
+	 * @see https://shelving.cc/db/DBCache/refreshItem
 	 */
 	async refreshItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, maxAge?: number): Promise<void> {
 		await this._get(collection)?.refreshItem(id, maxAge);
@@ -114,7 +114,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every item store has refreshed.
 	 * @example await cache.refreshItems(collection)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/refreshItems
+	 * @see https://shelving.cc/db/DBCache/refreshItems
 	 */
 	async refreshItems<II extends I, TT extends T>(collection: Collection<string, II, TT>, maxAge?: number): Promise<void> {
 		await this._get(collection)?.refreshItems(maxAge);
@@ -128,7 +128,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once the refresh has completed.
 	 * @example await cache.refreshQuery(collection, query)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/refreshQuery
+	 * @see https://shelving.cc/db/DBCache/refreshQuery
 	 */
 	async refreshQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -145,7 +145,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every query store has refreshed.
 	 * @example await cache.refreshQueries(collection)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/refreshQueries
+	 * @see https://shelving.cc/db/DBCache/refreshQueries
 	 */
 	async refreshQueries<II extends I, TT extends T>(collection: Collection<string, II, TT>, maxAge?: number): Promise<void> {
 		await this._get(collection)?.refreshQueries(maxAge);
@@ -158,7 +158,7 @@ export class DBCache<I extends Identifier = Identifier, T extends Data = Data> i
 	 * @param maxAge Maximum age in milliseconds of cached data that may be reused instead of refetching.
 	 * @returns Promise that resolves once every store has refreshed.
 	 * @example await cache.refreshAll(collection)
-	 * @see https://dhoulb.github.io/shelving/db/cache/DBCache/DBCache/refreshAll
+	 * @see https://shelving.cc/db/DBCache/refreshAll
 	 */
 	async refreshAll<II extends I, TT extends T>(collection: Collection<string, II, TT>, maxAge?: number): Promise<void> {
 		await this._get(collection)?.refreshAll(maxAge);

--- a/modules/db/collection/Collection.ts
+++ b/modules/db/collection/Collection.ts
@@ -8,7 +8,7 @@ import type { Identifier, Item, Items, OptionalItem } from "../../util/item.js";
 /**
  * Default identifier schema (integer) used when a collection doesn't supply its own.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/ID
+ * @see https://shelving.cc/db/ID
  */
 export const ID = new NumberSchema({
 	step: 1,
@@ -29,27 +29,27 @@ export const ID = new NumberSchema({
  *  const users = new Collection("users", ID, { name: STRING, age: NUMBER });
  *  users.validate({ name: "Dave", age: 40 }); // Validates item data.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collection
+ * @see https://shelving.cc/db/Collection
  */
 export class Collection<N extends string = string, I extends Identifier = Identifier, T extends Data = Data> extends DataSchema<T> {
 	/**
 	 * Collection name (used as the table/collection key).
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collection/name
+	 * @see https://shelving.cc/db/Collection/name
 	 */
 	readonly name: N;
 
 	/**
 	 * Schema for the identifier type.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collection/id
+	 * @see https://shelving.cc/db/Collection/id
 	 */
 	readonly id: Schema<I>;
 
 	/**
 	 * Schema for a complete item (id + data).
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collection/item
+	 * @see https://shelving.cc/db/Collection/item
 	 */
 	readonly item: DataSchema<Item<I, T>>;
 
@@ -73,7 +73,7 @@ export class Collection<N extends string = string, I extends Identifier = Identi
 	 *
 	 * @returns The collection name.
 	 * @example `${users}` // "users"
-	 * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collection/toString
+	 * @see https://shelving.cc/db/Collection/toString
 	 */
 	override toString(): string {
 		return this.name;
@@ -89,7 +89,7 @@ export class Collection<N extends string = string, I extends Identifier = Identi
  * @param id Schema for the identifier type.
  * @param data Data schema, or the `Schemas` props used to construct one.
  * @example COLLECTION("users", ID, { name: STRING, age: NUMBER }) // Collection<"users", number, { name: string; age: number }>
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/COLLECTION
+ * @see https://shelving.cc/db/COLLECTION
  */
 export function COLLECTION<K extends string, I extends Identifier, T extends Data>(
 	name: K,
@@ -102,63 +102,63 @@ export function COLLECTION<K extends string, I extends Identifier, T extends Dat
 /**
  * Extract the string name from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionName
+ * @see https://shelving.cc/db/CollectionName
  */
 export type CollectionName<C extends Collection> = C extends Collection<infer N, infer _I, infer _T> ? N : never;
 
 /**
  * Extract the `Identifier` type from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionIdentifier
+ * @see https://shelving.cc/db/CollectionIdentifier
  */
 export type CollectionIdentifier<C extends Collection> = C extends Collection<infer _N, infer I, infer _T> ? I : never;
 
 /**
  * Extract the `Data` type from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionData
+ * @see https://shelving.cc/db/CollectionData
  */
 export type CollectionData<C extends Collection> = C extends Collection<infer _N, infer _I, infer T> ? T : never;
 
 /**
  * Extract the `Item` type from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionItem
+ * @see https://shelving.cc/db/CollectionItem
  */
 export type CollectionItem<C extends Collection> = Item<CollectionIdentifier<C>, CollectionData<C>>;
 
 /**
  * Extract the optional (possibly undefined) `Item` type from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/OptionalCollectionItem
+ * @see https://shelving.cc/db/OptionalCollectionItem
  */
 export type OptionalCollectionItem<C extends Collection> = OptionalItem<CollectionIdentifier<C>, CollectionData<C>>;
 
 /**
  * Extract the array of `Item` types from a `Collection` instance.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionItems
+ * @see https://shelving.cc/db/CollectionItems
  */
 export type CollectionItems<C extends Collection> = Items<CollectionIdentifier<C>, CollectionData<C>>;
 
 /**
  * A readonly array of `Collection` instances, optionally narrowed to a standardised `Identifier` and `Data` type.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/Collections
+ * @see https://shelving.cc/db/Collections
  */
 export type Collections<I extends Identifier = Identifier, D extends Data = Data> = ImmutableArray<Collection<string, I, D>>;
 
 /**
  * Extract the union of string collection names from a `Collections` type.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionNames
+ * @see https://shelving.cc/db/CollectionNames
  */
 export type CollectionNames<C extends Collections> = C[number]["name"];
 
 /**
  * Convert a `Collections` array type to a database-style object mapping in `{ name: data }` format.
  *
- * @see https://dhoulb.github.io/shelving/db/collection/Collection/CollectionsDatabase
+ * @see https://shelving.cc/db/CollectionsDatabase
  */
 export type CollectionsDatabase<C extends Collections> = {
 	[E in C[number] as E extends Collection<infer N, Identifier, Data> ? N : never]: E extends Collection<string, Identifier, infer T>

--- a/modules/db/migrate/DBMigrator.ts
+++ b/modules/db/migrate/DBMigrator.ts
@@ -9,12 +9,12 @@ import type { DBProvider } from "../provider/DBProvider.js";
  * @example
  *  class MyMigrator extends DBMigrator { async migrate(...collections) { ... } }
  *  await new MyMigrator(provider).migrate(users, posts);
- * @see https://dhoulb.github.io/shelving/db/migrate/DBMigrator/DBMigrator
+ * @see https://shelving.cc/db/DBMigrator
  */
 export abstract class DBMigrator<T extends DBProvider = DBProvider> {
 	/**
 	 * The database provider whose storage this migrator updates.
-	 * @see https://dhoulb.github.io/shelving/db/migrate/DBMigrator/DBMigrator/provider
+	 * @see https://shelving.cc/db/DBMigrator/provider
 	 */
 	readonly provider: T;
 
@@ -35,7 +35,7 @@ export abstract class DBMigrator<T extends DBProvider = DBProvider> {
 	 * @returns Promise that resolves once migration has completed.
 	 * @throws {UnimplementedError} If a schema feature can't be represented by the backend.
 	 * @example await migrator.migrate(users, posts)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/DBMigrator/DBMigrator/migrate
+	 * @see https://shelving.cc/db/DBMigrator/migrate
 	 */
 	abstract migrate(...collections: Collections): Promise<void>;
 }

--- a/modules/db/migrate/PostgreSQLMigrator.ts
+++ b/modules/db/migrate/PostgreSQLMigrator.ts
@@ -38,7 +38,7 @@ type PostgreSQLColumnRow = {
  * @example
  *  const migrator = new PostgreSQLMigrator(provider);
  *  await migrator.migrate(users, posts);
- * @see https://dhoulb.github.io/shelving/db/migrate/PostgreSQLMigrator/PostgreSQLMigrator
+ * @see https://shelving.cc/db/PostgreSQLMigrator
  */
 export class PostgreSQLMigrator<T extends SQLProvider = SQLProvider> extends SQLMigrator<T> {
 	protected override async getTables(): Promise<readonly string[]> {

--- a/modules/db/migrate/SQLMigrator.ts
+++ b/modules/db/migrate/SQLMigrator.ts
@@ -16,7 +16,7 @@ import { DBMigrator } from "./DBMigrator.js";
 
 /**
  * Column definition in a live SQL table, pairing a column name with its raw definition statement.
- * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLTableColumn
+ * @see https://shelving.cc/db/SQLTableColumn
  */
 export type SQLTableColumn = {
 	readonly name: string;
@@ -25,7 +25,7 @@ export type SQLTableColumn = {
 
 /**
  * Existing SQL table schema keyed by column name, as read back from the database.
- * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLTable
+ * @see https://shelving.cc/db/SQLTable
  */
 export type SQLTable = {
 	readonly columns: Readonly<Record<string, SQLTableColumn>>;
@@ -35,7 +35,7 @@ export type SQLTable = {
 
 /**
  * Generated SQL column mapped from a collection schema path, holding its column name, key, and JSON path.
- * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLColumn
+ * @see https://shelving.cc/db/SQLColumn
  */
 export type SQLColumn = {
 	readonly column: string;
@@ -51,7 +51,7 @@ export type SQLColumn = {
  * @example
  *  const migrator = new SQLiteMigrator(provider);
  *  await migrator.migrate(users, posts);
- * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator
+ * @see https://shelving.cc/db/SQLMigrator
  */
 export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends DBMigrator<T> {
 	/**
@@ -61,7 +61,7 @@ export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends D
 	 * @returns Promise that resolves once every migration has been executed.
 	 * @throws {UnimplementedError} If a schema feature can't be represented as a SQL column.
 	 * @example await migrator.migrate(users, posts)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator/migrate
+	 * @see https://shelving.cc/db/SQLMigrator/migrate
 	 */
 	async migrate(...collections: Collections<number>): Promise<void> {
 		for (const migration of await this.getMigrations(...collections)) await this.provider.exec(_getTemplateStrings(migration));
@@ -73,7 +73,7 @@ export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends D
 	 * @param collections The collections whose schemas the tables should match.
 	 * @returns Promise resolving to the ordered list of SQL migration statements.
 	 * @example const sql = await migrator.getMigrations(users)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator/getMigrations
+	 * @see https://shelving.cc/db/SQLMigrator/getMigrations
 	 */
 	async getMigrations(...collections: Collections<number>): Promise<readonly string[]> {
 		const tables = await this.getTables();
@@ -93,7 +93,7 @@ export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends D
 	 * @param collection The collection to create a table for.
 	 * @returns The `CREATE TABLE` SQL statement.
 	 * @example migrator.getCreateTableQuery(users) // CREATE TABLE "users" (...)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator/getCreateTableQuery
+	 * @see https://shelving.cc/db/SQLMigrator/getCreateTableQuery
 	 */
 	getCreateTableQuery<T extends Data>(collection: Collection<string, number, T>): string {
 		const suffix = this.getCreateTableSuffix(collection);
@@ -108,7 +108,7 @@ export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends D
 	 * @param collection The collection to get columns for.
 	 * @returns The ordered list of table columns.
 	 * @example migrator.getCreateTableColumns(users)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator/getCreateTableColumns
+	 * @see https://shelving.cc/db/SQLMigrator/getCreateTableColumns
 	 */
 	getCreateTableColumns<T extends Data>(collection: Collection<string, number, T>): readonly SQLTableColumn[] {
 		return [this.getIDColumn(collection), this.getDataColumn(), ...this.getGeneratedTableColumns(collection)];
@@ -120,7 +120,7 @@ export abstract class SQLMigrator<T extends SQLProvider = SQLProvider> extends D
 	 * @param collection The collection to get generated columns for.
 	 * @returns The list of generated table columns.
 	 * @example migrator.getGeneratedTableColumns(users)
-	 * @see https://dhoulb.github.io/shelving/db/migrate/SQLMigrator/SQLMigrator/getGeneratedTableColumns
+	 * @see https://shelving.cc/db/SQLMigrator/getGeneratedTableColumns
 	 */
 	getGeneratedTableColumns<T extends Data>(collection: Collection<string, number, T>): readonly SQLTableColumn[] {
 		return this.getGeneratedColumns(collection).map(column => this.getGeneratedColumn(column, collection));

--- a/modules/db/migrate/SQLiteMigrator.ts
+++ b/modules/db/migrate/SQLiteMigrator.ts
@@ -14,7 +14,7 @@ import { SQLMigrator, type SQLTable, type SQLTableColumn } from "./SQLMigrator.j
  * @example
  *  const migrator = new SQLiteMigrator(provider);
  *  await migrator.migrate(users, posts);
- * @see https://dhoulb.github.io/shelving/db/migrate/SQLiteMigrator/SQLiteMigrator
+ * @see https://shelving.cc/db/SQLiteMigrator
  */
 export class SQLiteMigrator<T extends SQLProvider = SQLProvider> extends SQLMigrator<T> {
 	protected override async getTables(): Promise<readonly string[]> {

--- a/modules/db/provider/CacheDBProvider.ts
+++ b/modules/db/provider/CacheDBProvider.ts
@@ -19,20 +19,20 @@ import { MemoryDBProvider } from "./MemoryDBProvider.js";
  *  const provider = new CacheDBProvider(new FirestoreProvider());
  *  await provider.getItem(users, 123); // Fetches from source, then caches in memory.
  *
- * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider
+ * @see https://shelving.cc/db/CacheDBProvider
  */
 export class CacheDBProvider<I extends Identifier, T extends Data> extends DBProvider<I, T> implements Sourceable<DBProvider<I, T>> {
 	/**
 	 * The wrapped source provider that data is fetched from and written to.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/source
+	 * @see https://shelving.cc/db/CacheDBProvider/source
 	 */
 	readonly source: DBProvider<I, T>;
 
 	/**
 	 * The in-memory provider holding the local synchronous cache of `source` data.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/memory
+	 * @see https://shelving.cc/db/CacheDBProvider/memory
 	 */
 	readonly memory: MemoryDBProvider<I, T>;
 
@@ -55,7 +55,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/getItem
+	 * @see https://shelving.cc/db/CacheDBProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const item = await this.source.getItem(collection, id);
@@ -71,7 +71,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/getItemSequence
+	 * @see https://shelving.cc/db/CacheDBProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		return this.memory.getTable(collection).setItemSequence(id, this.source.getItemSequence(collection, id));
@@ -84,7 +84,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/addItem
+	 * @see https://shelving.cc/db/CacheDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = await this.source.addItem(collection, data);
@@ -99,7 +99,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/setItem
+	 * @see https://shelving.cc/db/CacheDBProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this.source.setItem(collection, id, data);
@@ -113,7 +113,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/updateItem
+	 * @see https://shelving.cc/db/CacheDBProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -130,7 +130,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/deleteItem
+	 * @see https://shelving.cc/db/CacheDBProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await this.source.deleteItem(collection, id);
@@ -144,7 +144,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/countQuery
+	 * @see https://shelving.cc/db/CacheDBProvider/countQuery
 	 */
 	override countQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<number> {
 		return this.source.countQuery(collection, query);
@@ -157,7 +157,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/getQuery
+	 * @see https://shelving.cc/db/CacheDBProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -175,7 +175,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/CacheDBProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -191,7 +191,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/setQuery
+	 * @see https://shelving.cc/db/CacheDBProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -209,7 +209,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/updateQuery
+	 * @see https://shelving.cc/db/CacheDBProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -226,7 +226,7 @@ export class CacheDBProvider<I extends Identifier, T extends Data> extends DBPro
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/CacheDBProvider/CacheDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/CacheDBProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,

--- a/modules/db/provider/ChangesDBProvider.ts
+++ b/modules/db/provider/ChangesDBProvider.ts
@@ -11,7 +11,7 @@ import { ThroughDBProvider } from "./ThroughDBProvider.js";
  *
  * - `action` is the kind of write; `collection` is the collection name; `id`, `query`, `data`, and `updates` carry whichever fields apply to that write.
  *
- * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/DBChange
+ * @see https://shelving.cc/db/DBChange
  */
 export type DBChange<I extends Identifier> = {
 	readonly action: "add" | "set" | "update" | "delete";
@@ -33,13 +33,13 @@ export type DBChange<I extends Identifier> = {
  *  await provider.addItem(users, { name: "Dave" });
  *  provider.changes; // [{ action: "add", collection: "users", id: 123, data: { name: "Dave" } }]
  *
- * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider
+ * @see https://shelving.cc/db/ChangesDBProvider
  */
 export class ChangesDBProvider<I extends Identifier, T extends Data> extends ThroughDBProvider<I, T> {
 	/**
 	 * The log of writes performed through this provider, in the order they happened.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/changes
+	 * @see https://shelving.cc/db/ChangesDBProvider/changes
 	 */
 	get changes(): ReadonlyArray<DBChange<I>> {
 		return this._changes;
@@ -53,7 +53,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/addItem
+	 * @see https://shelving.cc/db/ChangesDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = await super.addItem(collection, data);
@@ -68,7 +68,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/setItem
+	 * @see https://shelving.cc/db/ChangesDBProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await super.setItem(collection, id, data);
@@ -82,7 +82,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/updateItem
+	 * @see https://shelving.cc/db/ChangesDBProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -99,7 +99,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/deleteItem
+	 * @see https://shelving.cc/db/ChangesDBProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await super.deleteItem(collection, id);
@@ -113,7 +113,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/setQuery
+	 * @see https://shelving.cc/db/ChangesDBProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -131,7 +131,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/updateQuery
+	 * @see https://shelving.cc/db/ChangesDBProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -148,7 +148,7 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ChangesDBProvider/ChangesDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/ChangesDBProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,

--- a/modules/db/provider/DBProvider.ts
+++ b/modules/db/provider/DBProvider.ts
@@ -18,7 +18,7 @@ import type { Collection } from "../collection/Collection.js";
  *  const provider = new MemoryDBProvider();
  *  const id = await provider.addItem(users, { name: "Dave" });
  *
- * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider
+ * @see https://shelving.cc/db/DBProvider
  */
 export abstract class DBProvider<I extends Identifier = Identifier, T extends Data = Data> implements AsyncDisposable {
 	/**
@@ -28,7 +28,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/getItem
+	 * @see https://shelving.cc/db/DBProvider/getItem
 	 */
 	abstract getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>>;
 
@@ -40,7 +40,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @returns The item.
 	 * @throws `RequiredError` if no item exists with that id.
 	 * @example await provider.requireItem(users, 123) // Item (or throws).
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/requireItem
+	 * @see https://shelving.cc/db/DBProvider/requireItem
 	 */
 	async requireItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<Item<II, TT>> {
 		const item = await this.getItem(collection, id);
@@ -61,7 +61,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/getItemSequence
+	 * @see https://shelving.cc/db/DBProvider/getItemSequence
 	 */
 	abstract getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT>;
 
@@ -72,7 +72,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/addItem
+	 * @see https://shelving.cc/db/DBProvider/addItem
 	 */
 	abstract addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II>;
 
@@ -83,7 +83,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/setItem
+	 * @see https://shelving.cc/db/DBProvider/setItem
 	 */
 	abstract setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void>;
 
@@ -94,7 +94,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/updateItem
+	 * @see https://shelving.cc/db/DBProvider/updateItem
 	 */
 	abstract updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -108,7 +108,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/deleteItem
+	 * @see https://shelving.cc/db/DBProvider/deleteItem
 	 */
 	abstract deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void>;
 
@@ -119,7 +119,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/countQuery
+	 * @see https://shelving.cc/db/DBProvider/countQuery
 	 */
 	async countQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<number> {
 		return countArray(await this.getQuery(collection, query));
@@ -132,7 +132,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/getQuery
+	 * @see https://shelving.cc/db/DBProvider/getQuery
 	 */
 	abstract getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -146,7 +146,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/DBProvider/getQuerySequence
 	 */
 	abstract getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -160,7 +160,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/setQuery
+	 * @see https://shelving.cc/db/DBProvider/setQuery
 	 */
 	abstract setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -175,7 +175,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/updateQuery
+	 * @see https://shelving.cc/db/DBProvider/updateQuery
 	 */
 	abstract updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -189,7 +189,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/deleteQuery
+	 * @see https://shelving.cc/db/DBProvider/deleteQuery
 	 */
 	abstract deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void>;
 
@@ -200,7 +200,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @param query Query to filter and sort the items.
 	 * @returns The first matching item, or `undefined` if none match.
 	 * @example await provider.getFirst(users, { $order: "name" }) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/getFirst
+	 * @see https://shelving.cc/db/DBProvider/getFirst
 	 */
 	async getFirst<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -217,7 +217,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 	 * @returns The first matching item.
 	 * @throws `RequiredError` if no item matches the query.
 	 * @example await provider.requireFirst(users, { $order: "name" }) // Item (or throws).
-	 * @see https://dhoulb.github.io/shelving/db/provider/DBProvider/DBProvider/requireFirst
+	 * @see https://shelving.cc/db/DBProvider/requireFirst
 	 */
 	async requireFirst<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,

--- a/modules/db/provider/DebugDBProvider.ts
+++ b/modules/db/provider/DebugDBProvider.ts
@@ -16,7 +16,7 @@ import { ThroughDBProvider } from "./ThroughDBProvider.js";
  *  const provider = new DebugDBProvider(new MemoryDBProvider());
  *  await provider.getItem(users, 123); // Logs the call and its result.
  *
- * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider
+ * @see https://shelving.cc/db/DebugDBProvider
  */
 export class DebugDBProvider<I extends Identifier, T extends Data> extends ThroughDBProvider<I, T> {
 	/**
@@ -26,7 +26,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/getItem
+	 * @see https://shelving.cc/db/DebugDBProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		try {
@@ -47,7 +47,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/getItemSequence
+	 * @see https://shelving.cc/db/DebugDBProvider/getItemSequence
 	 */
 	override async *getItemSequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -72,7 +72,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/addItem
+	 * @see https://shelving.cc/db/DebugDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		try {
@@ -93,7 +93,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/setItem
+	 * @see https://shelving.cc/db/DebugDBProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		try {
@@ -113,7 +113,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/updateItem
+	 * @see https://shelving.cc/db/DebugDBProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -136,7 +136,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/deleteItem
+	 * @see https://shelving.cc/db/DebugDBProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		try {
@@ -156,7 +156,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/countQuery
+	 * @see https://shelving.cc/db/DebugDBProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -180,7 +180,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/getQuery
+	 * @see https://shelving.cc/db/DebugDBProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -204,7 +204,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/DebugDBProvider/getQuerySequence
 	 */
 	override async *getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -229,7 +229,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/setQuery
+	 * @see https://shelving.cc/db/DebugDBProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -253,7 +253,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/updateQuery
+	 * @see https://shelving.cc/db/DebugDBProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -276,7 +276,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/DebugDBProvider/DebugDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/DebugDBProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,

--- a/modules/db/provider/MemoryDBProvider.ts
+++ b/modules/db/provider/MemoryDBProvider.ts
@@ -25,7 +25,7 @@ import { DBProvider } from "./DBProvider.js";
  *  const provider = new MemoryDBProvider();
  *  const id = await provider.addItem(users, { name: "Dave" });
  *
- * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider
+ * @see https://shelving.cc/db/MemoryDBProvider
  */
 export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data = Data> extends DBProvider<I, T> {
 	/** List of tables in `{ name: MemoryTable }` format. */
@@ -37,7 +37,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param collection Collection to get the table for.
 	 * @returns The `MemoryTable` holding that collection's items.
 	 * @example provider.getTable(users) // MemoryTable
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/getTable
+	 * @see https://shelving.cc/db/MemoryDBProvider/getTable
 	 */
 	getTable<II extends I, TT extends T>(collection: Collection<string, II, TT>): MemoryTable<II, TT> {
 		return ((this._tables[collection.name] as MemoryTable<II, TT>) ||= new MemoryTable<II, TT>(collection));
@@ -50,7 +50,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/getItem
+	 * @see https://shelving.cc/db/MemoryDBProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return this.getTable(collection).getItem(id);
@@ -63,7 +63,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/getItemSequence
+	 * @see https://shelving.cc/db/MemoryDBProvider/getItemSequence
 	 */
 	override async *getItemSequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -79,7 +79,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/addItem
+	 * @see https://shelving.cc/db/MemoryDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		return this.getTable(collection).addItem(data);
@@ -92,7 +92,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/setItem
+	 * @see https://shelving.cc/db/MemoryDBProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		this.getTable(collection).setItem(id, data);
@@ -105,7 +105,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/updateItem
+	 * @see https://shelving.cc/db/MemoryDBProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -121,7 +121,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/deleteItem
+	 * @see https://shelving.cc/db/MemoryDBProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		this.getTable(collection).deleteItem(id);
@@ -134,7 +134,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/countQuery
+	 * @see https://shelving.cc/db/MemoryDBProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -150,7 +150,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/getQuery
+	 * @see https://shelving.cc/db/MemoryDBProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -166,7 +166,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/MemoryDBProvider/getQuerySequence
 	 */
 	override async *getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -182,7 +182,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/setQuery
+	 * @see https://shelving.cc/db/MemoryDBProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -199,7 +199,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/updateQuery
+	 * @see https://shelving.cc/db/MemoryDBProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -215,7 +215,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/MemoryDBProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -230,7 +230,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
 	 * @param collection Collection to write to.
 	 * @param items Items (each with its own id) to store.
 	 * @example provider.setItems(users, [{ id: 123, name: "Dave" }]);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryDBProvider/setItems
+	 * @see https://shelving.cc/db/MemoryDBProvider/setItems
 	 */
 	setItems<II extends I, TT extends T>(collection: Collection<string, II, TT>, items: Items<II, TT>): void {
 		this.getTable(collection).setItems(items);
@@ -247,7 +247,7 @@ export class MemoryDBProvider<I extends Identifier = Identifier, T extends Data 
  *  const table = provider.getTable(users);
  *  table.setItem(123, { name: "Dave" });
  *
- * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable
+ * @see https://shelving.cc/db/MemoryTable
  */
 export class MemoryTable<I extends Identifier, T extends Data> {
 	/** Actual data in this table. */
@@ -256,14 +256,14 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	/**
 	 * Deferred sequence that resolves on every change to this table.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/next
+	 * @see https://shelving.cc/db/MemoryTable/next
 	 */
 	public readonly next = new DeferredSequence();
 
 	/**
 	 * Collection this table stores the items of.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/collection
+	 * @see https://shelving.cc/db/MemoryTable/collection
 	 */
 	readonly collection: Collection<string, I, T>;
 
@@ -282,7 +282,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example table.getItem(123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/getItem
+	 * @see https://shelving.cc/db/MemoryTable/getItem
 	 */
 	getItem(id: I): OptionalItem<I, T> {
 		return this._data.get(id);
@@ -296,7 +296,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of table.getItemSequence(123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/getItemSequence
+	 * @see https://shelving.cc/db/MemoryTable/getItemSequence
 	 */
 	async *getItemSequence(id: I): AsyncIterable<OptionalItem<I, T>> {
 		let lastValue = this.getItem(id);
@@ -317,7 +317,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 *
 	 * @returns An id that no existing item in this table uses.
 	 * @example table.generateUniqueID() // 4827193 (or a random string)
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/generateUniqueID
+	 * @see https://shelving.cc/db/MemoryTable/generateUniqueID
 	 */
 	generateUniqueID(): I {
 		const gen = (this.collection.id instanceof StringSchema ? getRandomKey : getRandom) as () => I;
@@ -332,7 +332,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example table.addItem({ name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/addItem
+	 * @see https://shelving.cc/db/MemoryTable/addItem
 	 */
 	addItem(data: T): I {
 		const id = this.generateUniqueID();
@@ -347,7 +347,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param id Identifier of the item to set.
 	 * @param data Full item, or data to combine with `id` into an item.
 	 * @example table.setItem(123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/setItem
+	 * @see https://shelving.cc/db/MemoryTable/setItem
 	 */
 	setItem(id: I, data: Item<I, T> | T): void {
 		const item = getItem(id, data);
@@ -365,7 +365,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param sequence Source sequence of item values (or `undefined`) to mirror.
 	 * @returns Async sequence yielding each value after it has been mirrored.
 	 * @example for await (const item of table.setItemSequence(123, source)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/setItemSequence
+	 * @see https://shelving.cc/db/MemoryTable/setItemSequence
 	 */
 	async *setItemSequence(id: I, sequence: AsyncIterable<OptionalItem<I, T>>): AsyncIterable<OptionalItem<I, T>> {
 		for await (const item of sequence) {
@@ -381,7 +381,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example table.updateItem(123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/updateItem
+	 * @see https://shelving.cc/db/MemoryTable/updateItem
 	 */
 	updateItem(id: I, updates: Updates<Item<I, T>>): void {
 		const oldItem = this._data.get(id);
@@ -399,7 +399,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 *
 	 * @param id Identifier of the item to delete.
 	 * @example table.deleteItem(123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/deleteItem
+	 * @see https://shelving.cc/db/MemoryTable/deleteItem
 	 */
 	deleteItem(id: I): void {
 		if (this._data.has(id)) {
@@ -414,7 +414,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example table.countQuery({ age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/countQuery
+	 * @see https://shelving.cc/db/MemoryTable/countQuery
 	 */
 	countQuery(query?: Query<Item<I, T>>): number {
 		return query ? countItems(queryItems(this._data.values(), query)) : this._data.size;
@@ -426,7 +426,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example table.getQuery({ age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/getQuery
+	 * @see https://shelving.cc/db/MemoryTable/getQuery
 	 */
 	getQuery(query?: Query<Item<I, T>>): Items<I, T> {
 		return requireArray(query ? queryItems(this._data.values(), query) : this._data.values());
@@ -440,7 +440,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of table.getQuerySequence({ age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/getQuerySequence
+	 * @see https://shelving.cc/db/MemoryTable/getQuerySequence
 	 */
 	async *getQuerySequence(query?: Query<Item<I, T>>): AsyncIterable<Items<I, T>> {
 		let lastItems = this.getQuery(query);
@@ -461,7 +461,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example table.setQuery({ age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/setQuery
+	 * @see https://shelving.cc/db/MemoryTable/setQuery
 	 */
 	setQuery(query: Query<Item<I, T>>, data: T): void {
 		let changed = false;
@@ -481,7 +481,7 @@ export class MemoryTable<I extends Identifier, T extends Data> {
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example table.updateQuery({ age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MemoryDBProvider/MemoryTable/updateQuery
+	 * @see https://shelving.cc/db/MemoryTable/updateQuery
 	 */
 	updateQuery(query: Query<Item<I, T>>, updates: Updates<T>): void {
 		let changed = false;

--- a/modules/db/provider/MockDBProvider.ts
+++ b/modules/db/provider/MockDBProvider.ts
@@ -10,7 +10,7 @@ import { MemoryDBProvider } from "./MemoryDBProvider.js";
  *
  * - `type` is the operation name; `collection` is the collection name; `id`, `query`, `data`, `updates`, and `result` carry whichever fields apply to that operation.
  *
- * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBCall
+ * @see https://shelving.cc/db/MockDBCall
  */
 export type MockDBCall = {
 	readonly type:
@@ -43,13 +43,13 @@ export type MockDBCall = {
  *  await provider.addItem(users, { name: "Dave" });
  *  provider.calls; // [{ type: "addItem", collection: "users", data: { name: "Dave" }, result: 123 }]
  *
- * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider
+ * @see https://shelving.cc/db/MockDBProvider
  */
 export class MockDBProvider<I extends Identifier = Identifier, T extends Data = Data> extends MemoryDBProvider<I, T> {
 	/**
 	 * The log of operations performed through this provider, in the order they happened.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/calls
+	 * @see https://shelving.cc/db/MockDBProvider/calls
 	 */
 	readonly calls: MockDBCall[] = [];
 
@@ -60,7 +60,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/getItem
+	 * @see https://shelving.cc/db/MockDBProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const result = await super.getItem(collection, id);
@@ -75,7 +75,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/addItem
+	 * @see https://shelving.cc/db/MockDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const result = await super.addItem(collection, data);
@@ -90,7 +90,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/setItem
+	 * @see https://shelving.cc/db/MockDBProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await super.setItem(collection, id, data);
@@ -104,7 +104,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/updateItem
+	 * @see https://shelving.cc/db/MockDBProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -121,7 +121,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/deleteItem
+	 * @see https://shelving.cc/db/MockDBProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await super.deleteItem(collection, id);
@@ -135,7 +135,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/countQuery
+	 * @see https://shelving.cc/db/MockDBProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -153,7 +153,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/getQuery
+	 * @see https://shelving.cc/db/MockDBProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -171,7 +171,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/setQuery
+	 * @see https://shelving.cc/db/MockDBProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -189,7 +189,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/updateQuery
+	 * @see https://shelving.cc/db/MockDBProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -206,7 +206,7 @@ export class MockDBProvider<I extends Identifier = Identifier, T extends Data = 
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/MockDBProvider/MockDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/MockDBProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,

--- a/modules/db/provider/PostgreSQLProvider.ts
+++ b/modules/db/provider/PostgreSQLProvider.ts
@@ -11,7 +11,7 @@ import { type SQLFragment, SQLProvider } from "./SQLProvider.js";
  * @example
  *  class MyProvider extends PostgreSQLProvider { async exec(strings, ...values) { ... } }
  *  const item = await new MyProvider().getItem(collection, "abc");
- * @see https://dhoulb.github.io/shelving/db/provider/PostgreSQLProvider/PostgreSQLProvider
+ * @see https://shelving.cc/db/PostgreSQLProvider
  */
 export abstract class PostgreSQLProvider<I extends Identifier = Identifier, T extends Data = Data> extends SQLProvider<I, T> {
 	/** Get the Postgres JSONB path for the nested segments of a key, e.g. `{"b","c"}`. */
@@ -30,7 +30,7 @@ export abstract class PostgreSQLProvider<I extends Identifier = Identifier, T ex
 	 * @param key The key segments identifying the column and any nested JSONB path.
 	 * @returns An `SQLFragment` extracting the value.
 	 * @example this.sqlExtract(["a", "b"]); // "a" #>> {"b"}
-	 * @see https://dhoulb.github.io/shelving/db/provider/PostgreSQLProvider/PostgreSQLProvider/sqlExtract
+	 * @see https://shelving.cc/db/PostgreSQLProvider/sqlExtract
 	 */
 	override sqlExtract(key: Segments): SQLFragment {
 		const column = this.sqlIdentifier(key[0]);
@@ -48,7 +48,7 @@ export abstract class PostgreSQLProvider<I extends Identifier = Identifier, T ex
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the action is unsupported.
 	 * @example this.sqlUpdate({ action: "set", key: ["a", "b"], value: 1 })
-	 * @see https://dhoulb.github.io/shelving/db/provider/PostgreSQLProvider/PostgreSQLProvider/sqlUpdate
+	 * @see https://shelving.cc/db/PostgreSQLProvider/sqlUpdate
 	 */
 	override sqlUpdate(update: Update): SQLFragment {
 		const { action, key, value } = update;
@@ -107,7 +107,7 @@ export abstract class PostgreSQLProvider<I extends Identifier = Identifier, T ex
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the operator is unsupported.
 	 * @example this.sqlFilter({ key: ["tags"], operator: "contains", value: "x" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/PostgreSQLProvider/PostgreSQLProvider/sqlFilter
+	 * @see https://shelving.cc/db/PostgreSQLProvider/sqlFilter
 	 */
 	override sqlFilter(filter: QueryFilter): SQLFragment {
 		const { key, operator, value } = filter;

--- a/modules/db/provider/SQLProvider.ts
+++ b/modules/db/provider/SQLProvider.ts
@@ -11,7 +11,7 @@ import { DBProvider } from "./DBProvider.js";
 
 /**
  * SQL fragment made from template strings plus embedded expressions, ready to be composed into a query.
- * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLFragment
+ * @see https://shelving.cc/db/SQLFragment
  */
 export interface SQLFragment {
 	readonly strings: ImmutableArray<string>;
@@ -32,7 +32,7 @@ type CountRow = {
  * @example
  *  class MyProvider extends SQLProvider { async exec(strings, ...values) { ... } }
  *  const item = await new MyProvider().getItem(collection, "abc");
- * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider
+ * @see https://shelving.cc/db/SQLProvider
  */
 export abstract class SQLProvider<I extends Identifier = Identifier, T extends Data = Data> extends DBProvider<I, T> {
 	/**
@@ -42,7 +42,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param values The interpolated values to bind into the query.
 	 * @returns Promise resolving to the array of rows returned by the database.
 	 * @example await provider.exec`SELECT * FROM ${table}`
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/exec
+	 * @see https://shelving.cc/db/SQLProvider/exec
 	 */
 	abstract exec<X extends Data>(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): Promise<ImmutableArray<X>>;
 
@@ -53,7 +53,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param id The ID of the item to get.
 	 * @returns Promise resolving to the item, or `undefined` if it doesn't exist.
 	 * @example await provider.getItem(collection, "abc")
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/getItem
+	 * @see https://shelving.cc/db/SQLProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const rows = await this.exec<Item<II, TT>>`
@@ -72,7 +72,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns Never returns; always throws.
 	 * @throws {UnimplementedError} Always, because SQL providers don't support realtime subscriptions.
 	 * @example provider.getItemSequence(collection, "abc") // throws
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/getItemSequence
+	 * @see https://shelving.cc/db/SQLProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(_collection: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError(`SQLProvider does not support realtime subscriptions`);
@@ -86,7 +86,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns Promise resolving to the ID of the inserted item.
 	 * @throws {RequiredError} If the `INSERT` didn't return an ID.
 	 * @example await provider.addItem(collection, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/addItem
+	 * @see https://shelving.cc/db/SQLProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const rows = await this.exec<{ id: II }>`
@@ -106,7 +106,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param data The full data to store for the item.
 	 * @returns Promise that resolves once the item has been set.
 	 * @example await provider.setItem(collection, "abc", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/setItem
+	 * @see https://shelving.cc/db/SQLProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this.exec`
@@ -123,7 +123,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param updates The updates to apply.
 	 * @returns Promise that resolves once the item has been updated.
 	 * @example await provider.updateItem(collection, "abc", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/updateItem
+	 * @see https://shelving.cc/db/SQLProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -144,7 +144,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param id The ID of the item to delete.
 	 * @returns Promise that resolves once the item has been deleted.
 	 * @example await provider.deleteItem(collection, "abc")
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/deleteItem
+	 * @see https://shelving.cc/db/SQLProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await this.exec`DELETE FROM ${this.sqlIdentifier(collection.name)} WHERE ${this.sqlIdentifier("id")} = ${id}`;
@@ -157,7 +157,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query Optional query to filter the items to count.
 	 * @returns Promise resolving to the number of matching items.
 	 * @example await provider.countQuery(collection, query)
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/countQuery
+	 * @see https://shelving.cc/db/SQLProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -177,7 +177,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query Optional query to filter, sort, and limit the items.
 	 * @returns Promise resolving to the array of matching items.
 	 * @example await provider.getQuery(collection, query)
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/getQuery
+	 * @see https://shelving.cc/db/SQLProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -197,7 +197,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns Never returns; always throws.
 	 * @throws {UnimplementedError} Always, because SQL providers don't support realtime subscriptions.
 	 * @example provider.getQuerySequence(collection, query) // throws
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/getQuerySequence
+	 * @see https://shelving.cc/db/SQLProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(
 		_collection: Collection<string, II, TT>,
@@ -214,7 +214,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param data The full data to store for each matching item.
 	 * @returns Promise that resolves once the matching items have been set.
 	 * @example await provider.setQuery(collection, query, { active: true })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/setQuery
+	 * @see https://shelving.cc/db/SQLProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -232,7 +232,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param updates The updates to apply to each matching item.
 	 * @returns Promise that resolves once the matching items have been updated.
 	 * @example await provider.updateQuery(collection, query, { active: true })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/updateQuery
+	 * @see https://shelving.cc/db/SQLProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -249,7 +249,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query The query selecting the items to delete.
 	 * @returns Promise that resolves once the matching items have been deleted.
 	 * @example await provider.deleteQuery(collection, query)
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/deleteQuery
+	 * @see https://shelving.cc/db/SQLProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -265,7 +265,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param values The interpolated values to embed into the fragment.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sql`SELECT * FROM ${table}`; // SQLFragment
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sql
+	 * @see https://shelving.cc/db/SQLProvider/sql
 	 */
 	sql(strings: TemplateStringsArray, ...values: ImmutableArray<unknown>): SQLFragment {
 		return { strings, values };
@@ -277,7 +277,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param name The identifier (table or column name) to escape.
 	 * @returns An `SQLFragment` containing the quoted identifier.
 	 * @example this.sqlIdentifier("myTable"); // "myTable"
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlIdentifier
+	 * @see https://shelving.cc/db/SQLProvider/sqlIdentifier
 	 */
 	sqlIdentifier(name: string): SQLFragment {
 		return { strings: [_escapeIdentifier(name)], values: [] };
@@ -291,7 +291,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns An `SQLFragment` extracting the value.
 	 * @throws {UnimplementedError} If the key is nested (multi-segment).
 	 * @example this.sqlExtract(["name"]); // "name"
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlExtract
+	 * @see https://shelving.cc/db/SQLProvider/sqlExtract
 	 */
 	sqlExtract(key: Segments): SQLFragment {
 		if (key.length > 1) throw new UnimplementedError("SQLProvider does not support nested filter keys");
@@ -307,7 +307,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param after Text placed after the last fragment.
 	 * @returns The joined `SQLFragment`.
 	 * @example this.sqlConcat([a, b], " AND "); // a AND b
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlConcat
+	 * @see https://shelving.cc/db/SQLProvider/sqlConcat
 	 */
 	sqlConcat(values: ImmutableArray<SQLFragment>, separator = ", ", before = "", after = ""): SQLFragment {
 		const strings = [before, ...new Array(Math.max(0, values.length - 1)).fill(separator), after];
@@ -320,7 +320,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param data The data whose entries become `column = value` assignments.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sqlSetters({ a: 1, b: 2 }); // "a" = 1, "b" = 2
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlSetters
+	 * @see https://shelving.cc/db/SQLProvider/sqlSetters
 	 */
 	sqlSetters<TT extends Data>(data: TT): SQLFragment {
 		const entries = Object.entries(data);
@@ -336,7 +336,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param updates The updates to convert into SQL assignments.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sqlUpdates({ a: 1 }); // "a" = 1
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlUpdates
+	 * @see https://shelving.cc/db/SQLProvider/sqlUpdates
 	 */
 	sqlUpdates<TT extends Data>(updates: Updates<TT>): SQLFragment {
 		return this.sqlConcat(
@@ -355,7 +355,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the key is nested or the action is unsupported.
 	 * @example this.sqlUpdate({ action: "set", key: ["a"], value: 1 }); // "a" = 1
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlUpdate
+	 * @see https://shelving.cc/db/SQLProvider/sqlUpdate
 	 */
 	sqlUpdate({ action, key, value }: Update): SQLFragment {
 		if (key.length > 1) throw new UnimplementedError("SQLProvider does not support nested update keys");
@@ -371,7 +371,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param data The data whose keys and values become the column list and values.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sqlValues({ a: 1, b: 2 }); // ("a", "b") VALUES (1, 2)
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlValues
+	 * @see https://shelving.cc/db/SQLProvider/sqlValues
 	 */
 	sqlValues(data: Data): SQLFragment {
 		const entries = Object.entries(data);
@@ -392,7 +392,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query The query to translate into clauses.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sqlClauses(query); // WHERE ... ORDER BY ... LIMIT ...
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlClauses
+	 * @see https://shelving.cc/db/SQLProvider/sqlClauses
 	 */
 	sqlClauses(query: Query<Item>) {
 		return this.sql`${this.sqlWhere(query)}${this.sqlOrder(query)}${this.sqlLimit(query)}`;
@@ -404,7 +404,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query The query whose filters become the `WHERE` clause.
 	 * @returns The composed `SQLFragment` (empty if there are no filters).
 	 * @example this.sqlWhere(query); // WHERE x = 1
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlWhere
+	 * @see https://shelving.cc/db/SQLProvider/sqlWhere
 	 */
 	sqlWhere(query: Query<Item>) {
 		const filters = getQueryFilters(query);
@@ -422,7 +422,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the operator is unsupported.
 	 * @example this.sqlFilter({ key: ["x"], operator: "is", value: 1 }); // "x" = 1
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlFilter
+	 * @see https://shelving.cc/db/SQLProvider/sqlFilter
 	 */
 	sqlFilter({ key, operator, value }: QueryFilter): SQLFragment {
 		const path = this.sqlExtract(key);
@@ -451,7 +451,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @returns The composed `SQLFragment` (empty if there are no orders).
 	 * @throws {UnimplementedError} If an order key is nested (multi-segment).
 	 * @example this.sqlOrder(query); // ORDER BY "a" ASC
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlOrder
+	 * @see https://shelving.cc/db/SQLProvider/sqlOrder
 	 */
 	sqlOrder(query: Query<Item>) {
 		const orders = getQueryOrders(query);
@@ -468,7 +468,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param order The order (`key`, `direction`) to translate.
 	 * @returns The composed `SQLFragment`.
 	 * @example this.sqlSort({ key: ["a"], direction: "asc" }); // "a" ASC
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlSort
+	 * @see https://shelving.cc/db/SQLProvider/sqlSort
 	 */
 	sqlSort({ key, direction }: QueryOrder): SQLFragment {
 		const path = this.sqlExtract(key);
@@ -483,7 +483,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 * @param query The query whose limit becomes the `LIMIT` clause.
 	 * @returns The composed `SQLFragment` (empty if the query has no limit).
 	 * @example this.sqlLimit(query); // LIMIT 50
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLProvider/SQLProvider/sqlLimit
+	 * @see https://shelving.cc/db/SQLProvider/sqlLimit
 	 */
 	sqlLimit(query: Query<Item>) {
 		const limit = getQueryLimit(query);

--- a/modules/db/provider/SQLiteProvider.ts
+++ b/modules/db/provider/SQLiteProvider.ts
@@ -17,7 +17,7 @@ import { type SQLFragment, SQLProvider } from "./SQLProvider.js";
  * @example
  *  class MyProvider extends SQLiteProvider { async exec(strings, ...values) { ... } }
  *  const item = await new MyProvider().getItem(collection, "abc");
- * @see https://dhoulb.github.io/shelving/db/provider/SQLiteProvider/SQLiteProvider
+ * @see https://shelving.cc/db/SQLiteProvider
  */
 export abstract class SQLiteProvider<I extends Identifier = Identifier, T extends Data = Data> extends SQLProvider<I, T> {
 	/**
@@ -28,7 +28,7 @@ export abstract class SQLiteProvider<I extends Identifier = Identifier, T extend
 	 * @param data The data of the item to insert.
 	 * @returns Promise resolving to the ID of the inserted item.
 	 * @example await provider.addItem(collection, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLiteProvider/SQLiteProvider/addItem
+	 * @see https://shelving.cc/db/SQLiteProvider/addItem
 	 */
 	// SQLite has no native UUID generation, so when the collection uses a `StringSchema` ID
 	// we generate the UUID client-side and delegate to `setItem`.
@@ -57,7 +57,7 @@ export abstract class SQLiteProvider<I extends Identifier = Identifier, T extend
 	 * @param key The key segments identifying the column and any nested JSON path.
 	 * @returns An `SQLFragment` extracting the value.
 	 * @example this.sqlExtract(["a", "b"]); // json_extract("a", $.b)
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLiteProvider/SQLiteProvider/sqlExtract
+	 * @see https://shelving.cc/db/SQLiteProvider/sqlExtract
 	 */
 	override sqlExtract(key: Segments): SQLFragment {
 		const column = this.sqlIdentifier(key[0]);
@@ -75,7 +75,7 @@ export abstract class SQLiteProvider<I extends Identifier = Identifier, T extend
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the action is unsupported.
 	 * @example this.sqlUpdate({ action: "set", key: ["a", "b"], value: 1 })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLiteProvider/SQLiteProvider/sqlUpdate
+	 * @see https://shelving.cc/db/SQLiteProvider/sqlUpdate
 	 */
 	override sqlUpdate(update: Update): SQLFragment {
 		const { action, key, value } = update;
@@ -148,7 +148,7 @@ export abstract class SQLiteProvider<I extends Identifier = Identifier, T extend
 	 * @returns The composed `SQLFragment`.
 	 * @throws {UnimplementedError} If the operator is unsupported.
 	 * @example this.sqlFilter({ key: ["tags"], operator: "contains", value: "x" })
-	 * @see https://dhoulb.github.io/shelving/db/provider/SQLiteProvider/SQLiteProvider/sqlFilter
+	 * @see https://shelving.cc/db/SQLiteProvider/sqlFilter
 	 */
 	override sqlFilter(filter: QueryFilter): SQLFragment {
 		const { key, operator, value } = filter;

--- a/modules/db/provider/ThroughDBProvider.ts
+++ b/modules/db/provider/ThroughDBProvider.ts
@@ -16,13 +16,13 @@ import type { DBProvider } from "./DBProvider.js";
  * @example
  *  const provider = new ValidationDBProvider(new MemoryDBProvider());
  *
- * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider
+ * @see https://shelving.cc/db/ThroughDBProvider
  */
 export class ThroughDBProvider<I extends Identifier, T extends Data> implements DBProvider<I, T>, Sourceable<DBProvider<I, T>> {
 	/**
 	 * The wrapped source provider that every operation is delegated to.
 	 *
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/source
+	 * @see https://shelving.cc/db/ThroughDBProvider/source
 	 */
 	readonly source: DBProvider<I, T>;
 
@@ -42,7 +42,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param id Identifier of the item to get.
 	 * @returns The item, or `undefined` if no item exists with that id.
 	 * @example await provider.getItem(users, 123) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/getItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/getItem
 	 */
 	getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return this.source.getItem(collection, id);
@@ -56,7 +56,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @returns The item.
 	 * @throws `RequiredError` if no item exists with that id.
 	 * @example await provider.requireItem(users, 123) // Item (or throws).
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/requireItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/requireItem
 	 */
 	requireItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<Item<II, TT>> {
 		return this.source.requireItem(collection, id);
@@ -69,7 +69,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param id Identifier of the item to subscribe to.
 	 * @returns Async sequence yielding the item (or `undefined`) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/getItemSequence
+	 * @see https://shelving.cc/db/ThroughDBProvider/getItemSequence
 	 */
 	getItemSequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		return this.source.getItemSequence(collection, id);
@@ -82,7 +82,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param data Data for the new item.
 	 * @returns The generated identifier for the new item.
 	 * @example await provider.addItem(users, { name: "Dave" }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/addItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/addItem
 	 */
 	addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		return this.source.addItem(collection, data);
@@ -95,7 +95,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param id Identifier of the item to set.
 	 * @param data Full data to store for the item.
 	 * @example await provider.setItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/setItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/setItem
 	 */
 	setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		return this.source.setItem(collection, id, data);
@@ -108,7 +108,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param id Identifier of the item to update.
 	 * @param updates Updates to apply to the item.
 	 * @example await provider.updateItem(users, 123, { name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/updateItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/updateItem
 	 */
 	updateItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, updates: Updates<Item<II, TT>>): Promise<void> {
 		return this.source.updateItem(collection, id, updates);
@@ -120,7 +120,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param collection Collection the item belongs to.
 	 * @param id Identifier of the item to delete.
 	 * @example await provider.deleteItem(users, 123);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/deleteItem
+	 * @see https://shelving.cc/db/ThroughDBProvider/deleteItem
 	 */
 	deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		return this.source.deleteItem(collection, id);
@@ -133,7 +133,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/countQuery
+	 * @see https://shelving.cc/db/ThroughDBProvider/countQuery
 	 */
 	countQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<number> {
 		return this.source.countQuery(collection, query);
@@ -146,7 +146,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query to filter, sort, and limit the items (returns all items when omitted).
 	 * @returns An array of matching items.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/getQuery
+	 * @see https://shelving.cc/db/ThroughDBProvider/getQuery
 	 */
 	getQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return this.source.getQuery(collection, query);
@@ -159,7 +159,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query to filter, sort, and limit the items.
 	 * @returns Async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/ThroughDBProvider/getQuerySequence
 	 */
 	getQuerySequence<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		return this.source.getQuerySequence(collection, query);
@@ -172,7 +172,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query selecting the items to set.
 	 * @param data Full data to store for each matching item.
 	 * @example await provider.setQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/setQuery
+	 * @see https://shelving.cc/db/ThroughDBProvider/setQuery
 	 */
 	setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
 		return this.source.setQuery(collection, query, data);
@@ -185,7 +185,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query selecting the items to update.
 	 * @param updates Updates to apply to each matching item.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/updateQuery
+	 * @see https://shelving.cc/db/ThroughDBProvider/updateQuery
 	 */
 	updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -201,7 +201,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/ThroughDBProvider/deleteQuery
 	 */
 	deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
 		return this.source.deleteQuery(collection, query);
@@ -214,7 +214,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @param query Query to filter and sort the items.
 	 * @returns The first matching item, or `undefined` if none match.
 	 * @example await provider.getFirst(users, { $order: "name" }) // Item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/getFirst
+	 * @see https://shelving.cc/db/ThroughDBProvider/getFirst
 	 */
 	getFirst<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<OptionalItem<II, TT>> {
 		return this.source.getFirst(collection, query);
@@ -228,7 +228,7 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	 * @returns The first matching item.
 	 * @throws `RequiredError` if no item matches the query.
 	 * @example await provider.requireFirst(users, { $order: "name" }) // Item (or throws).
-	 * @see https://dhoulb.github.io/shelving/db/provider/ThroughDBProvider/ThroughDBProvider/requireFirst
+	 * @see https://shelving.cc/db/ThroughDBProvider/requireFirst
 	 */
 	requireFirst<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<Item<II, TT>> {
 		return this.source.requireFirst(collection, query);

--- a/modules/db/provider/ValidationDBProvider.ts
+++ b/modules/db/provider/ValidationDBProvider.ts
@@ -21,7 +21,7 @@ import { ThroughDBProvider } from "./ThroughDBProvider.js";
  *  const provider = new ValidationDBProvider(new FirestoreProvider());
  *  await provider.setItem(users, 123, { name: "Dave", age: 40 }); // Validates before writing.
  *
- * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider
+ * @see https://shelving.cc/db/ValidationDBProvider
  */
 export class ValidationDBProvider<I extends Identifier, T extends Data> extends ThroughDBProvider<I, T> {
 	/**
@@ -32,7 +32,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @returns The validated item, or `undefined` if no item exists with that id.
 	 * @throws `ValueError` if the stored item does not validate against the collection schema.
 	 * @example await provider.getItem(users, 123) // Validated item or undefined.
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/getItem
+	 * @see https://shelving.cc/db/ValidationDBProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return _validateItem(collection, await super.getItem(collection, id), this.getItem);
@@ -46,7 +46,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @returns Async sequence yielding the validated item (or `undefined`) on every change.
 	 * @throws `ValueError` if an emitted item does not validate against the collection schema.
 	 * @example for await (const item of provider.getItemSequence(users, 123)) console.log(item);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/getItemSequence
+	 * @see https://shelving.cc/db/ValidationDBProvider/getItemSequence
 	 */
 	override async *getItemSequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -63,7 +63,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @returns The validated generated identifier for the new item.
 	 * @throws `ValueError` if the data or returned id does not validate against the collection schema.
 	 * @example await provider.addItem(users, { name: "Dave", age: 40 }) // 123
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/addItem
+	 * @see https://shelving.cc/db/ValidationDBProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		return _validateIdentifier(collection, await super.addItem(collection, collection.validate(data)), this.addItem);
@@ -77,7 +77,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param data Full data to store for the item (validated before writing).
 	 * @throws `ValueError` if the data does not validate against the collection schema.
 	 * @example await provider.setItem(users, 123, { name: "Dave", age: 40 });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/setItem
+	 * @see https://shelving.cc/db/ValidationDBProvider/setItem
 	 */
 	override setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		return super.setItem(collection, id, collection.validate(data));
@@ -91,7 +91,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param updates Updates to apply (validated before writing).
 	 * @throws `ValueError` if the updates do not validate against the collection schema.
 	 * @example await provider.updateItem(users, 123, { age: 41 });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/updateItem
+	 * @see https://shelving.cc/db/ValidationDBProvider/updateItem
 	 */
 	override updateItem<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -108,7 +108,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param query Query to filter the counted items (counts all items when omitted).
 	 * @returns The number of matching items.
 	 * @example await provider.countQuery(users, { age: 40 }) // 7
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/countQuery
+	 * @see https://shelving.cc/db/ValidationDBProvider/countQuery
 	 */
 	override countQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query?: Query<Item<II, TT>>): Promise<number> {
 		return super.countQuery(collection, query);
@@ -122,7 +122,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @returns An array of validated matching items.
 	 * @throws `ValueError` if one or more stored items do not validate against the collection schema.
 	 * @example await provider.getQuery(users, { age: 40, $order: "name" }) // Validated items.
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/getQuery
+	 * @see https://shelving.cc/db/ValidationDBProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -139,7 +139,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @returns Async sequence yielding the validated matching items on every change.
 	 * @throws `ValueError` if one or more emitted items do not validate against the collection schema.
 	 * @example for await (const items of provider.getQuerySequence(users, { age: 40 })) console.log(items);
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/getQuerySequence
+	 * @see https://shelving.cc/db/ValidationDBProvider/getQuerySequence
 	 */
 	override async *getQuerySequence<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -156,7 +156,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param data Full data to store for each matching item (validated before writing).
 	 * @throws `ValueError` if the data does not validate against the collection schema.
 	 * @example await provider.setQuery(users, { age: 40 }, { name: "Dave", age: 41 });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/setQuery
+	 * @see https://shelving.cc/db/ValidationDBProvider/setQuery
 	 */
 	override setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -174,7 +174,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param updates Updates to apply to each matching item (validated before writing).
 	 * @throws `ValueError` if the updates do not validate against the collection schema.
 	 * @example await provider.updateQuery(users, { age: 40 }, { active: true });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/updateQuery
+	 * @see https://shelving.cc/db/ValidationDBProvider/updateQuery
 	 */
 	override updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
@@ -190,7 +190,7 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.
 	 * @example await provider.deleteQuery(users, { active: false });
-	 * @see https://dhoulb.github.io/shelving/db/provider/ValidationDBProvider/ValidationDBProvider/deleteQuery
+	 * @see https://shelving.cc/db/ValidationDBProvider/deleteQuery
 	 */
 	override deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
 		return super.deleteQuery(collection, query);

--- a/modules/db/store/ItemStore.ts
+++ b/modules/db/store/ItemStore.ts
@@ -19,22 +19,22 @@ import type { MemoryDBProvider } from "../provider/MemoryDBProvider.js";
  * @example
  *  const store = new ItemStore(collection, "abc", provider);
  *  const item = await store; // OptionalItem<I, T>
- * @see https://dhoulb.github.io/shelving/db/store/ItemStore/ItemStore
+ * @see https://shelving.cc/db/ItemStore
  */
 export class ItemStore<I extends Identifier, T extends Data> extends FetchStore<OptionalItem<I, T>> {
 	/**
 	 * The database provider this store fetches its item from.
-	 * @see https://dhoulb.github.io/shelving/db/store/ItemStore/ItemStore/provider
+	 * @see https://shelving.cc/db/ItemStore/provider
 	 */
 	readonly provider: DBProvider<I>;
 	/**
 	 * The collection the item lives in.
-	 * @see https://dhoulb.github.io/shelving/db/store/ItemStore/ItemStore/collection
+	 * @see https://shelving.cc/db/ItemStore/collection
 	 */
 	readonly collection: Collection<string, I, T>;
 	/**
 	 * The ID of the item this store tracks.
-	 * @see https://dhoulb.github.io/shelving/db/store/ItemStore/ItemStore/id
+	 * @see https://shelving.cc/db/ItemStore/id
 	 */
 	readonly id: I;
 
@@ -45,7 +45,7 @@ export class ItemStore<I extends Identifier, T extends Data> extends FetchStore<
 	 * @returns The item data including its ID.
 	 * @throws {RequiredError} If the item doesn't exist (i.e. if `this.value` is `undefined`).
 	 * @example store.item // Item<I, T>
-	 * @see https://dhoulb.github.io/shelving/db/store/ItemStore/ItemStore/item
+	 * @see https://shelving.cc/db/ItemStore/item
 	 */
 	get item(): Item<I, T> {
 		const item = this.value;

--- a/modules/db/store/QueryStore.ts
+++ b/modules/db/store/QueryStore.ts
@@ -20,27 +20,27 @@ import type { MemoryDBProvider } from "../provider/MemoryDBProvider.js";
  * @example
  *  const store = new QueryStore(collection, query, provider);
  *  for (const item of store) console.log(item);
- * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore
+ * @see https://shelving.cc/db/QueryStore
  */
 export class QueryStore<I extends Identifier, T extends Data> extends FetchStore<Items<I, T>> implements Iterable<Item<I, T>> {
 	/**
 	 * The database provider this store fetches its items from.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/provider
+	 * @see https://shelving.cc/db/QueryStore/provider
 	 */
 	readonly provider: DBProvider<I>;
 	/**
 	 * The collection the query runs against.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/collection
+	 * @see https://shelving.cc/db/QueryStore/collection
 	 */
 	readonly collection: Collection<string, I, T>;
 	/**
 	 * The query that selects the items tracked by this store.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/query
+	 * @see https://shelving.cc/db/QueryStore/query
 	 */
 	readonly query: Query<Item<I, T>>;
 	/**
 	 * The maximum number of items the query can return, or `Infinity` if unlimited.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/limit
+	 * @see https://shelving.cc/db/QueryStore/limit
 	 */
 	get limit(): number {
 		return getQueryLimit(this.query) ?? Number.POSITIVE_INFINITY;
@@ -48,7 +48,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 
 	/**
 	 * Whether more items can be loaded after the current result.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/hasMore
+	 * @see https://shelving.cc/db/QueryStore/hasMore
 	 */
 	get hasMore(): boolean {
 		return this._hasMore;
@@ -57,7 +57,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 
 	/**
 	 * The first item in this store, or `undefined` if the query has no items.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/optionalFirst
+	 * @see https://shelving.cc/db/QueryStore/optionalFirst
 	 */
 	get optionalFirst(): Item<I, T> | undefined {
 		return getFirst(this.value);
@@ -65,7 +65,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 
 	/**
 	 * The last item in this store, or `undefined` if the query has no items.
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/optionalLast
+	 * @see https://shelving.cc/db/QueryStore/optionalLast
 	 */
 	get optionalLast(): Item<I, T> | undefined {
 		return getLast(this.value);
@@ -77,7 +77,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 	 * @returns The first matching item including its ID.
 	 * @throws {RequiredError} If the query has no items.
 	 * @example store.first // Item<I, T>
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/first
+	 * @see https://shelving.cc/db/QueryStore/first
 	 */
 	get first(): Item<I, T> {
 		const first = this.optionalFirst;
@@ -98,7 +98,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 	 * @returns The last matching item including its ID.
 	 * @throws {RequiredError} If the query has no items.
 	 * @example store.last // Item<I, T>
-	 * @see https://dhoulb.github.io/shelving/db/store/QueryStore/QueryStore/last
+	 * @see https://shelving.cc/db/QueryStore/last
 	 */
 	get last(): Item<I, T> {
 		const last = this.optionalLast;

--- a/modules/error/BaseError.ts
+++ b/modules/error/BaseError.ts
@@ -4,7 +4,7 @@ import type { AnyCaller } from "../util/function.js";
  * Options for `BaseError` that provide additional helpful error functionality.
  * - Extends the built-in `ErrorOptions` (so `cause` is supported) and adds a `caller` plus arbitrary contextual fields.
  *
- * @see https://dhoulb.github.io/shelving/error/BaseError/BaseErrorOptions
+ * @see https://shelving.cc/error/BaseErrorOptions
  */
 export interface BaseErrorOptions extends globalThis.ErrorOptions {
 	/**
@@ -23,7 +23,7 @@ export interface BaseErrorOptions extends globalThis.ErrorOptions {
  * - Carries arbitrary named contextual data alongside the standard `Error` fields.
  * - All concrete error classes in this module (`ValueError`, `RequiredError`, etc.) implement this shape.
  *
- * @see https://dhoulb.github.io/shelving/error/BaseError/BaseError
+ * @see https://shelving.cc/error/BaseError
  */
 export interface BaseError extends Error {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */
@@ -42,7 +42,7 @@ export interface BaseError extends Error {
  * @example
  * 	const error = new ValueError("Wrong");
  * 	setBaseErrorOptions(ValueError, error, { received: 123, caller: myFunction });
- * @see https://dhoulb.github.io/shelving/error/BaseError/setBaseErrorOptions
+ * @see https://shelving.cc/error/setBaseErrorOptions
  */
 export function setBaseErrorOptions(defaultCaller: AnyCaller, error: BaseError, options: BaseErrorOptions): void {
 	const { cause: _cause, caller = defaultCaller, ...rest } = options;

--- a/modules/error/Errors.ts
+++ b/modules/error/Errors.ts
@@ -6,7 +6,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new Errors([new ValueError("Bad name"), new ValueError("Bad age")], "Validation failed");
- * @see https://dhoulb.github.io/shelving/error/Errors/Errors
+ * @see https://shelving.cc/error/Errors
  */
 export class Errors extends AggregateError implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/error/NetworkError.ts
+++ b/modules/error/NetworkError.ts
@@ -5,7 +5,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new NetworkError("Connection lost");
- * @see https://dhoulb.github.io/shelving/error/NetworkError/NetworkError
+ * @see https://shelving.cc/error/NetworkError
  */
 export class NetworkError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/error/RequestError.ts
+++ b/modules/error/RequestError.ts
@@ -12,7 +12,7 @@ interface RequestErrorOptions extends BaseErrorOptions {
  *
  * @example
  * 	throw new RequestError("Bad request", { code: 400 });
- * @see https://dhoulb.github.io/shelving/error/RequestError/RequestError
+ * @see https://shelving.cc/error/RequestError
  */
 export class RequestError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */
@@ -21,7 +21,7 @@ export class RequestError extends Error implements BaseError {
 	/**
 	 * HTTP status code for this error in the range `400-499`, defaults to `400`.
 	 *
-	 * @see https://dhoulb.github.io/shelving/error/RequestError/RequestError/code
+	 * @see https://shelving.cc/error/RequestError/code
 	 */
 	readonly code: number;
 
@@ -45,7 +45,7 @@ RequestError.prototype.name = "RequestError";
  *
  * @example
  * 	throw new UnauthorizedError("Please log in");
- * @see https://dhoulb.github.io/shelving/error/RequestError/UnauthorizedError
+ * @see https://shelving.cc/error/UnauthorizedError
  */
 export class UnauthorizedError extends RequestError {
 	/**
@@ -66,7 +66,7 @@ UnauthorizedError.prototype.name = "UnauthorizedError";
  *
  * @example
  * 	throw new NotFoundError("User does not exist");
- * @see https://dhoulb.github.io/shelving/error/RequestError/NotFoundError
+ * @see https://shelving.cc/error/NotFoundError
  */
 export class NotFoundError extends RequestError {
 	/**
@@ -87,7 +87,7 @@ NotFoundError.prototype.name = "NotFoundError";
  *
  * @example
  * 	throw new UnprocessableError("Email address is invalid");
- * @see https://dhoulb.github.io/shelving/error/RequestError/UnprocessableError
+ * @see https://shelving.cc/error/UnprocessableError
  */
 export class UnprocessableError extends RequestError {
 	/**
@@ -108,7 +108,7 @@ UnprocessableError.prototype.name = "UnprocessableError";
  *
  * @example
  * 	throw new ForbiddenError("Admins only");
- * @see https://dhoulb.github.io/shelving/error/RequestError/ForbiddenError
+ * @see https://shelving.cc/error/ForbiddenError
  */
 export class ForbiddenError extends RequestError {
 	/**
@@ -129,7 +129,7 @@ ForbiddenError.prototype.name = "ForbiddenError";
  *
  * @example
  * 	throw new MethodNotAllowedError("Use POST not GET");
- * @see https://dhoulb.github.io/shelving/error/RequestError/MethodNotAllowedError
+ * @see https://shelving.cc/error/MethodNotAllowedError
  */
 export class MethodNotAllowedError extends RequestError {
 	/**

--- a/modules/error/RequiredError.ts
+++ b/modules/error/RequiredError.ts
@@ -6,7 +6,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new RequiredError("Name is required");
- * @see https://dhoulb.github.io/shelving/error/RequiredError/RequiredError
+ * @see https://shelving.cc/error/RequiredError
  */
 export class RequiredError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/error/ResponseError.ts
+++ b/modules/error/ResponseError.ts
@@ -11,7 +11,7 @@ interface ResponseErrorOptions extends BaseErrorOptions {
  *
  * @example
  * 	throw new ResponseError("Unexpected response body", { code: 422 });
- * @see https://dhoulb.github.io/shelving/error/ResponseError/ResponseError
+ * @see https://shelving.cc/error/ResponseError
  */
 export class ResponseError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */
@@ -20,7 +20,7 @@ export class ResponseError extends Error implements BaseError {
 	/**
 	 * HTTP status code for the response.
 	 *
-	 * @see https://dhoulb.github.io/shelving/error/ResponseError/ResponseError/code
+	 * @see https://shelving.cc/error/ResponseError/code
 	 */
 	readonly code: number;
 

--- a/modules/error/UnexpectedError.ts
+++ b/modules/error/UnexpectedError.ts
@@ -6,7 +6,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new UnexpectedError("Should never reach here");
- * @see https://dhoulb.github.io/shelving/error/UnexpectedError/UnexpectedError
+ * @see https://shelving.cc/error/UnexpectedError
  */
 export class UnexpectedError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/error/UnimplementedError.ts
+++ b/modules/error/UnimplementedError.ts
@@ -5,7 +5,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new UnimplementedError("Not supported by this provider");
- * @see https://dhoulb.github.io/shelving/error/UnimplementedError/UnimplementedError
+ * @see https://shelving.cc/error/UnimplementedError
  */
 export class UnimplementedError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/error/ValueError.ts
+++ b/modules/error/ValueError.ts
@@ -6,7 +6,7 @@ import { type BaseError, type BaseErrorOptions, setBaseErrorOptions } from "./Ba
  *
  * @example
  * 	throw new ValueError("Must be a positive number", { received: -1 });
- * @see https://dhoulb.github.io/shelving/error/ValueError/ValueError
+ * @see https://shelving.cc/error/ValueError
  */
 export class ValueError extends Error implements BaseError {
 	/** Provide additional named contextual data that is relevant to the `Error` instance. */

--- a/modules/extract/DirectoryExtractor.ts
+++ b/modules/extract/DirectoryExtractor.ts
@@ -28,7 +28,7 @@ const DEFAULT_IGNORE: Matchables = [/\.test\.tsx?$/i, /\.spec\.tsx?$/i, /^node_m
 /**
  * Options for a directory extractor.
  *
- * @see https://dhoulb.github.io/shelving/extract/DirectoryExtractor/DirectoryExtractorOptions
+ * @see https://shelving.cc/extract/DirectoryExtractorOptions
  */
 export interface DirectoryExtractorOptions {
 	/**
@@ -57,7 +57,7 @@ export interface DirectoryExtractorOptions {
  *
  * @example const tree = await new DirectoryExtractor().extract("modules/util");
  *
- * @see https://dhoulb.github.io/shelving/extract/DirectoryExtractor
+ * @see https://shelving.cc/extract/DirectoryExtractor
  */
 export class DirectoryExtractor extends Extractor<Path, TreeElement> {
 	private readonly _extractors: ImmutableDictionary<FileExtractor>;
@@ -84,7 +84,7 @@ export class DirectoryExtractor extends Extractor<Path, TreeElement> {
 	 *
 	 * @example const tree = await new DirectoryExtractor().extract("modules/util");
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/DirectoryExtractor/extract
+	 * @see https://shelving.cc/extract/extract
 	 */
 	override extract(source: Path): Promise<TreeElement> {
 		return this._extractDirectory(requirePath(source, this._base, this.extract));

--- a/modules/extract/Extractor.ts
+++ b/modules/extract/Extractor.ts
@@ -10,7 +10,7 @@ import type { TreeElement } from "../util/tree.js";
  * class JSONExtractor extends Extractor<string, TreeElement> {
  * 	extract(input: string): TreeElement { return JSON.parse(input); }
  * }
- * @see https://dhoulb.github.io/shelving/extract/Extractor/Extractor
+ * @see https://shelving.cc/extract/Extractor
  */
 export abstract class Extractor<I, O extends TreeElement = TreeElement> {
 	/**
@@ -19,7 +19,7 @@ export abstract class Extractor<I, O extends TreeElement = TreeElement> {
 	 * @param input The input value to extract from.
 	 * @returns The extracted `TreeElement`, or a promise resolving to one.
 	 * @example await myExtractor.extract(input)
-	 * @see https://dhoulb.github.io/shelving/extract/Extractor/Extractor/extract
+	 * @see https://shelving.cc/extract/Extractor/extract
 	 */
 	abstract extract(input: I): O | Promise<O>;
 }
@@ -35,7 +35,7 @@ export abstract class Extractor<I, O extends TreeElement = TreeElement> {
  * @param secondary The element whose metadata fills any gaps in `primary`.
  * @returns A new `TreeElement` with `primary`'s identity and the merged metadata of both.
  * @example mergeTreeElements(tsElement, mdElement) // ts identity + md prose
- * @see https://dhoulb.github.io/shelving/extract/Extractor/mergeTreeElements
+ * @see https://shelving.cc/extract/mergeTreeElements
  */
 export function mergeTreeElements<T extends TreeElement>(primary: T, secondary: TreeElement): T;
 export function mergeTreeElements(primary: TreeElement, secondary: TreeElement): TreeElement {

--- a/modules/extract/FileExtractor.ts
+++ b/modules/extract/FileExtractor.ts
@@ -16,7 +16,7 @@ import { Extractor } from "./Extractor.js";
  * - Subclasses (e.g. `MarkupExtractor`, `TypescriptExtractor`) override `extractProps()` to parse the content into richer elements.
  *
  * @example new FileExtractor().extract(Bun.file("/abs/path/notes.txt"))
- * @see https://dhoulb.github.io/shelving/extract/FileExtractor/FileExtractor
+ * @see https://shelving.cc/extract/FileExtractor
  */
 export class FileExtractor extends Extractor<BunFile, TreeElement> {
 	/**
@@ -26,7 +26,7 @@ export class FileExtractor extends Extractor<BunFile, TreeElement> {
 	 * @returns A promise resolving to the file's `tree-element`, keyed by its verbatim filename.
 	 * @throws `RequiredError` If the file has no name or its path is not absolute.
 	 * @example await new FileExtractor().extract(Bun.file("/abs/path/notes.txt"))
-	 * @see https://dhoulb.github.io/shelving/extract/FileExtractor/FileExtractor/extract
+	 * @see https://shelving.cc/extract/FileExtractor/extract
 	 */
 	async extract(file: BunFile): Promise<TreeElement> {
 		const source = file.name;
@@ -53,7 +53,7 @@ export class FileExtractor extends Extractor<BunFile, TreeElement> {
 	 * @param content The raw text content of the file.
 	 * @returns The element props, always including a `name`; the base implementation stores `content` verbatim.
 	 * @example extractProps("notes", "Some text") // { name: "notes", content: "Some text" }
-	 * @see https://dhoulb.github.io/shelving/extract/FileExtractor/FileExtractor/extractProps
+	 * @see https://shelving.cc/extract/FileExtractor/extractProps
 	 */
 	extractProps(name: string, content: string): Partial<TreeElementProps> & { name: string } {
 		return { name, content };

--- a/modules/extract/IndexExtractor.ts
+++ b/modules/extract/IndexExtractor.ts
@@ -15,7 +15,7 @@ const DEFAULT_INDEX: Matchables = [/^readme\.txt$/i, /^readme\.md$/i, /^index\.m
 /**
  * Options for an `IndexExtractor`.
  *
- * @see https://dhoulb.github.io/shelving/extract/IndexExtractor/IndexExtractorOptions
+ * @see https://shelving.cc/extract/IndexExtractorOptions
  */
 export interface IndexExtractorOptions {
 	/**
@@ -34,7 +34,7 @@ export interface IndexExtractorOptions {
  *
  * @example const extractor = new IndexExtractor(new DirectoryExtractor());
  *
- * @see https://dhoulb.github.io/shelving/extract/IndexExtractor
+ * @see https://shelving.cc/extract/IndexExtractor
  */
 export class IndexExtractor<I> extends ThroughExtractor<I, TreeElement> {
 	private readonly _index: Matchables;
@@ -59,7 +59,7 @@ export class IndexExtractor<I> extends ThroughExtractor<I, TreeElement> {
 	 *
 	 * @example const tree = await new IndexExtractor(source).extract(input);
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/IndexExtractor/extract
+	 * @see https://shelving.cc/extract/extract
 	 */
 	override async extract(input: I): Promise<TreeElement> {
 		const root = await this.source.extract(input);

--- a/modules/extract/MarkupExtractor.ts
+++ b/modules/extract/MarkupExtractor.ts
@@ -13,7 +13,7 @@ import { FileExtractor } from "./FileExtractor.js";
  * - Sets `description` to the first prose paragraph as a plain-text summary (used for card listings and `<meta>`).
  *
  * @example new MarkupExtractor().extract(Bun.file("/abs/path/README.md"))
- * @see https://dhoulb.github.io/shelving/extract/MarkupExtractor/MarkupExtractor
+ * @see https://shelving.cc/extract/MarkupExtractor
  */
 export class MarkupExtractor extends FileExtractor {
 	/**
@@ -24,7 +24,7 @@ export class MarkupExtractor extends FileExtractor {
 	 * @param text The raw Markdown source.
 	 * @returns The element props with `name`, `content`, and (when present) `title` and `description`.
 	 * @example new MarkupExtractor().extractProps("guide", "# Guide\n\nIntro text.")
-	 * @see https://dhoulb.github.io/shelving/extract/MarkupExtractor/MarkupExtractor/extractProps
+	 * @see https://shelving.cc/extract/MarkupExtractor/extractProps
 	 */
 	override extractProps(name: string, text: string): Partial<TreeElementProps> & { name: string } {
 		const { title, description } = extractMarkdownProps(text);
@@ -42,7 +42,7 @@ export class MarkupExtractor extends FileExtractor {
  * @param text The markdown source string (a markdown file's text, or a JSDoc description).
  * @returns An object whose `title` and `description` are each a plain string, or `undefined` when absent.
  * @example extractMarkdownProps("# Title\n\nSome intro.") // { title: "Title", description: "Some intro." }
- * @see https://dhoulb.github.io/shelving/extract/MarkupExtractor/extractMarkdownProps
+ * @see https://shelving.cc/extract/extractMarkdownProps
  */
 export function extractMarkdownProps(text: string): { title: string | undefined; description: string | undefined } {
 	let title: string | undefined;

--- a/modules/extract/MergingExtractor.ts
+++ b/modules/extract/MergingExtractor.ts
@@ -20,7 +20,7 @@ const DEFAULT_MERGES: ImmutableDictionary<readonly string[]> = {
 /**
  * Options for a `MergingExtractor`.
  *
- * @see https://dhoulb.github.io/shelving/extract/MergingExtractor/MergingExtractorOptions
+ * @see https://shelving.cc/extract/MergingExtractorOptions
  */
 export interface MergingExtractorOptions {
 	/**
@@ -44,7 +44,7 @@ export interface MergingExtractorOptions {
  *
  * @example const extractor = new MergingExtractor(new DirectoryExtractor());
  *
- * @see https://dhoulb.github.io/shelving/extract/MergingExtractor
+ * @see https://shelving.cc/extract/MergingExtractor
  */
 export class MergingExtractor<I> extends ThroughExtractor<I, TreeElement> {
 	private readonly _merges: ImmutableDictionary<readonly string[]>;
@@ -69,7 +69,7 @@ export class MergingExtractor<I> extends ThroughExtractor<I, TreeElement> {
 	 *
 	 * @example const tree = await new MergingExtractor(source).extract(input);
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/MergingExtractor/extract
+	 * @see https://shelving.cc/extract/extract
 	 */
 	override async extract(input: I): Promise<TreeElement> {
 		const root = await this.source.extract(input);

--- a/modules/extract/ModuleExtractor.ts
+++ b/modules/extract/ModuleExtractor.ts
@@ -6,7 +6,7 @@ import { Extractor } from "./Extractor.js";
 /**
  * Input for a `ModuleExtractor`.
  *
- * @see https://dhoulb.github.io/shelving/extract/ModuleExtractor/ModuleExtractorInput
+ * @see https://shelving.cc/extract/ModuleExtractorInput
  */
 export interface ModuleExtractorInput {
 	/** Display name for the module, derived from the package.json export key (e.g. `"util/string"`, `"firestore/client"`). */
@@ -28,7 +28,7 @@ export interface ModuleExtractorInput {
  *
  * @example const module = new ModuleExtractor().extract({ name: "util/string", source });
  *
- * @see https://dhoulb.github.io/shelving/extract/ModuleExtractor
+ * @see https://shelving.cc/extract/ModuleExtractor
  */
 export class ModuleExtractor extends Extractor<ModuleExtractorInput, DocumentationElement> {
 	/**
@@ -39,7 +39,7 @@ export class ModuleExtractor extends Extractor<ModuleExtractorInput, Documentati
 	 *
 	 * @example const module = new ModuleExtractor().extract({ name: "util/string", source });
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/ModuleExtractor/extract
+	 * @see https://shelving.cc/extract/extract
 	 */
 	override extract({ name, source }: ModuleExtractorInput): DocumentationElement {
 		const children = _collectChildren(source);

--- a/modules/extract/PackageExtractor.ts
+++ b/modules/extract/PackageExtractor.ts
@@ -24,7 +24,7 @@ interface PackageJson {
 /**
  * Options for a `PackageExtractor`.
  *
- * @see https://dhoulb.github.io/shelving/extract/PackageExtractor/PackageExtractorOptions
+ * @see https://shelving.cc/extract/PackageExtractorOptions
  */
 export interface PackageExtractorOptions {
 	/**
@@ -57,7 +57,7 @@ export interface PackageExtractorOptions {
  *
  * @example const tree = await new PackageExtractor({ tree: sourceTree }).extract("package.json");
  *
- * @see https://dhoulb.github.io/shelving/extract/PackageExtractor
+ * @see https://shelving.cc/extract/PackageExtractor
  */
 export class PackageExtractor extends Extractor<Path, TreeElement> {
 	private readonly _tree: TreeElement;
@@ -87,7 +87,7 @@ export class PackageExtractor extends Extractor<Path, TreeElement> {
 	 *
 	 * @example const tree = await new PackageExtractor({ tree: sourceTree }).extract("package.json");
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/PackageExtractor/extract
+	 * @see https://shelving.cc/extract/extract
 	 */
 	override async extract(packageJson: Path): Promise<TreeElement> {
 		const pkgPath = requirePath(packageJson, this._base, this.extract);

--- a/modules/extract/ThroughExtractor.ts
+++ b/modules/extract/ThroughExtractor.ts
@@ -7,12 +7,12 @@ import { Extractor } from "./Extractor.js";
  * - Composes the same way `Through*Provider` chains do — chain multiple `ThroughExtractor`s to build up behaviour.
  *
  * @example new MergingExtractor(new DirectoryExtractor()) // a ThroughExtractor wrapping a source extractor
- * @see https://dhoulb.github.io/shelving/extract/ThroughExtractor/ThroughExtractor
+ * @see https://shelving.cc/extract/ThroughExtractor
  */
 export abstract class ThroughExtractor<I, O extends TreeElement = TreeElement> extends Extractor<I, O> {
 	/**
 	 * The wrapped source extractor this through extractor delegates to.
-	 * @see https://dhoulb.github.io/shelving/extract/ThroughExtractor/ThroughExtractor/source
+	 * @see https://shelving.cc/extract/ThroughExtractor/source
 	 */
 	readonly source: Extractor<I, O>;
 
@@ -20,7 +20,7 @@ export abstract class ThroughExtractor<I, O extends TreeElement = TreeElement> e
 	 * Create a `ThroughExtractor` wrapping a source extractor.
 	 *
 	 * @param source The inner extractor to delegate to.
-	 * @see https://dhoulb.github.io/shelving/extract/ThroughExtractor/ThroughExtractor
+	 * @see https://shelving.cc/extract/ThroughExtractor
 	 */
 	constructor(source: Extractor<I, O>) {
 		super();
@@ -34,7 +34,7 @@ export abstract class ThroughExtractor<I, O extends TreeElement = TreeElement> e
 	 * @param input The input value to extract from.
 	 * @returns The extracted `TreeElement`, or a promise resolving to one.
 	 * @example await myThroughExtractor.extract(input)
-	 * @see https://dhoulb.github.io/shelving/extract/ThroughExtractor/ThroughExtractor/extract
+	 * @see https://shelving.cc/extract/ThroughExtractor/extract
 	 */
 	extract(input: I): O | Promise<O> {
 		return this.source.extract(input);

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -846,7 +846,7 @@ export function add(a: number, b: number): number { return a + b; }
 			file(`
 /**
  * Add two numbers.
- * @see https://dhoulb.github.io/shelving/math/add
+ * @see https://shelving.cc/math/add
  */
 export function add(a: number, b: number): number { return a + b; }
 `),
@@ -861,7 +861,7 @@ export function add(a: number, b: number): number { return a + b; }
 			file(`
 /**
  * Add two numbers.
- * @see https://dhoulb.github.io/shelving/math/add
+ * @see https://shelving.cc/math/add
  * @deprecated Use \`sum()\` instead.
  */
 export function add(a: number, b: number): number { return a + b; }

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -32,7 +32,7 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  *
  * @example const element = new TypescriptExtractor().extractProps("string.ts", sourceText);
  *
- * @see https://dhoulb.github.io/shelving/extract/TypescriptExtractor
+ * @see https://shelving.cc/extract/TypescriptExtractor
  */
 export class TypescriptExtractor extends FileExtractor {
 	/**
@@ -44,7 +44,7 @@ export class TypescriptExtractor extends FileExtractor {
 	 *
 	 * @example const props = new TypescriptExtractor().extractProps("string.ts", sourceText);
 	 *
-	 * @see https://dhoulb.github.io/shelving/extract/TypescriptExtractor/extractProps
+	 * @see https://shelving.cc/extract/extractProps
 	 */
 	override extractProps(name: string, text: string): Partial<TreeElementProps> & { name: string } {
 		const source = ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);

--- a/modules/firestore/client/FirestoreClientProvider.ts
+++ b/modules/firestore/client/FirestoreClientProvider.ts
@@ -109,7 +109,7 @@ function _getFieldValue({ key, action, value }: Update): DataProp<Data> {
  * import { getFirestore } from "firebase/firestore";
  * const provider = new FirestoreClientProvider(getFirestore());
  *
- * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider
+ * @see https://shelving.cc/firestore/client/FirestoreClientProvider
  */
 export class FirestoreClientProvider<I extends string = string, T extends Data = Data> extends DBProvider<I, T> {
 	private readonly _firestore: Firestore;
@@ -118,7 +118,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * Create a provider wrapping a Firebase `Firestore` instance.
 	 *
 	 * @param firestore The `Firestore` instance to read and write through.
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider
 	 */
 	constructor(firestore: Firestore) {
 		super();
@@ -147,7 +147,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to read.
 	 * @returns Promise resolving to the item, or `undefined` if the document does not exist.
 	 * @example await provider.getItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/getItem
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const snapshot = await getDoc(this._doc(c, id));
@@ -160,7 +160,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to subscribe to.
 	 * @returns An async sequence yielding the item (or `undefined` when absent) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, "abc123")) console.log(item)
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/getItemSequence
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		const sequence = new DeferredSequence<OptionalItem<II, TT>>();
@@ -179,7 +179,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param data The data for the new item.
 	 * @returns Promise resolving to the generated ID of the new item.
 	 * @example const id = await provider.addItem(users, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/addItem
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		const reference = await addDoc(this._collection(c), data);
@@ -193,7 +193,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param data The data to store for the item.
 	 * @returns Promise resolving once the write completes.
 	 * @example await provider.setItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/setItem
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await setDoc(this._doc(c, id), data);
@@ -206,7 +206,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param updates The updates to apply to the item.
 	 * @returns Promise resolving once the update completes.
 	 * @example await provider.updateItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/updateItem
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -222,7 +222,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to delete.
 	 * @returns Promise resolving once the deletion completes.
 	 * @example await provider.deleteItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/deleteItem
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await deleteDoc(this._doc(c, id));
@@ -234,7 +234,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to count; counts the whole collection when omitted.
 	 * @returns Promise resolving to the number of matching items.
 	 * @example const total = await provider.countQuery(users)
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/countQuery
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<number> {
 		const snapshot = await getCountFromServer(this._query(c, q));
@@ -247,7 +247,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to read; reads the whole collection when omitted.
 	 * @returns Promise resolving to the array of matching items.
 	 * @example const items = await provider.getQuery(users, { "name": "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/getQuery
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await getDocs(this._query(c, q)));
@@ -259,7 +259,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to subscribe to; subscribes to the whole collection when omitted.
 	 * @returns An async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users)) console.log(items)
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/getQuerySequence
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		const sequence = new DeferredSequence<Items<II, TT>>();
@@ -279,7 +279,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param data The data to write to each matching item.
 	 * @returns Promise resolving once all writes complete.
 	 * @example await provider.setQuery(users, { "name": "Dave" }, { active: false })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/setQuery
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
@@ -293,7 +293,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param updates The updates to apply to each matching item.
 	 * @returns Promise resolving once all updates complete.
 	 * @example await provider.updateQuery(users, { "active": true }, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/updateQuery
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -311,7 +311,7 @@ export class FirestoreClientProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to delete.
 	 * @returns Promise resolving once all deletions complete.
 	 * @example await provider.deleteQuery(users, { "active": false })
-	 * @see https://dhoulb.github.io/shelving/firestore/client/FirestoreClientProvider/FirestoreClientProvider/deleteQuery
+	 * @see https://shelving.cc/firestore/client/FirestoreClientProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));

--- a/modules/firestore/lite/FirestoreLiteProvider.ts
+++ b/modules/firestore/lite/FirestoreLiteProvider.ts
@@ -107,7 +107,7 @@ function _getFieldValue({ key, action, value }: Update): DataProp<Data> {
  * import { getFirestore } from "firebase/firestore/lite";
  * const provider = new FirestoreLiteProvider(getFirestore());
  *
- * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider
+ * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider
  */
 export class FirestoreLiteProvider<I extends string = string, T extends Data = Data> extends DBProvider<I, T> {
 	private readonly _firestore: Firestore;
@@ -116,7 +116,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * Create a provider wrapping a Firebase Lite `Firestore` instance.
 	 *
 	 * @param firestore The `Firestore` instance to read and write through.
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider
 	 */
 	constructor(firestore: Firestore) {
 		super();
@@ -145,7 +145,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param id The ID of the item to read.
 	 * @returns Promise resolving to the item, or `undefined` if the document does not exist.
 	 * @example await provider.getItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/getItem
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		const snapshot = await getDoc(this._doc(c, id));
@@ -158,7 +158,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param _id The ID of the item to subscribe to.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because Firestore Lite does not support realtime subscriptions.
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/getItemSequence
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _id: II): OptionalItemSequence<II, TT> {
 		throw new UnimplementedError("FirestoreLiteProvider does not support realtime subscriptions");
@@ -170,7 +170,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param data The data for the new item.
 	 * @returns Promise resolving to the generated ID of the new item.
 	 * @example const id = await provider.addItem(users, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/addItem
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		const reference = await addDoc(this._collection(c), data);
@@ -184,7 +184,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param data The data to store for the item.
 	 * @returns Promise resolving once the write completes.
 	 * @example await provider.setItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/setItem
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await setDoc(this._doc(c, id), data);
@@ -197,7 +197,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param updates The updates to apply to the item.
 	 * @returns Promise resolving once the update completes.
 	 * @example await provider.updateItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/updateItem
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -213,7 +213,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param id The ID of the item to delete.
 	 * @returns Promise resolving once the deletion completes.
 	 * @example await provider.deleteItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/deleteItem
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await deleteDoc(this._doc(c, id));
@@ -225,7 +225,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param q The query selecting which items to count; counts the whole collection when omitted.
 	 * @returns Promise resolving to the number of matching items.
 	 * @example const total = await provider.countQuery(users)
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/countQuery
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<number> {
 		const snapshot = await getCount(this._query(c, q));
@@ -238,7 +238,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param q The query selecting which items to read; reads the whole collection when omitted.
 	 * @returns Promise resolving to the array of matching items.
 	 * @example const items = await provider.getQuery(users, { "name": "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/getQuery
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await getDocs(this._query(c, q)));
@@ -250,7 +250,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param _q The query to subscribe to.
 	 * @returns Never returns normally.
 	 * @throws {UnimplementedError} Always, because Firestore Lite does not support realtime subscriptions.
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/getQuerySequence
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(_c: Collection<string, II, TT>, _q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		throw new UnimplementedError("FirestoreLiteProvider does not support realtime subscriptions");
@@ -263,7 +263,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param data The data to write to each matching item.
 	 * @returns Promise resolving once all writes complete.
 	 * @example await provider.setQuery(users, { "name": "Dave" }, { active: false })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/setQuery
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));
@@ -277,7 +277,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param updates The updates to apply to each matching item.
 	 * @returns Promise resolving once all updates complete.
 	 * @example await provider.updateQuery(users, { "active": true }, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/updateQuery
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -295,7 +295,7 @@ export class FirestoreLiteProvider<I extends string = string, T extends Data = D
 	 * @param q The query selecting which items to delete.
 	 * @returns Promise resolving once all deletions complete.
 	 * @example await provider.deleteQuery(users, { "active": false })
-	 * @see https://dhoulb.github.io/shelving/firestore/lite/FirestoreLiteProvider/FirestoreLiteProvider/deleteQuery
+	 * @see https://shelving.cc/firestore/lite/FirestoreLiteProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		const snapshot = await getDocs(this._query(c, q));

--- a/modules/firestore/server/FirestoreServerProvider.ts
+++ b/modules/firestore/server/FirestoreServerProvider.ts
@@ -76,7 +76,7 @@ function _getFieldValue({ key, action, value }: Update): DataProp<Data> {
  * import { Firestore } from "@google-cloud/firestore";
  * const provider = new FirestoreServerProvider(new Firestore());
  *
- * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider
+ * @see https://shelving.cc/firestore/server/FirestoreServerProvider
  */
 export class FirestoreServerProvider<I extends string = string, T extends Data = Data> extends DBProvider<I, T> {
 	private readonly _firestore: Firestore;
@@ -85,7 +85,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * Create a provider wrapping a Firestore Admin SDK instance.
 	 *
 	 * @param firestore The `Firestore` instance to read and write through; defaults to a new `Firestore()`.
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider
 	 */
 	constructor(firestore = new Firestore()) {
 		super();
@@ -140,7 +140,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to read.
 	 * @returns Promise resolving to the item, or `undefined` if the document does not exist.
 	 * @example await provider.getItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/getItem
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/getItem
 	 */
 	override async getItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<OptionalItem<II, TT>> {
 		return _getOptionalItem<II, TT>(await this._getCollection(collection).doc(id).get());
@@ -153,7 +153,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to subscribe to.
 	 * @returns An async sequence yielding the item (or `undefined` when absent) on every change.
 	 * @example for await (const item of provider.getItemSequence(users, "abc123")) console.log(item)
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/getItemSequence
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/getItemSequence
 	 */
 	override getItemSequence<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): OptionalItemSequence<II, TT> {
 		const ref = this._getCollection(c).doc(id);
@@ -173,7 +173,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param data The data for the new item.
 	 * @returns Promise resolving to the generated ID of the new item.
 	 * @example const id = await provider.addItem(users, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/addItem
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/addItem
 	 */
 	override async addItem<II extends I, TT extends T>(c: Collection<string, II, TT>, data: TT): Promise<II> {
 		return (await this._getCollection(c).add(data)).id as II; // `as II` needed: Firestore returns string, not II.
@@ -187,7 +187,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param data The data to store for the item.
 	 * @returns Promise resolving once the write completes.
 	 * @example await provider.setItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/setItem
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/setItem
 	 */
 	override async setItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await this._getCollection(c).doc(id).set(data);
@@ -201,7 +201,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param updates The updates to apply to the item.
 	 * @returns Promise resolving once the update completes.
 	 * @example await provider.updateItem(users, "abc123", { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/updateItem
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/updateItem
 	 */
 	override async updateItem<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -218,7 +218,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param id The ID of the item to delete.
 	 * @returns Promise resolving once the deletion completes.
 	 * @example await provider.deleteItem(users, "abc123")
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/deleteItem
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/deleteItem
 	 */
 	override async deleteItem<II extends I, TT extends T>(c: Collection<string, II, TT>, id: II): Promise<void> {
 		await this._getCollection(c).doc(id).delete();
@@ -231,7 +231,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to count; counts the whole collection when omitted.
 	 * @returns Promise resolving to the number of matching items.
 	 * @example const total = await provider.countQuery(users)
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/countQuery
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/countQuery
 	 */
 	override async countQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<number> {
 		const snapshot = await this._getQuery(c, q).count().get();
@@ -245,7 +245,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to read; reads the whole collection when omitted.
 	 * @returns Promise resolving to the array of matching items.
 	 * @example const items = await provider.getQuery(users, { "name": "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/getQuery
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/getQuery
 	 */
 	override async getQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): Promise<Items<II, TT>> {
 		return _getItems<II, TT>(await this._getQuery(c, q).get());
@@ -258,7 +258,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to subscribe to; subscribes to the whole collection when omitted.
 	 * @returns An async sequence yielding the matching items on every change.
 	 * @example for await (const items of provider.getQuerySequence(users)) console.log(items)
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/getQuerySequence
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/getQuerySequence
 	 */
 	override getQuerySequence<II extends I, TT extends T>(c: Collection<string, II, TT>, q?: Query<Item<II, TT>>): ItemsSequence<II, TT> {
 		const ref = this._getQuery(c, q);
@@ -279,7 +279,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param data The data to write to each matching item.
 	 * @returns Promise resolving once all writes complete.
 	 * @example await provider.setQuery(users, { "name": "Dave" }, { active: false })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/setQuery
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/setQuery
 	 */
 	override async setQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>, data: TT): Promise<void> {
 		return await this._bulkWrite(c, q, (w, s) => void w.set(s.ref, data));
@@ -293,7 +293,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param updates The updates to apply to each matching item.
 	 * @returns Promise resolving once all updates complete.
 	 * @example await provider.updateQuery(users, { "active": true }, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/updateQuery
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/updateQuery
 	 */
 	override async updateQuery<II extends I, TT extends T>(
 		c: Collection<string, II, TT>,
@@ -311,7 +311,7 @@ export class FirestoreServerProvider<I extends string = string, T extends Data =
 	 * @param q The query selecting which items to delete.
 	 * @returns Promise resolving once all deletions complete.
 	 * @example await provider.deleteQuery(users, { "active": false })
-	 * @see https://dhoulb.github.io/shelving/firestore/server/FirestoreServerProvider/FirestoreServerProvider/deleteQuery
+	 * @see https://shelving.cc/firestore/server/FirestoreServerProvider/deleteQuery
 	 */
 	override async deleteQuery<II extends I, TT extends T>(c: Collection<string, II, TT>, q: Query<Item<II, TT>>): Promise<void> {
 		return await this._bulkWrite(c, q, (w, s) => void w.delete(s.ref));

--- a/modules/markup/MarkupParser.ts
+++ b/modules/markup/MarkupParser.ts
@@ -14,7 +14,7 @@ import { MARKUP_RULES } from "./rule/index.js";
  * - Every field is optional — an empty object yields a parser with the default rules and behaviour.
  * - Link resolution honours `url`, `root`, and `schemes`; link safety hinges on `schemes`.
  *
- * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupOptions
+ * @see https://shelving.cc/markup/MarkupOptions
  */
 export type MarkupOptions = {
 	/**
@@ -60,37 +60,37 @@ export type MarkupOptions = {
  *
  * @example
  * const node = new MarkupParser().parse("This is a *bold* string.");
- * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser
+ * @see https://shelving.cc/markup/MarkupParser
  */
 export class MarkupParser implements Parser<string, ReactNode> {
 	/**
 	 * The list of parsing rules this parser applies.
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/rules
+	 * @see https://shelving.cc/markup/MarkupParser/rules
 	 */
 	readonly rules: MarkupRules;
 
 	/**
 	 * Calculated list of priorities to iterate over (extracted from the rules), e.g. [10, 0, -10]
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/priorities
+	 * @see https://shelving.cc/markup/MarkupParser/priorities
 	 */
 	readonly priorities: ImmutableArray<number>;
 
 	/**
 	 * Set the `rel=""` property used for any links (e.g. `rel="nofollow ugc"`).
 	 * @example "nofollow ugc"
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/rel
+	 * @see https://shelving.cc/markup/MarkupParser/rel
 	 */
 	readonly rel: string | undefined;
 
 	/**
 	 * Current page URL — used as the base for resolving relative refs (`./foo`, `#x`, bare segments) in link hrefs. Falls back to `root` if not set.
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/url
+	 * @see https://shelving.cc/markup/MarkupParser/url
 	 */
 	readonly url: ImmutableURL | undefined;
 
 	/**
 	 * Site root URL — used as the base for resolving site-absolute path hrefs (`/foo`), honoring its subfolder. Falls back to `url` if not set.
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/root
+	 * @see https://shelving.cc/markup/MarkupParser/root
 	 */
 	readonly root: ImmutableURL | undefined;
 
@@ -98,13 +98,13 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 * Valid URI schemes/protocols for URLs and URIs.
 	 * @example ["http:", "https:"]
 	 * @default ["http:", "https:"]
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/schemes
+	 * @see https://shelving.cc/markup/MarkupParser/schemes
 	 */
 	readonly schemes: URISchemes;
 
 	/**
 	 * Default context to use if one isn't set. Defaults to `"block"`
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/context
+	 * @see https://shelving.cc/markup/MarkupParser/context
 	 */
 	readonly context: string;
 
@@ -112,7 +112,7 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 * Create a new `MarkupParser` from a set of options.
 	 *
 	 * @example new MarkupParser({ rel: "nofollow ugc" })
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser
+	 * @see https://shelving.cc/markup/MarkupParser
 	 */
 	constructor({ rules = MARKUP_RULES, rel, url, root, schemes = HTTP_SCHEMES, context = "block" }: MarkupOptions = {}) {
 		this.rules = rules;
@@ -132,7 +132,7 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 * @param context The context to render in (defaults to this parser's `context`, i.e. `"block"` unless overridden).
 	 * @returns A React node — an element, a string, `null`, or an array of zero or more of those.
 	 * @example new MarkupParser().parse("This is a *bold* string.")
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/parse
+	 * @see https://shelving.cc/markup/MarkupParser/parse
 	 */
 	parse(input: string, context = this.context): ReactNode {
 		const nodes = _parseNodes(input, this, context);
@@ -146,7 +146,7 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 * @param priority The priority tier to filter rules by.
 	 * @returns An iterable of the matching `MarkupRule` instances.
 	 * @example for (const rule of parser.getRules("block", 0)) { ... }
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/getRules
+	 * @see https://shelving.cc/markup/MarkupParser/getRules
 	 */
 	*getRules(context: string, priority: number): Iterable<MarkupRule> {
 		for (const r of this.rules) if (r.priority === priority && r.contexts.includes(context)) yield r;
@@ -158,7 +158,7 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 * @param href The raw link reference to resolve (relative or absolute), or a nullish value.
 	 * @returns An `ImmutableURI` if the link parses and its scheme is in `schemes`, otherwise `undefined`.
 	 * @example parser.getLink("/about") // ImmutableURI | undefined
-	 * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MarkupParser/getLink
+	 * @see https://shelving.cc/markup/MarkupParser/getLink
 	 */
 	getLink(href: Nullish<PossibleLink>): ImmutableURI | undefined {
 		const link = getLink(href, this.url, this.root);
@@ -362,6 +362,6 @@ function _mask(text: string, start: number, end: number): string {
  * - Use this singleton when no custom rules, link resolution, or default context are needed.
  *
  * @example MARKUP_PARSER.parse("This is a *bold* string.")
- * @see https://dhoulb.github.io/shelving/markup/MarkupParser/MARKUP_PARSER
+ * @see https://shelving.cc/markup/MARKUP_PARSER
  */
 export const MARKUP_PARSER = new MarkupParser();

--- a/modules/markup/MarkupRule.ts
+++ b/modules/markup/MarkupRule.ts
@@ -6,7 +6,7 @@ import type { MarkupParser } from "./MarkupParser.js";
 /**
  * One or more named contexts a markup rule renders in (e.g. `["block"]`, `["inline", "list", "link"]`).
  *
- * @see https://dhoulb.github.io/shelving/markup/MarkupRule/MarkupContexts
+ * @see https://shelving.cc/markup/MarkupContexts
  */
 export type MarkupContexts = [string, ...string[]];
 
@@ -15,7 +15,7 @@ export type MarkupContexts = [string, ...string[]];
  * - Rules are grouped into priority tiers and resolved highest tier first by `MarkupParser`.
  * - A rule renders only in the contexts it lists, letting the same syntax behave differently in block vs inline vs list context.
  *
- * @see https://dhoulb.github.io/shelving/markup/MarkupRule/MarkupRule
+ * @see https://shelving.cc/markup/MarkupRule
  */
 export interface MarkupRule {
 	/** Regular expression used for matching the rule. */
@@ -31,7 +31,7 @@ export interface MarkupRule {
 /**
  * An immutable list of `MarkupRule` instances applied by a `MarkupParser`.
  *
- * @see https://dhoulb.github.io/shelving/markup/MarkupRule/MarkupRules
+ * @see https://shelving.cc/markup/MarkupRules
  */
 export type MarkupRules = readonly MarkupRule[];
 
@@ -50,7 +50,7 @@ export type MarkupRules = readonly MarkupRule[];
  * @returns A `MarkupRule` ready to add to a `MarkupRules` list.
  * @example
  * const HR_RULE = createMarkupRule(/^---$/m, key => <hr key={key} />, ["block"]);
- * @see https://dhoulb.github.io/shelving/markup/MarkupRule/createMarkupRule
+ * @see https://shelving.cc/markup/createMarkupRule
  */
 export function createMarkupRule<T extends NamedRegExpData>(
 	regexp: NamedRegExp<T>,

--- a/modules/markup/Parser.ts
+++ b/modules/markup/Parser.ts
@@ -7,7 +7,7 @@
  * class UppercaseParser extends Parser<string, string> {
  * 	parse(input: string): string { return input.toUpperCase(); }
  * }
- * @see https://dhoulb.github.io/shelving/markup/Parser/Parser
+ * @see https://shelving.cc/markup/Parser
  */
 export abstract class Parser<I, O> {
 	/**
@@ -15,7 +15,7 @@ export abstract class Parser<I, O> {
 	 *
 	 * @param input The input value to parse.
 	 * @returns The parsed output value.
-	 * @see https://dhoulb.github.io/shelving/markup/Parser/Parser/parse
+	 * @see https://shelving.cc/markup/Parser/parse
 	 */
 	abstract parse(input: I): O;
 }

--- a/modules/markup/rule/blockquote.tsx
+++ b/modules/markup/rule/blockquote.tsx
@@ -11,7 +11,7 @@ const INDENT = new RegExp(`^${PREFIX}`, "gm");
  * - Quote block is only broken by `\n\n` two newline characters.
  *
  * @example new MarkupParser({ rules: [BLOCKQUOTE_RULE] }).parse("> Quoted text")
- * @see https://dhoulb.github.io/shelving/markup/rule/blockquote/BLOCKQUOTE_RULE
+ * @see https://shelving.cc/markup/BLOCKQUOTE_RULE
  */
 export const BLOCKQUOTE_RULE = createMarkupRule<{
 	quote: string;

--- a/modules/markup/rule/code.tsx
+++ b/modules/markup/rule/code.tsx
@@ -11,7 +11,7 @@ import { BLOCK_CONTENT_REGEXP } from "../util/regexp.js";
  * - Same as Markdown syntax.
  *
  * @example new MarkupParser({ rules: [CODE_RULE] }).parse("Some `inline code` here")
- * @see https://dhoulb.github.io/shelving/markup/rule/code/CODE_RULE
+ * @see https://shelving.cc/markup/CODE_RULE
  */
 // Priority 10: code is a higher-precedence tier, resolved and masked before links/emphasis, so a
 // code span that straddles a link delimiter wins and the link cannot form across it.

--- a/modules/markup/rule/fenced.tsx
+++ b/modules/markup/rule/fenced.tsx
@@ -13,7 +13,7 @@ const FENCE = "`{3,}|~{3,}";
  * - Markdown-style four-space indent syntax is not supported (only fenced code since it's less confusing and more common).
  *
  * @example new MarkupParser({ rules: [FENCED_RULE] }).parse("```\ncode block\n```")
- * @see https://dhoulb.github.io/shelving/markup/rule/fenced/FENCED_RULE
+ * @see https://shelving.cc/markup/FENCED_RULE
  */
 export const FENCED_RULE = createMarkupRule<{
 	fence: string;

--- a/modules/markup/rule/heading.tsx
+++ b/modules/markup/rule/heading.tsx
@@ -8,7 +8,7 @@ import { createLineRegExp, LINE_CONTENT_REGEXP, LINE_SPACE_REGEXP } from "../uti
  * - Markdown's underline syntax is not supported (for simplification).
  *
  * @example new MarkupParser({ rules: [HEADING_RULE] }).parse("# Title")
- * @see https://dhoulb.github.io/shelving/markup/rule/heading/HEADING_RULE
+ * @see https://shelving.cc/markup/HEADING_RULE
  */
 export const HEADING_RULE = createMarkupRule<{
 	prefix: string;

--- a/modules/markup/rule/index.ts
+++ b/modules/markup/rule/index.ts
@@ -16,7 +16,7 @@ import { UNORDERED_RULE } from "./unordered.js";
  * Default markup rules that render in a block context — fenced code, headings, separators, lists, blockquotes, tables, and paragraphs.
  *
  * @example new MarkupParser({ rules: MARKUP_RULES_BLOCK })
- * @see https://dhoulb.github.io/shelving/markup/rule/MARKUP_RULES_BLOCK
+ * @see https://shelving.cc/markup/MARKUP_RULES_BLOCK
  */
 export const MARKUP_RULES_BLOCK: MarkupRules = [
 	FENCED_RULE,
@@ -33,7 +33,7 @@ export const MARKUP_RULES_BLOCK: MarkupRules = [
  * Default markup rules that render in an inline context — inline code, links, autolinks, emphasis, and hard linebreaks.
  *
  * @example new MarkupParser({ rules: MARKUP_RULES_INLINE })
- * @see https://dhoulb.github.io/shelving/markup/rule/MARKUP_RULES_INLINE
+ * @see https://shelving.cc/markup/MARKUP_RULES_INLINE
  */
 export const MARKUP_RULES_INLINE: MarkupRules = [
 	CODE_RULE, //
@@ -52,7 +52,7 @@ export const MARKUP_RULES_INLINE: MarkupRules = [
  * 3. Don't support fussy fragile syntax that lets users make mistakes (e.g. literal HTML tags or `&amp;` character entities).
  *
  * @example new MarkupParser({ rules: MARKUP_RULES }).parse("This is a *bold* string.")
- * @see https://dhoulb.github.io/shelving/markup/rule/MARKUP_RULES
+ * @see https://shelving.cc/markup/MARKUP_RULES
  */
 export const MARKUP_RULES: MarkupRules = [
 	...MARKUP_RULES_BLOCK, //

--- a/modules/markup/rule/inline.tsx
+++ b/modules/markup/rule/inline.tsx
@@ -18,7 +18,7 @@ const INLINE_CHARS = { "~": "del", "+": "ins", "*": "strong", _: "em", "=": "mar
  * - Different to Markdown: strong is always surrounded by `*asterisks*` and emphasis is always surrounded by `_underscores_` (strong isn't 'double emphasis').
  *
  * @example new MarkupParser({ rules: [INLINE_RULE] }).parse("This is *bold* and _italic_")
- * @see https://dhoulb.github.io/shelving/markup/rule/inline/INLINE_RULE
+ * @see https://shelving.cc/markup/INLINE_RULE
  */
 export const INLINE_RULE = createMarkupRule<{
 	char: keyof typeof INLINE_CHARS;

--- a/modules/markup/rule/linebreak.tsx
+++ b/modules/markup/rule/linebreak.tsx
@@ -11,7 +11,7 @@ import { createMarkupRule } from "../MarkupRule.js";
  *   - This works better with textareas that wrap text (since manually breaking up long lines is no longer necessary).
  *
  * @example new MarkupParser({ rules: [LINEBREAK_RULE] }).parse("Line one\nLine two")
- * @see https://dhoulb.github.io/shelving/markup/rule/linebreak/LINEBREAK_RULE
+ * @see https://shelving.cc/markup/LINEBREAK_RULE
  */
 export const LINEBREAK_RULE = createMarkupRule(
 	/[^\n\S]*\n[^\n\S]*/, //

--- a/modules/markup/rule/link.tsx
+++ b/modules/markup/rule/link.tsx
@@ -28,7 +28,7 @@ function _renderLink(key: string, { title, href }: LinkData, parser: MarkupParse
  * - For security only schemes that appear in `MarkupOptions.schemes` will match (defaults to `http:` and `https:`).
  *
  * @example new MarkupParser({ rules: [LINK_RULE] }).parse("[Google Maps](http://google.com/maps)")
- * @see https://dhoulb.github.io/shelving/markup/rule/link/LINK_RULE
+ * @see https://shelving.cc/markup/LINK_RULE
  */
 export const LINK_RULE = createMarkupRule<LinkData>(
 	getRegExp(/\[(?<title>[^\]\n]*?)\]\((?<href>[^)\n]*?)\)/), //
@@ -44,7 +44,7 @@ export const LINK_RULE = createMarkupRule<LinkData>(
  * - For security only schemes that appear in `MarkupOptions.schemes` will match (defaults to `http:` and `https:`).
  *
  * @example new MarkupParser({ rules: [AUTOLINK_RULE] }).parse("http://google.com/maps (Google Maps)")
- * @see https://dhoulb.github.io/shelving/markup/rule/link/AUTOLINK_RULE
+ * @see https://shelving.cc/markup/AUTOLINK_RULE
  */
 export const AUTOLINK_RULE = createMarkupRule<LinkData>(
 	getRegExp(/(?<href>[a-z]{3,}?:\S+)(?: +(?:\((?<title>[^)\n]*?)\)))?/), //

--- a/modules/markup/rule/ordered.tsx
+++ b/modules/markup/rule/ordered.tsx
@@ -29,7 +29,7 @@ const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n`);
  * - Sparse lists are not supported.
  *
  * @example new MarkupParser({ rules: [ORDERED_RULE] }).parse("1. First\n2. Second")
- * @see https://dhoulb.github.io/shelving/markup/rule/ordered/ORDERED_RULE
+ * @see https://shelving.cc/markup/ORDERED_RULE
  */
 export const ORDERED_RULE = createMarkupRule<{
 	list: string;

--- a/modules/markup/rule/paragraph.tsx
+++ b/modules/markup/rule/paragraph.tsx
@@ -7,7 +7,7 @@ import { BLOCK_SPACE_REGEXP, BLOCK_START_REGEXP, createBlockRegExp } from "../ut
  * - Leading and trailing whitespace is trimmed.
  *
  * @example new MarkupParser({ rules: [PARAGRAPH_RULE] }).parse("Some plain text")
- * @see https://dhoulb.github.io/shelving/markup/rule/paragraph/PARAGRAPH_RULE
+ * @see https://shelving.cc/markup/PARAGRAPH_RULE
  */
 export const PARAGRAPH_RULE = createMarkupRule<{
 	paragraph: string;

--- a/modules/markup/rule/separator.tsx
+++ b/modules/markup/rule/separator.tsx
@@ -9,7 +9,7 @@ import { createLineRegExp } from "../util/regexp.js";
  * - Might have infinite number of spaces between the characters.
  *
  * @example new MarkupParser({ rules: [SEPARATOR_RULE] }).parse("---")
- * @see https://dhoulb.github.io/shelving/markup/rule/separator/SEPARATOR_RULE
+ * @see https://shelving.cc/markup/SEPARATOR_RULE
  */
 export const SEPARATOR_RULE = createMarkupRule(
 	createLineRegExp("([-*•+_=])(?: *\\1){2,}"), //

--- a/modules/markup/rule/table.tsx
+++ b/modules/markup/rule/table.tsx
@@ -19,7 +19,7 @@ const _SPLIT = /(?<!\\)\|/; // Splits a row into cells on unescaped pipes.
  * - Cell content is rendered as inline markup; write `\|` for a literal pipe inside a cell.
  *
  * @example new MarkupParser({ rules: [TABLE_RULE] }).parse("| A | B |\n|---|---|\n| 1 | 2 |")
- * @see https://dhoulb.github.io/shelving/markup/rule/table/TABLE_RULE
+ * @see https://shelving.cc/markup/TABLE_RULE
  */
 export const TABLE_RULE = createMarkupRule<{
 	table: string;

--- a/modules/markup/rule/unordered.tsx
+++ b/modules/markup/rule/unordered.tsx
@@ -34,7 +34,7 @@ const _LOOSE = new RegExp(`\\n${LINE_SPACE_REGEXP}*\\n`);
  * - Sparse lists are not supported.
  *
  * @example new MarkupParser({ rules: [UNORDERED_RULE] }).parse("- First\n- Second")
- * @see https://dhoulb.github.io/shelving/markup/rule/unordered/UNORDERED_RULE
+ * @see https://shelving.cc/markup/UNORDERED_RULE
  */
 export const UNORDERED_RULE = createMarkupRule<{
 	list: string;

--- a/modules/markup/util/regexp.ts
+++ b/modules/markup/util/regexp.ts
@@ -3,67 +3,67 @@ import { getRegExpSource } from "../../util/regexp.js";
 
 /**
  * Regular expression source matching block content — the shortest run of any character.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/BLOCK_CONTENT_REGEXP
+ * @see https://shelving.cc/markup/BLOCK_CONTENT_REGEXP
  */
 export const BLOCK_CONTENT_REGEXP = "[\\s\\S]*?"; // Block content (shortest run of any character).
 
 /**
  * Regular expression source matching block whitespace — any single whitespace character.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/BLOCK_SPACE_REGEXP
+ * @see https://shelving.cc/markup/BLOCK_SPACE_REGEXP
  */
 export const BLOCK_SPACE_REGEXP = "\\s"; // Block whitespace (run of any whitespace character).
 
 /**
  * Regular expression source matching the start of a block — the start of the string, or one linebreak.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/BLOCK_START_REGEXP
+ * @see https://shelving.cc/markup/BLOCK_START_REGEXP
  */
 export const BLOCK_START_REGEXP = "(?:\\s*\\n|^)"; // Start of block (start of string, or one linebreak).
 
 /**
  * Regular expression source matching the end of a block — the end of the string, or two linebreaks, with trailing whitespace trimmed.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/BLOCK_END_REGEXP
+ * @see https://shelving.cc/markup/BLOCK_END_REGEXP
  */
 export const BLOCK_END_REGEXP = "\\s*(?:$|\\n\\s*\\n)"; // End of block (end of string, or two linebreaks, trimmed whitespace).
 
 /**
  * Regular expression source matching line content — the shortest run of any character except newline.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/LINE_CONTENT_REGEXP
+ * @see https://shelving.cc/markup/LINE_CONTENT_REGEXP
  */
 export const LINE_CONTENT_REGEXP = "[^\\n]*?"; // Line content (shortest run of any character except newline).
 
 /**
  * Regular expression source matching line whitespace — any single whitespace character except newline.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/LINE_SPACE_REGEXP
+ * @see https://shelving.cc/markup/LINE_SPACE_REGEXP
  */
 export const LINE_SPACE_REGEXP = "[^\\n\\S]"; // Line whitespace (run of any whitespace character except newline).
 
 /**
  * Regular expression source matching the start of a line — the start of the string, or one linebreak.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/LINE_START_REGEXP
+ * @see https://shelving.cc/markup/LINE_START_REGEXP
  */
 export const LINE_START_REGEXP = BLOCK_START_REGEXP; // Start of line (start of string, or one linebreak).
 
 /**
  * Regular expression source matching the end of a line — the end of the string, or one linebreak, with trailing whitespace trimmed.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/LINE_END_REGEXP
+ * @see https://shelving.cc/markup/LINE_END_REGEXP
  */
 export const LINE_END_REGEXP = `${LINE_SPACE_REGEXP}*(?:\\s*\\n|$)`; // End of line (end of string, or one linebreak, trimmed whitespace).
 
 /**
  * Regular expression source matching word content — at least one letter or number character.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/WORD_CONTENT_REGEXP
+ * @see https://shelving.cc/markup/WORD_CONTENT_REGEXP
  */
 export const WORD_CONTENT_REGEXP = "[\\p{L}\\p{N}]+"; // Word content (at least one character that is a letter or number).
 
 /**
  * Regular expression source matching the start of a word — a zero-width assertion that the previous character is not a letter or number.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/WORD_START_REGEXP
+ * @see https://shelving.cc/markup/WORD_START_REGEXP
  */
 export const WORD_START_REGEXP = "(?<![\\p{L}\\p{N}])"; // Start of word (previous character is not a letter or number).
 
 /**
  * Regular expression source matching the end of a word — a zero-width assertion that the next character is not a letter or number.
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/WORD_END_REGEXP
+ * @see https://shelving.cc/markup/WORD_END_REGEXP
  */
 export const WORD_END_REGEXP = "(?![\\p{L}\\p{N}])"; // End of word (next character is not a letter or number).
 
@@ -77,7 +77,7 @@ export const WORD_END_REGEXP = "(?![\\p{L}\\p{N}])"; // End of word (next charac
  * @param end The trailing boundary pattern (defaults to `BLOCK_END_REGEXP`).
  * @returns A `RegExp` (a `NamedRegExp<T>` when the content pattern names its capture groups).
  * @example createBlockRegExp("(?<quote>>[\\s\\S]*?)")
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/createBlockRegExp
+ * @see https://shelving.cc/markup/createBlockRegExp
  */
 export function createBlockRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
@@ -107,7 +107,7 @@ export function createBlockRegExp(
  * @param end The trailing boundary pattern (defaults to `LINE_END_REGEXP`).
  * @returns A `RegExp` (a `NamedRegExp<T>` when the content pattern names its capture groups).
  * @example createLineRegExp("(?<prefix>#{1,6})")
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/createLineRegExp
+ * @see https://shelving.cc/markup/createLineRegExp
  */
 export function createLineRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
@@ -137,7 +137,7 @@ export function createLineRegExp(
  * @param end The trailing boundary pattern (defaults to `WORD_END_REGEXP`).
  * @returns A `RegExp` (a `NamedRegExp<T>` when the content pattern names its capture groups).
  * @example createWordRegExp("(?<char>[*_])+")
- * @see https://dhoulb.github.io/shelving/markup/util/regexp/createWordRegExp
+ * @see https://shelving.cc/markup/createWordRegExp
  */
 export function createWordRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,

--- a/modules/react/createAPIContext.tsx
+++ b/modules/react/createAPIContext.tsx
@@ -11,7 +11,7 @@ import { useStore } from "./useStore.js";
 /**
  * Bundle of hooks and a provider component returned by `createAPIContext()`.
  *
- * @see https://dhoulb.github.io/shelving/react/createAPIContext/APIContext
+ * @see https://shelving.cc/react/APIContext
  */
 export interface APIContext<P, R> {
 	/** Get an `EndpointStore` for the specified endpoint/payload in the current `APIProvider` context. */
@@ -34,7 +34,7 @@ export interface APIContext<P, R> {
  *
  * @example const { useAPI, APIContext } = createAPIContext(provider);
  *
- * @see https://dhoulb.github.io/shelving/react/createAPIContext
+ * @see https://shelving.cc/react/createAPIContext
  */
 export function createAPIContext<P, R>(provider: APIProvider<P, R>): APIContext<P, R> {
 	const CacheContext = createContext<APICache<P, R> | undefined>(undefined);

--- a/modules/react/createDBContext.tsx
+++ b/modules/react/createDBContext.tsx
@@ -15,7 +15,7 @@ import { useStore } from "./useStore.js";
 /**
  * Bundle of hooks and a provider component returned by `createDBContext()`.
  *
- * @see https://dhoulb.github.io/shelving/react/createDBContext/DBContext
+ * @see https://shelving.cc/react/DBContext
  */
 export interface DBContext<I extends Identifier, T extends Data> {
 	/** Get an `ItemStore` for the specified collection item in the current `DataProvider` context and subscribe to any changes in it. */
@@ -52,7 +52,7 @@ export interface DBContext<I extends Identifier, T extends Data> {
  *
  * @example const { useItem, useQuery, DBContext } = createDBContext(provider);
  *
- * @see https://dhoulb.github.io/shelving/react/createDBContext
+ * @see https://shelving.cc/react/createDBContext
  */
 export function createDBContext<I extends Identifier, T extends Data>(provider: DBProvider<I, T>): DBContext<I, T> {
 	const CacheContext = createContext<DBCache<I, T> | undefined>(undefined);

--- a/modules/react/useInstance.ts
+++ b/modules/react/useInstance.ts
@@ -13,7 +13,7 @@ import type { Arguments } from "../util/function.js";
  *
  * @example const cache = useInstance(DBCache, provider);
  *
- * @see https://dhoulb.github.io/shelving/react/useInstance
+ * @see https://shelving.cc/react/useInstance
  */
 export function useInstance<T, A extends Arguments = []>(Constructor: new (...a: A) => T, ...args: A): T {
 	const _internals = (useRef<{ instance: T; args: A }>(undefined).current ??= {

--- a/modules/react/useLazy.ts
+++ b/modules/react/useLazy.ts
@@ -14,7 +14,7 @@ import { getLazy, type Lazy } from "../util/lazy.js";
  *
  * @example const config = useLazy(() => expensiveConfig(id), id);
  *
- * @see https://dhoulb.github.io/shelving/react/useLazy
+ * @see https://shelving.cc/react/useLazy
  */
 export function useLazy<T, A extends Arguments = []>(value: (...args: A) => T, ...args: A): T; // Generics flow through this overload better than using `Lazy`
 export function useLazy<T>(value: T, ...args: Arguments): T;

--- a/modules/react/useMap.ts
+++ b/modules/react/useMap.ts
@@ -10,7 +10,7 @@ import { useRef } from "react";
  * const cache = useMap<string, number>();
  * cache.set("a", 1);
  *
- * @see https://dhoulb.github.io/shelving/react/useMap
+ * @see https://shelving.cc/react/useMap
  */
 export function useMap<K, V>(): Map<K, V> {
 	return (useRef<Map<K, V>>(undefined).current ??= new Map());

--- a/modules/react/useReduce.ts
+++ b/modules/react/useReduce.ts
@@ -16,7 +16,7 @@ import type { Arguments } from "../util/function.js";
  * // Keep the highest count ever seen.
  * const max = useReduce((previous = 0, next: number) => Math.max(previous, next), count);
  *
- * @see https://dhoulb.github.io/shelving/react/useReduce
+ * @see https://shelving.cc/react/useReduce
  */
 export function useReduce<T, A extends Arguments = []>(reduce: (previous: T | undefined, ...a: A) => T, ...args: A): T;
 export function useReduce<T, A extends Arguments = []>(

--- a/modules/react/useSequence.ts
+++ b/modules/react/useSequence.ts
@@ -13,7 +13,7 @@ import { runSequence } from "../util/sequence.js";
  *
  * @example const value = useSequence(myAsyncIterable);
  *
- * @see https://dhoulb.github.io/shelving/react/useSequence
+ * @see https://shelving.cc/react/useSequence
  */
 export function useSequence<T>(sequence?: AsyncIterable<T>): T | undefined {
 	const [value, setValue] = useState<T | undefined>(undefined);

--- a/modules/react/useStore.ts
+++ b/modules/react/useStore.ts
@@ -27,7 +27,7 @@ const EXTERNAL_BLACKHOLE: ExternalStore = {
  * const store = useStore(myStore);
  * return <>{store.value}</>;
  *
- * @see https://dhoulb.github.io/shelving/react/useStore
+ * @see https://shelving.cc/react/useStore
  */
 export function useStore<T extends AnyStore>(store: T): T;
 export function useStore<T extends AnyStore>(store?: T | undefined): T | undefined;

--- a/modules/schema/AddressSchema.ts
+++ b/modules/schema/AddressSchema.ts
@@ -22,7 +22,7 @@ const ADDRESS_PROPS: Schemas<AddressData> = {
  *
  * - The `props` are fixed to the postal-address fields internally, so only the default `value` and base schema options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/AddressSchema/AddressSchemaOptions
+ * @see https://shelving.cc/schema/AddressSchemaOptions
  */
 export interface AddressSchemaOptions extends SchemaOptions {
 	/** Partial default value merged over the per-field defaults. */
@@ -36,7 +36,7 @@ export interface AddressSchemaOptions extends SchemaOptions {
  * - Formats validated values into a human-readable address string via `formatAddress()`.
  *
  * @example ADDRESS.validate({ address1: "1 High St", city: "London", postcode: "SW1A 1AA", country: "GB" });
- * @see https://dhoulb.github.io/shelving/schema/AddressSchema/AddressSchema
+ * @see https://shelving.cc/schema/AddressSchema
  */
 export class AddressSchema extends DataSchema<AddressData> {
 	/**
@@ -52,7 +52,7 @@ export class AddressSchema extends DataSchema<AddressData> {
 	 * @param value The valid address data to format.
 	 * @returns The address formatted as a single display string.
 	 * @example ADDRESS.format({ address1: "1 High St", city: "London", postcode: "SW1A 1AA", country: "GB" });
-	 * @see https://dhoulb.github.io/shelving/schema/AddressSchema/AddressSchema/format
+	 * @see https://shelving.cc/schema/AddressSchema/format
 	 */
 	override format(value: AddressData) {
 		return formatAddress(value);
@@ -63,7 +63,7 @@ export class AddressSchema extends DataSchema<AddressData> {
  * Sugar instance of `AddressSchema` for postal address data. Equivalent to `new AddressSchema({})`.
  *
  * @example ADDRESS.validate({ address1: "1 High St", city: "London", postcode: "SW1A 1AA", country: "GB" });
- * @see https://dhoulb.github.io/shelving/schema/AddressSchema/ADDRESS
+ * @see https://shelving.cc/schema/ADDRESS
  */
 export const ADDRESS = new AddressSchema({});
 
@@ -71,6 +71,6 @@ export const ADDRESS = new AddressSchema({});
  * Sugar instance allowing an `ADDRESS` or `null`. Equivalent to `NULLABLE(ADDRESS)`.
  *
  * @example NULLABLE_ADDRESS.validate(null); // Returns null
- * @see https://dhoulb.github.io/shelving/schema/AddressSchema/NULLABLE_ADDRESS
+ * @see https://shelving.cc/schema/NULLABLE_ADDRESS
  */
 export const NULLABLE_ADDRESS = NULLABLE(ADDRESS);

--- a/modules/schema/ArraySchema.ts
+++ b/modules/schema/ArraySchema.ts
@@ -8,7 +8,7 @@ import { Schema } from "./Schema.js";
 /**
  * Options for `ArraySchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ArraySchemaOptions
+ * @see https://shelving.cc/schema/ArraySchemaOptions
  */
 export interface ArraySchemaOptions<T> extends SchemaOptions {
 	/**
@@ -60,7 +60,7 @@ export interface ArraySchemaOptions<T> extends SchemaOptions {
  *  schema.validate(["a", "a"], schema); // Returns ["a", "a"]
  *  schema.validate(["a", null], schema); // Throws Invalids({ "1": Invalid('Must be a string') });
  *
- * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ArraySchema
+ * @see https://shelving.cc/schema/ArraySchema
  */
 export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 	declare readonly value: ImmutableArray<T>;
@@ -100,7 +100,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 	 * @returns The valid array with each item validated by the `items` schema.
 	 * @throws `string` `"Must be array"` if not an array, `"Required"` or `` `Minimum ${min} ${many}` `` if too few items, or `` `Maximum ${max} ${many}` `` if too many.
 	 * @example schema.validate([1, 2, 3]) // [1, 2, 3]
-	 * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ArraySchema/validate
+	 * @see https://shelving.cc/schema/ArraySchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): ImmutableArray<T> {
 		const unsafeArray = typeof unsafeValue === "string" ? unsafeValue.split(this.separator).filter(Boolean) : unsafeValue;
@@ -118,7 +118,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
 	 * @param arr The valid array to format.
 	 * @returns The array's items formatted as a human-readable string.
 	 * @example schema.format([1, 2, 3]) // "1, 2, 3"
-	 * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ArraySchema/format
+	 * @see https://shelving.cc/schema/ArraySchema/format
 	 */
 	override format(arr: ImmutableArray<T>): string {
 		return formatArray(
@@ -136,7 +136,7 @@ export class ArraySchema<T> extends Schema<ImmutableArray<T>> {
  *
  * @param items Schema every item in the array must conform to.
  * @example ARRAY(NUMBER) // ArraySchema<number>
- * @see https://dhoulb.github.io/shelving/schema/ArraySchema/ARRAY
+ * @see https://shelving.cc/schema/ARRAY
  */
 export function ARRAY<T>(items: Schema<T>): ArraySchema<T> {
 	return new ArraySchema({ items });

--- a/modules/schema/BooleanSchema.ts
+++ b/modules/schema/BooleanSchema.ts
@@ -5,7 +5,7 @@ import { Schema } from "./Schema.js";
 /**
  * Allowed options for `BooleanSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchemaOptions
+ * @see https://shelving.cc/schema/BooleanSchemaOptions
  */
 export interface BooleanSchemaOptions extends SchemaOptions {
 	/**
@@ -33,7 +33,7 @@ const NEGATIVE = ["", "false", "0", "no", "n", "off"];
  *  schema.validate("yes"); // Returns true
  *  schema.validate(""); // Throws "Required"
  *
- * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchema
+ * @see https://shelving.cc/schema/BooleanSchema
  */
 export class BooleanSchema extends Schema<boolean> {
 	declare readonly value: boolean;
@@ -55,7 +55,7 @@ export class BooleanSchema extends Schema<boolean> {
 	 * @example
 	 *  BOOLEAN.validate("yes"); // Returns true
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchema/validate
+	 * @see https://shelving.cc/schema/BooleanSchema/validate
 	 */
 	validate(unsafeValue: unknown = this.value): boolean {
 		const value: boolean = typeof unsafeValue === "string" ? !NEGATIVE.includes(unsafeValue.toLowerCase().trim()) : !!unsafeValue;
@@ -71,7 +71,7 @@ export class BooleanSchema extends Schema<boolean> {
 	 * @example
 	 *  BOOLEAN.format(true); // Returns "Yes"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BooleanSchema/format
+	 * @see https://shelving.cc/schema/BooleanSchema/format
 	 */
 	override format(value: boolean): string {
 		return formatBoolean(value);
@@ -84,6 +84,6 @@ export class BooleanSchema extends Schema<boolean> {
  * @example
  *  BOOLEAN.validate("yes"); // Returns true
  *
- * @see https://dhoulb.github.io/shelving/schema/BooleanSchema/BOOLEAN
+ * @see https://shelving.cc/schema/BOOLEAN
  */
 export const BOOLEAN = new BooleanSchema({});

--- a/modules/schema/ChoiceSchema.ts
+++ b/modules/schema/ChoiceSchema.ts
@@ -6,7 +6,7 @@ import { Schema } from "./Schema.js";
 /**
  * Dictionary of allowed options for a `ChoiceSchema` in `{ key: title }` format.
  *
- * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceOptions
+ * @see https://shelving.cc/schema/ChoiceOptions
  */
 export type ChoiceOptions<K extends string> = { readonly [KK in K]: string };
 
@@ -16,7 +16,7 @@ export type ChoiceOptions<K extends string> = { readonly [KK in K]: string };
  * - Dictionary of string options in `{ key: title }` format.
  * - Array of string options in `[key]` format (`key` is used as the `title` too).
  *
- * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/PossibleChoiceOptions
+ * @see https://shelving.cc/schema/PossibleChoiceOptions
  */
 export type PossibleChoiceOptions<K extends string> = ImmutableArray<K> | ChoiceOptions<K>;
 
@@ -34,7 +34,7 @@ function _getChoiceOption<K extends string>(k: K): readonly [title: K, title: st
  * - `options` — the allowed choices, as a `{ key: title }` dictionary or an array of keys.
  * - `value` — default option used when the input is `undefined`.
  *
- * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceSchemaOptions
+ * @see https://shelving.cc/schema/ChoiceSchemaOptions
  */
 export interface ChoiceSchemaOptions<O extends string, I = never> extends SchemaOptions {
 	/** Specify correct options using a dictionary of entries. */
@@ -53,7 +53,7 @@ export interface ChoiceSchemaOptions<O extends string, I = never> extends Schema
  *  const schema = new ChoiceSchema({ options: { yes: "Yes", no: "No" } });
  *  schema.validate("yes"); // "yes"
  *
- * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceSchema
+ * @see https://shelving.cc/schema/ChoiceSchema
  */
 export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 	declare readonly value: O | I | undefined;
@@ -74,7 +74,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 	 * @returns The valid choice key.
 	 * @throws `string` `"Required"` if the value is empty or missing, or `` `Unknown ${one}` `` if it is not one of the allowed choices.
 	 * @example schema.validate("yes") // "yes"
-	 * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceSchema/validate
+	 * @see https://shelving.cc/schema/ChoiceSchema/validate
 	 */
 	validate(unsafeValue: unknown = this.value): O {
 		if (typeof unsafeValue === "string" && isProp(this.options, unsafeValue)) return unsafeValue;
@@ -87,7 +87,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
 	 * @param value The valid choice key to format.
 	 * @returns The choice's title from `options`.
 	 * @example schema.format("yes") // "Yes"
-	 * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/ChoiceSchema/format
+	 * @see https://shelving.cc/schema/ChoiceSchema/format
 	 */
 	override format(value: O): string {
 		return this.options[value];
@@ -101,7 +101,7 @@ export class ChoiceSchema<O extends string, I = never> extends Schema<O> {
  *
  * @param options The allowed choices, as a `{ key: title }` dictionary or an array of keys.
  * @example CHOICE({ yes: "Yes", no: "No" }) // ChoiceSchema<"yes" | "no">
- * @see https://dhoulb.github.io/shelving/schema/ChoiceSchema/CHOICE
+ * @see https://shelving.cc/schema/CHOICE
  */
 export function CHOICE<K extends string>(options: PossibleChoiceOptions<K>): ChoiceSchema<K> {
 	return new ChoiceSchema({ options });

--- a/modules/schema/ColorSchema.ts
+++ b/modules/schema/ColorSchema.ts
@@ -10,7 +10,7 @@ const NOT_HEX_REGEXP = /[^0-9A-F]/g;
  *
  * - The length, format, and single-line constraints are fixed internally, so only the presentation-level string options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/ColorSchema/ColorSchemaOptions
+ * @see https://shelving.cc/schema/ColorSchemaOptions
  */
 export interface ColorSchemaOptions extends SchemaOptions {
 	/**
@@ -39,7 +39,7 @@ export interface ColorSchemaOptions extends SchemaOptions {
  * - Rejects anything that isn't a valid hex color (use `NULLABLE_COLOR` to also allow `null`).
  *
  * @example COLOR.validate("00ccff"); // Returns "#00CCFF"
- * @see https://dhoulb.github.io/shelving/schema/ColorSchema/ColorSchema
+ * @see https://shelving.cc/schema/ColorSchema
  */
 export class ColorSchema extends StringSchema {
 	/**
@@ -67,7 +67,7 @@ export class ColorSchema extends StringSchema {
 	 * @param insaneString String to sanitize.
 	 * @returns The sanitized hex color, or `""` if no hex digits are present.
 	 * @example COLOR.sanitize("00ccff"); // Returns "#00CCFF"
-	 * @see https://dhoulb.github.io/shelving/schema/ColorSchema/ColorSchema/sanitize
+	 * @see https://shelving.cc/schema/ColorSchema/sanitize
 	 */
 	override sanitize(insaneString: string): string {
 		const saneString = insaneString.toUpperCase().replace(NOT_HEX_REGEXP, "");
@@ -79,7 +79,7 @@ export class ColorSchema extends StringSchema {
  * Sugar instance of `ColorSchema` for a required hex color string, e.g. `#00CCFF`. Equivalent to `new ColorSchema({})`.
  *
  * @example COLOR.validate("#00CCFF"); // Returns "#00CCFF"
- * @see https://dhoulb.github.io/shelving/schema/ColorSchema/COLOR
+ * @see https://shelving.cc/schema/COLOR
  */
 export const COLOR = new ColorSchema({});
 
@@ -87,6 +87,6 @@ export const COLOR = new ColorSchema({});
  * Sugar instance allowing a `COLOR` or `null`. Equivalent to `NULLABLE(COLOR)`.
  *
  * @example NULLABLE_COLOR.validate(null); // Returns null
- * @see https://dhoulb.github.io/shelving/schema/ColorSchema/NULLABLE_COLOR
+ * @see https://shelving.cc/schema/NULLABLE_COLOR
  */
 export const NULLABLE_COLOR = NULLABLE(COLOR);

--- a/modules/schema/CountrySchema.ts
+++ b/modules/schema/CountrySchema.ts
@@ -6,7 +6,7 @@ import type { SchemaOptions } from "./Schema.js";
 /**
  * Options for `CountrySchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/CountrySchema/CountrySchemaOptions
+ * @see https://shelving.cc/schema/CountrySchemaOptions
  */
 export interface CountrySchemaOptions extends SchemaOptions {
 	/** Country value, or `"detect"` to resolve from browser language. */
@@ -22,14 +22,14 @@ export interface CountrySchemaOptions extends SchemaOptions {
  * @example
  *  const schema = new CountrySchema({});
  *  schema.validate("GB"); // "GB"
- * @see https://dhoulb.github.io/shelving/schema/CountrySchema/CountrySchema
+ * @see https://shelving.cc/schema/CountrySchema
  */
 export class CountrySchema extends ChoiceSchema<Country, PossibleCountry> {
 	/**
 	 * Create a new `CountrySchema`.
 	 *
 	 * @example new CountrySchema({ value: "GB" })
-	 * @see https://dhoulb.github.io/shelving/schema/CountrySchema/CountrySchema
+	 * @see https://shelving.cc/schema/CountrySchema
 	 */
 	constructor({ one = "country", title = "Country", value = "detect", ...options }: CountrySchemaOptions = {}) {
 		super({ one, title, options: COUNTRIES, value, ...options });
@@ -42,7 +42,7 @@ export class CountrySchema extends ChoiceSchema<Country, PossibleCountry> {
 	 * @returns The validated ISO 3166 country code.
 	 * @throws `string` `"Required"` if the value is empty, or `` `Unknown ${one}` `` if it is not a known country.
 	 * @example schema.validate("GB") // "GB"
-	 * @see https://dhoulb.github.io/shelving/schema/CountrySchema/CountrySchema/validate
+	 * @see https://shelving.cc/schema/CountrySchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): Country {
 		const country = getCountry(unsafeValue);
@@ -55,7 +55,7 @@ export class CountrySchema extends ChoiceSchema<Country, PossibleCountry> {
  * Sugar instance of `CountrySchema` for a required ISO 3166 country code, e.g. `GB`. Equivalent to `new CountrySchema({})`.
  *
  * @example COUNTRY.validate("GB") // "GB"
- * @see https://dhoulb.github.io/shelving/schema/CountrySchema/COUNTRY
+ * @see https://shelving.cc/schema/COUNTRY
  */
 export const COUNTRY = new CountrySchema({});
 
@@ -63,6 +63,6 @@ export const COUNTRY = new CountrySchema({});
  * Sugar instance allowing a `COUNTRY` or `null`. Equivalent to `NULLABLE(COUNTRY)`.
  *
  * @example NULLABLE_COUNTRY.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CountrySchema/NULLABLE_COUNTRY
+ * @see https://shelving.cc/schema/NULLABLE_COUNTRY
  */
 export const NULLABLE_COUNTRY = NULLABLE(COUNTRY);

--- a/modules/schema/CurrencyAmountSchema.ts
+++ b/modules/schema/CurrencyAmountSchema.ts
@@ -7,7 +7,7 @@ import { NumberSchema, type NumberSchemaOptions } from "./NumberSchema.js";
 /**
  * Options for `CurrencyAmountSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchemaOptions
+ * @see https://shelving.cc/schema/CurrencyAmountSchemaOptions
  */
 export interface CurrencyAmountSchemaOptions extends NumberSchemaOptions {
 	/** Override the currency symbol used when formatting. */
@@ -26,25 +26,25 @@ export interface CurrencyAmountSchemaOptions extends NumberSchemaOptions {
  * const PRICE = new CurrencyAmountSchema({ currency: "GBP", min: 0 });
  * PRICE.validate("12.345"); // 12.35
  * PRICE.format(12.3); // "£12.30"
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchema
+ * @see https://shelving.cc/schema/CurrencyAmountSchema
  */
 export class CurrencyAmountSchema extends NumberSchema {
 	/**
 	 * Rounding step, always defined and inferred from the currency's minor units.
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchema/step
+	 * @see https://shelving.cc/schema/CurrencyAmountSchema/step
 	 */
 	declare readonly step: number; // Step is always defined for `CurrencyAmountSchema`, as it's inferred from the currency.
 	/**
 	 * ISO 4217 currency code this schema validates amounts for.
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchema/currency
+	 * @see https://shelving.cc/schema/CurrencyAmountSchema/currency
 	 */
 	readonly currency: CurrencyCode;
 	/**
 	 * Currency symbol used when formatting amounts.
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchema/symbol
+	 * @see https://shelving.cc/schema/CurrencyAmountSchema/symbol
 	 */
 	readonly symbol: string;
 
@@ -73,7 +73,7 @@ export class CurrencyAmountSchema extends NumberSchema {
 	 * @param value The validated amount to format.
 	 * @returns The amount formatted using the schema's currency and symbol.
 	 * @example schema.format(12.3) // "£12.30"
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CurrencyAmountSchema/format
+	 * @see https://shelving.cc/schema/CurrencyAmountSchema/format
 	 */
 	override format(value: number): string {
 		const options = this.step >= 1 ? { maximumFractionDigits: 0 } : {}; // Skip showing decimal places if step is 1 or more.
@@ -89,7 +89,7 @@ export class CurrencyAmountSchema extends NumberSchema {
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @throws `string` if `currency` is not a valid ISO 4217 currency code.
  * @example CURRENCY_AMOUNT("GBP").validate("12.345") // 12.35
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/CURRENCY_AMOUNT
+ * @see https://shelving.cc/schema/CURRENCY_AMOUNT
  */
 export function CURRENCY_AMOUNT(currency: CurrencyCode): CurrencyAmountSchema {
 	return new CurrencyAmountSchema({ currency });
@@ -99,7 +99,7 @@ export function CURRENCY_AMOUNT(currency: CurrencyCode): CurrencyAmountSchema {
  * Sugar instance of `CurrencyAmountSchema` for a US dollar amount. Equivalent to `new CurrencyAmountSchema({ currency: "USD" })`.
  *
  * @example USD_AMOUNT.validate("12.345") // 12.35
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/USD_AMOUNT
+ * @see https://shelving.cc/schema/USD_AMOUNT
  */
 export const USD_AMOUNT = new CurrencyAmountSchema({ currency: "USD" });
 
@@ -107,7 +107,7 @@ export const USD_AMOUNT = new CurrencyAmountSchema({ currency: "USD" });
  * Sugar instance of `CurrencyAmountSchema` for a pound sterling amount. Equivalent to `new CurrencyAmountSchema({ currency: "GBP" })`.
  *
  * @example GBP_AMOUNT.validate("12.345") // 12.35
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/GBP_AMOUNT
+ * @see https://shelving.cc/schema/GBP_AMOUNT
  */
 export const GBP_AMOUNT = new CurrencyAmountSchema({ currency: "GBP" });
 
@@ -115,7 +115,7 @@ export const GBP_AMOUNT = new CurrencyAmountSchema({ currency: "GBP" });
  * Sugar instance of `CurrencyAmountSchema` for a euro amount. Equivalent to `new CurrencyAmountSchema({ currency: "EUR" })`.
  *
  * @example EUR_AMOUNT.validate("12.345") // 12.35
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/EUR_AMOUNT
+ * @see https://shelving.cc/schema/EUR_AMOUNT
  */
 export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
 
@@ -127,7 +127,7 @@ export const EUR_AMOUNT = new CurrencyAmountSchema({ currency: "EUR" });
  * @param currency ISO 4217 currency code that determines the step and symbol.
  * @throws `string` if `currency` is not a valid ISO 4217 currency code.
  * @example NULLABLE_CURRENCY_AMOUNT("GBP").validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_CURRENCY_AMOUNT
+ * @see https://shelving.cc/schema/NULLABLE_CURRENCY_AMOUNT
  */
 export function NULLABLE_CURRENCY_AMOUNT(currency: CurrencyCode): NullableSchema<number> {
 	return NULLABLE(CURRENCY_AMOUNT(currency));
@@ -137,7 +137,7 @@ export function NULLABLE_CURRENCY_AMOUNT(currency: CurrencyCode): NullableSchema
  * Sugar instance allowing a `USD_AMOUNT` or `null`. Equivalent to `NULLABLE(USD_AMOUNT)`.
  *
  * @example NULLABLE_USD_AMOUNT.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_USD_AMOUNT
+ * @see https://shelving.cc/schema/NULLABLE_USD_AMOUNT
  */
 export const NULLABLE_USD_AMOUNT = NULLABLE(USD_AMOUNT);
 
@@ -145,7 +145,7 @@ export const NULLABLE_USD_AMOUNT = NULLABLE(USD_AMOUNT);
  * Sugar instance allowing a `GBP_AMOUNT` or `null`. Equivalent to `NULLABLE(GBP_AMOUNT)`.
  *
  * @example NULLABLE_GBP_AMOUNT.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_GBP_AMOUNT
+ * @see https://shelving.cc/schema/NULLABLE_GBP_AMOUNT
  */
 export const NULLABLE_GBP_AMOUNT = NULLABLE(GBP_AMOUNT);
 
@@ -153,6 +153,6 @@ export const NULLABLE_GBP_AMOUNT = NULLABLE(GBP_AMOUNT);
  * Sugar instance allowing an `EUR_AMOUNT` or `null`. Equivalent to `NULLABLE(EUR_AMOUNT)`.
  *
  * @example NULLABLE_EUR_AMOUNT.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CurrencyAmountSchema/NULLABLE_EUR_AMOUNT
+ * @see https://shelving.cc/schema/NULLABLE_EUR_AMOUNT
  */
 export const NULLABLE_EUR_AMOUNT = NULLABLE(EUR_AMOUNT);

--- a/modules/schema/CurrencyCodeSchema.ts
+++ b/modules/schema/CurrencyCodeSchema.ts
@@ -9,7 +9,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length, format, and single-line constraints are fixed internally, so only the presentation-level string options plus `currencies` are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchemaOptions
+ * @see https://shelving.cc/schema/CurrencyCodeSchemaOptions
  */
 export interface CurrencyCodeSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -38,13 +38,13 @@ export interface CurrencyCodeSchemaOptions extends SchemaOptions {
  * @example
  *  const schema = new CurrencyCodeSchema({});
  *  schema.validate("gbp"); // "GBP"
- * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema
+ * @see https://shelving.cc/schema/CurrencyCodeSchema
  */
 export class CurrencyCodeSchema extends StringSchema {
 	/**
 	 * Set of allowed ISO 4217 currency codes.
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema/currencies
+	 * @see https://shelving.cc/schema/CurrencyCodeSchema/currencies
 	 */
 	readonly currencies: ImmutableArray<CurrencyCode>;
 
@@ -52,7 +52,7 @@ export class CurrencyCodeSchema extends StringSchema {
 	 * Create a new `CurrencyCodeSchema`.
 	 *
 	 * @example new CurrencyCodeSchema({ currencies: ["GBP", "USD"] })
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema
+	 * @see https://shelving.cc/schema/CurrencyCodeSchema
 	 */
 	constructor({ one = "currency", title = "Currency", currencies = CURRENCY_CODES, max = 3, ...options }: CurrencyCodeSchemaOptions) {
 		super({
@@ -74,7 +74,7 @@ export class CurrencyCodeSchema extends StringSchema {
 	 * @param insaneString The raw input string to sanitize.
 	 * @returns The sanitized string with all non-`A-Z` characters stripped.
 	 * @example schema.sanitize(" gb p ") // "GBP"
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema/sanitize
+	 * @see https://shelving.cc/schema/CurrencyCodeSchema/sanitize
 	 */
 	override sanitize(insaneString: string): string {
 		// Strip characters that aren't A-Z (including whitespace).
@@ -88,7 +88,7 @@ export class CurrencyCodeSchema extends StringSchema {
 	 * @returns The validated three-letter uppercase currency code.
 	 * @throws `string` if the value is not a valid string, or `"Unknown currency code"` if it is not in `currencies`.
 	 * @example schema.validate("gbp") // "GBP"
-	 * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CurrencyCodeSchema/validate
+	 * @see https://shelving.cc/schema/CurrencyCodeSchema/validate
 	 */
 	override validate(value?: unknown): string {
 		const currency = super.validate(value);
@@ -101,7 +101,7 @@ export class CurrencyCodeSchema extends StringSchema {
  * Sugar instance of `CurrencyCodeSchema` for a required ISO 4217 currency code, e.g. `GBP`. Equivalent to `new CurrencyCodeSchema({})`.
  *
  * @example CURRENCY_CODE.validate("gbp") // "GBP"
- * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/CURRENCY_CODE
+ * @see https://shelving.cc/schema/CURRENCY_CODE
  */
 export const CURRENCY_CODE = new CurrencyCodeSchema({});
 
@@ -109,6 +109,6 @@ export const CURRENCY_CODE = new CurrencyCodeSchema({});
  * Sugar instance allowing a `CURRENCY_CODE` or `null`. Equivalent to `NULLABLE(CURRENCY_CODE)`.
  *
  * @example NULLABLE_CURRENCY_CODE.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/CurrencyCodeSchema/NULLABLE_CURRENCY_CODE
+ * @see https://shelving.cc/schema/NULLABLE_CURRENCY_CODE
  */
 export const NULLABLE_CURRENCY_CODE = NULLABLE(CURRENCY_CODE);

--- a/modules/schema/DataSchema.ts
+++ b/modules/schema/DataSchema.ts
@@ -14,7 +14,7 @@ import { Schema } from "./Schema.js";
 /**
  * Options for `DataSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchemaOptions
+ * @see https://shelving.cc/schema/DataSchemaOptions
  */
 export interface DataSchemaOptions<T extends Data> extends SchemaOptions {
 	/** A named schema for each property the data object must have. */
@@ -33,7 +33,7 @@ export interface DataSchemaOptions<T extends Data> extends SchemaOptions {
  *  const schema = new DataSchema({ props: { name: STRING, age: NUMBER } });
  *  schema.validate({ name: "Dave", age: 40 }); // { name: "Dave", age: 40 }
  *
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchema
+ * @see https://shelving.cc/schema/DataSchema
  */
 export class DataSchema<T extends Data> extends Schema<unknown> {
 	declare readonly value: T;
@@ -56,7 +56,7 @@ export class DataSchema<T extends Data> extends Schema<unknown> {
 	 * @returns The valid data object with each property validated by its schema.
 	 * @throws `string` `"Must be object"` if the value is not a data object, or a `"key: message"` line per invalid property.
 	 * @example schema.validate({ name: "Dave" }) // { name: "Dave" }
-	 * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchema/validate
+	 * @see https://shelving.cc/schema/DataSchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): T {
 		if (!isData(unsafeValue)) throw "Must be object";
@@ -68,7 +68,7 @@ export class DataSchema<T extends Data> extends Schema<unknown> {
 	 *
 	 * @param keys The property keys to keep.
 	 * @example schema.pick("name", "age") // DataSchema<Pick<T, "name" | "age">>
-	 * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchema/pick
+	 * @see https://shelving.cc/schema/DataSchema/pick
 	 */
 	pick<K extends Key<T>>(...keys: K[]): DataSchema<Pick<T, K>> {
 		return new DataSchema<Pick<T, K>>({ ...this, props: pickProps<Schemas<T>, K>(this.props, ...keys) });
@@ -79,7 +79,7 @@ export class DataSchema<T extends Data> extends Schema<unknown> {
 	 *
 	 * @param keys The property keys to remove.
 	 * @example schema.omit("age") // DataSchema<Omit<T, "age">>
-	 * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchema/omit
+	 * @see https://shelving.cc/schema/DataSchema/omit
 	 */
 	omit<K extends Key<T>>(...keys: K[]): DataSchema<Omit<T, K>> {
 		return new DataSchema<Omit<T, K>>({ ...this, props: omitProps<Schemas<T>, K>(this.props, ...keys) });
@@ -91,7 +91,7 @@ export class DataSchema<T extends Data> extends Schema<unknown> {
 	 * @param value The valid data object to format.
 	 * @returns The data object formatted as a human-readable string.
 	 * @example schema.format({ name: "Dave" }) // "name: Dave"
-	 * @see https://dhoulb.github.io/shelving/schema/DataSchema/DataSchema/format
+	 * @see https://shelving.cc/schema/DataSchema/format
 	 */
 	override format(value: T): string {
 		return formatObject(value);
@@ -109,7 +109,7 @@ function _getSchemaValue<T extends Data>([, { value }]: Prop<Schemas<T>>): Value
  *
  * @param props A named schema for each property of the data object.
  * @example DATA({ name: STRING, age: NUMBER }) // DataSchema<{ name: string; age: number }>
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/DATA
+ * @see https://shelving.cc/schema/DATA
  */
 export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
 	return new DataSchema({ props });
@@ -122,7 +122,7 @@ export function DATA<T extends Data>(props: Schemas<T>): DataSchema<T> {
  *
  * @param props A named schema for each property of the data object.
  * @example NULLABLE_DATA({ name: STRING }) // NullableSchema<{ name: string }>
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/NULLABLE_DATA
+ * @see https://shelving.cc/schema/NULLABLE_DATA
  */
 export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema<T> {
 	return NULLABLE(new DataSchema({ props }));
@@ -136,7 +136,7 @@ export function NULLABLE_DATA<T extends Data>(props: Schemas<T>): NullableSchema
  * @param source The props schemas or an existing `DataSchema` to make partial.
  * @returns A `DataSchema` whose every property is optional.
  * @example PARTIAL({ name: STRING, age: NUMBER }) // DataSchema<{ name?: string; age?: number }>
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/PARTIAL
+ * @see https://shelving.cc/schema/PARTIAL
  */
 export function PARTIAL<T extends Data>(source: Schemas<T> | DataSchema<T>): DataSchema<PartialData<T>>;
 export function PARTIAL(source: Schemas<Data> | DataSchema<Data>): DataSchema<PartialData<Data>> {
@@ -158,7 +158,7 @@ function _optionalProp([, v]: Prop<Schemas<Data>>): Schema<unknown> {
  * @param schemas The props schemas or an existing `DataSchema` for the rest of the item.
  * @returns A `DataSchema` validating an item with an `id` property plus the given props.
  * @example ITEM(NUMBER, { name: STRING }) // DataSchema<{ id: number; name: string }>
- * @see https://dhoulb.github.io/shelving/schema/DataSchema/ITEM
+ * @see https://shelving.cc/schema/ITEM
  */
 export function ITEM<I extends Identifier, T extends Data>(id: Schema<I>, schemas: Schemas<T> | DataSchema<T>): DataSchema<Item<I, T>> {
 	const props: Schemas<T> = schemas instanceof DataSchema ? schemas.props : schemas;

--- a/modules/schema/DateSchema.ts
+++ b/modules/schema/DateSchema.ts
@@ -10,14 +10,14 @@ import { Schema } from "./Schema.js";
 /**
  * `type=""` prop for HTML `<input />` tags that are relevant for dates.
  *
- * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateInputType
+ * @see https://shelving.cc/schema/DateInputType
  */
 export type DateInputType = "time" | "date" | "datetime-local";
 
 /**
  * Options for `DateSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchemaOptions
+ * @see https://shelving.cc/schema/DateSchemaOptions
  */
 export interface DateSchemaOptions extends SchemaOptions {
 	/** Default date used when the input is `undefined`. */
@@ -48,7 +48,7 @@ export interface DateSchemaOptions extends SchemaOptions {
  * @example
  *  const schema = new DateSchema({ min: "2000-01-01" });
  *  schema.validate("2005-09-12"); // "2005-09-12"
- * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchema
+ * @see https://shelving.cc/schema/DateSchema
  */
 export class DateSchema extends Schema<string> {
 	/** Default date used when `validate()` is called with an `undefined` value. */
@@ -80,7 +80,7 @@ export class DateSchema extends Schema<string> {
 	 * @returns The validated date as a `YYYY-MM-DD` string.
 	 * @throws `string` `"Required"` if the value is empty, `` `Invalid ${one} format` `` if it is not a date, or `` `Minimum…` `` / `` `Maximum…` `` if outside the allowed range.
 	 * @example schema.validate("2005-09-12") // "2005-09-12"
-	 * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchema/validate
+	 * @see https://shelving.cc/schema/DateSchema/validate
 	 */
 	override validate(value: unknown = this.value): string {
 		const date = getDate(value);
@@ -100,7 +100,7 @@ export class DateSchema extends Schema<string> {
 	 * @param value The `Date` to convert.
 	 * @returns The date as a `YYYY-MM-DD` string.
 	 * @example schema.stringify(new Date("2005-09-12")) // "2005-09-12"
-	 * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchema/stringify
+	 * @see https://shelving.cc/schema/DateSchema/stringify
 	 */
 	stringify(value: Date): string {
 		return requireDateString(value);
@@ -112,7 +112,7 @@ export class DateSchema extends Schema<string> {
 	 * @param value The validated date string to format.
 	 * @returns The date formatted for display.
 	 * @example schema.format("2005-09-12") // "12 Sep 2005"
-	 * @see https://dhoulb.github.io/shelving/schema/DateSchema/DateSchema/format
+	 * @see https://shelving.cc/schema/DateSchema/format
 	 */
 	override format(value: string): string {
 		return formatDate(value, undefined, this.format);
@@ -123,7 +123,7 @@ export class DateSchema extends Schema<string> {
  * Sugar instance of `DateSchema` for a required date. Equivalent to `new DateSchema({})`.
  *
  * @example DATE.validate("2005-09-12") // "2005-09-12"
- * @see https://dhoulb.github.io/shelving/schema/DateSchema/DATE
+ * @see https://shelving.cc/schema/DATE
  */
 export const DATE = new DateSchema({});
 
@@ -131,6 +131,6 @@ export const DATE = new DateSchema({});
  * Sugar instance allowing a `DATE` or `null`. Equivalent to `NULLABLE(DATE)`.
  *
  * @example NULLABLE_DATE.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/DateSchema/NULLABLE_DATE
+ * @see https://shelving.cc/schema/NULLABLE_DATE
  */
 export const NULLABLE_DATE = NULLABLE(DATE);

--- a/modules/schema/DateTimeSchema.ts
+++ b/modules/schema/DateTimeSchema.ts
@@ -12,7 +12,7 @@ import { NULLABLE } from "./NullableSchema.js";
  * @example
  *  const schema = new DateTimeSchema({});
  *  schema.validate("2005-09-12T18:15:00Z"); // "2005-09-12T18:15:00.000Z"
- * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/DateTimeSchema
+ * @see https://shelving.cc/schema/DateTimeSchema
  */
 export class DateTimeSchema extends DateSchema {
 	/**
@@ -27,7 +27,7 @@ export class DateTimeSchema extends DateSchema {
 	 * @param value The `Date` to convert.
 	 * @returns The datetime as an ISO 8601 string with `Z` suffix.
 	 * @example schema.stringify(new Date("2005-09-12T18:15:00Z")) // "2005-09-12T18:15:00.000Z"
-	 * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/DateTimeSchema/stringify
+	 * @see https://shelving.cc/schema/DateTimeSchema/stringify
 	 */
 	override stringify(value: Date): string {
 		return value.toISOString();
@@ -38,7 +38,7 @@ export class DateTimeSchema extends DateSchema {
 	 * @param value The validated datetime string to format.
 	 * @returns The datetime formatted for display.
 	 * @example schema.format("2005-09-12T18:15:00Z") // "12 Sep 2005, 18:15"
-	 * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/DateTimeSchema/format
+	 * @see https://shelving.cc/schema/DateTimeSchema/format
 	 */
 	override format(value: string): string {
 		return formatDateTime(value, undefined, this.format);
@@ -49,7 +49,7 @@ export class DateTimeSchema extends DateSchema {
  * Sugar instance of `DateTimeSchema` for a required UTC datetime. Equivalent to `new DateTimeSchema({})`.
  *
  * @example DATETIME.validate("2005-09-12T08:00:00Z") // "2005-09-12T08:00:00.000Z"
- * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/DATETIME
+ * @see https://shelving.cc/schema/DATETIME
  */
 export const DATETIME = new DateTimeSchema({});
 
@@ -57,6 +57,6 @@ export const DATETIME = new DateTimeSchema({});
  * Sugar instance allowing a `DATETIME` or `null`. Equivalent to `NULLABLE(DATETIME)`.
  *
  * @example NULLABLE_DATETIME.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/DateTimeSchema/NULLABLE_DATETIME
+ * @see https://shelving.cc/schema/NULLABLE_DATETIME
  */
 export const NULLABLE_DATETIME = NULLABLE(DATETIME);

--- a/modules/schema/DictionarySchema.ts
+++ b/modules/schema/DictionarySchema.ts
@@ -8,7 +8,7 @@ import { Schema } from "./Schema.js";
 /**
  * Options for `DictionarySchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DictionarySchemaOptions
+ * @see https://shelving.cc/schema/DictionarySchemaOptions
  */
 export interface DictionarySchemaOptions<T> extends SchemaOptions {
 	/** Schema every entry value in the dictionary must conform to. */
@@ -37,7 +37,7 @@ export interface DictionarySchemaOptions<T> extends SchemaOptions {
  *  const schema = new DictionarySchema({ items: NUMBER });
  *  schema.validate({ a: 1, b: 2 }); // { a: 1, b: 2 }
  *
- * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DictionarySchema
+ * @see https://shelving.cc/schema/DictionarySchema
  */
 export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 	declare readonly value: ImmutableDictionary<T>;
@@ -72,7 +72,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 	 * @returns The valid dictionary with each entry value validated by the `items` schema.
 	 * @throws `string` `"Must be object"` if not a dictionary, `"Required"` or `` `Minimum ${min} ${many}` `` if too few entries, or `` `Maximum ${max} ${many}` `` if too many.
 	 * @example schema.validate({ a: 1, b: 2 }) // { a: 1, b: 2 }
-	 * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DictionarySchema/validate
+	 * @see https://shelving.cc/schema/DictionarySchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): ImmutableDictionary<T> {
 		if (!isDictionary(unsafeValue)) throw "Must be object";
@@ -89,7 +89,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
 	 * @param dict The valid dictionary to format.
 	 * @returns The dictionary's values formatted as a human-readable string.
 	 * @example schema.format({ a: 1, b: 2 }) // "1, 2"
-	 * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DictionarySchema/format
+	 * @see https://shelving.cc/schema/DictionarySchema/format
 	 */
 	override format(dict: ImmutableDictionary<T>): string {
 		return formatArray(
@@ -107,7 +107,7 @@ export class DictionarySchema<T> extends Schema<ImmutableDictionary<T>> {
  *
  * @param items Schema every entry value in the dictionary must conform to.
  * @example DICTIONARY(NUMBER) // DictionarySchema<number>
- * @see https://dhoulb.github.io/shelving/schema/DictionarySchema/DICTIONARY
+ * @see https://shelving.cc/schema/DICTIONARY
  */
 export function DICTIONARY<T>(items: Schema<T>): DictionarySchema<T> {
 	return new DictionarySchema({ items });

--- a/modules/schema/EmailSchema.ts
+++ b/modules/schema/EmailSchema.ts
@@ -11,7 +11,7 @@ const R_MATCH =
  *
  * - The length, format, and single-line constraints are fixed internally, so only the presentation-level string options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchemaOptions
+ * @see https://shelving.cc/schema/EmailSchemaOptions
  */
 export interface EmailSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -48,7 +48,7 @@ export interface EmailSchemaOptions extends SchemaOptions {
  *     - TLD is a segment of 2-63 characters, possibly in `xn--` international format.
  *
  * @example EMAIL.validate("Test@Test.com"); // Returns "test@test.com"
- * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchema
+ * @see https://shelving.cc/schema/EmailSchema
  */
 export class EmailSchema extends StringSchema {
 	/**
@@ -75,7 +75,7 @@ export class EmailSchema extends StringSchema {
 	 * @param str String to sanitize.
 	 * @returns The sanitized, lowercased email address.
 	 * @example EMAIL.sanitize(" Test@Test.com "); // Returns "test@test.com"
-	 * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EmailSchema/sanitize
+	 * @see https://shelving.cc/schema/EmailSchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		// Email addresses never contain whitespace, so strip it entirely, then lowercase (RFC says addresses should be case-insensitive).
@@ -87,7 +87,7 @@ export class EmailSchema extends StringSchema {
  * Sugar instance of `EmailSchema` for a valid email address. Equivalent to `new EmailSchema({})`.
  *
  * @example EMAIL.validate("test@test.com"); // Returns "test@test.com"
- * @see https://dhoulb.github.io/shelving/schema/EmailSchema/EMAIL
+ * @see https://shelving.cc/schema/EMAIL
  */
 export const EMAIL = new EmailSchema({});
 
@@ -95,6 +95,6 @@ export const EMAIL = new EmailSchema({});
  * Sugar instance allowing an `EMAIL` or `null`. Equivalent to `NULLABLE(EMAIL)`.
  *
  * @example NULLABLE_EMAIL.validate(null); // Returns null
- * @see https://dhoulb.github.io/shelving/schema/EmailSchema/NULLABLE_EMAIL
+ * @see https://shelving.cc/schema/NULLABLE_EMAIL
  */
 export const NULLABLE_EMAIL = NULLABLE(EMAIL);

--- a/modules/schema/EntitySchema.ts
+++ b/modules/schema/EntitySchema.ts
@@ -6,7 +6,7 @@ import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 /**
  * Options for `EntitySchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/EntitySchema/EntitySchemaOptions
+ * @see https://shelving.cc/schema/EntitySchemaOptions
  */
 export interface EntitySchemaOptions<T extends string> extends StringSchemaOptions {
 	/** Restrict the allowed entity types; any other type is rejected. */
@@ -23,7 +23,7 @@ export interface EntitySchemaOptions<T extends string> extends StringSchemaOptio
  *  const schema = new EntitySchema({ types: ["challenge"] });
  *  schema.validate("challenge:a1b2c3"); // "challenge:a1b2c3"
  *
- * @see https://dhoulb.github.io/shelving/schema/EntitySchema/EntitySchema
+ * @see https://shelving.cc/schema/EntitySchema
  */
 export class EntitySchema<T extends string> extends StringSchema {
 	readonly types: ImmutableArray<T> | undefined;
@@ -43,7 +43,7 @@ export class EntitySchema<T extends string> extends StringSchema {
 	 * @returns The valid `Entity` string.
 	 * @throws `string` `"Must be entity"` if the value lacks a type and ID, or `"Invalid entity type"` if its type is not in the allowed `types`. Also throws any `string` from the underlying `StringSchema`.
 	 * @example schema.validate("challenge:a1b2c3") // "challenge:a1b2c3"
-	 * @see https://dhoulb.github.io/shelving/schema/EntitySchema/EntitySchema/validate
+	 * @see https://shelving.cc/schema/EntitySchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): Entity<T> {
 		const entity = super.validate(unsafeValue);
@@ -58,7 +58,7 @@ export class EntitySchema<T extends string> extends StringSchema {
  * Sugar instance of `EntitySchema` for an entity string, e.g. `challenge:a1b2c3`. Equivalent to `new EntitySchema({})`.
  *
  * @example ENTITY.validate("challenge:a1b2c3") // "challenge:a1b2c3"
- * @see https://dhoulb.github.io/shelving/schema/EntitySchema/ENTITY
+ * @see https://shelving.cc/schema/ENTITY
  */
 export const ENTITY = new EntitySchema({});
 
@@ -66,6 +66,6 @@ export const ENTITY = new EntitySchema({});
  * Sugar instance allowing an `ENTITY` or `null`. Equivalent to `NULLABLE(ENTITY)`.
  *
  * @example NULLABLE_ENTITY.validate("") // null
- * @see https://dhoulb.github.io/shelving/schema/EntitySchema/NULLABLE_ENTITY
+ * @see https://shelving.cc/schema/NULLABLE_ENTITY
  */
 export const NULLABLE_ENTITY = NULLABLE(ENTITY);

--- a/modules/schema/FileSchema.ts
+++ b/modules/schema/FileSchema.ts
@@ -7,7 +7,7 @@ import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
 /**
  * Allowed options for `FileSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/FileSchema/FileSchemaOptions
+ * @see https://shelving.cc/schema/FileSchemaOptions
  */
 export interface FileSchemaOptions extends StringSchemaOptions {
 	/** Set of allowed file extensions; when set, the file name's extension must be one of these. */
@@ -21,7 +21,7 @@ export interface FileSchemaOptions extends StringSchemaOptions {
  * - When `types` is set, the extension must be one of the allowed `FileTypes`.
  *
  * @example FILE.validate("photo.jpg"); // Returns "photo.jpg"
- * @see https://dhoulb.github.io/shelving/schema/FileSchema/FileSchema
+ * @see https://shelving.cc/schema/FileSchema
  */
 export class FileSchema extends StringSchema {
 	/** Set of allowed file extensions; when set, the file name's extension must be one of these. */
@@ -42,7 +42,7 @@ export class FileSchema extends StringSchema {
 	 * @returns The validated file name.
 	 * @throws `string` `` `Must have extension` `` if the file name has no extension, or `` `Invalid extension` `` if its extension isn't in `types`. Also throws the `string` messages from `StringSchema.validate()`.
 	 * @example FILE.validate("photo.jpg"); // Returns "photo.jpg"
-	 * @see https://dhoulb.github.io/shelving/schema/FileSchema/FileSchema/validate
+	 * @see https://shelving.cc/schema/FileSchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): string {
 		const path = super.validate(unsafeValue);
@@ -57,7 +57,7 @@ export class FileSchema extends StringSchema {
  * Sugar instance of `FileSchema` for a file name, e.g. `file.txt`. Equivalent to `new FileSchema({})`.
  *
  * @example FILE.validate("file.txt"); // Returns "file.txt"
- * @see https://dhoulb.github.io/shelving/schema/FileSchema/FILE
+ * @see https://shelving.cc/schema/FILE
  */
 export const FILE = new FileSchema({});
 
@@ -65,6 +65,6 @@ export const FILE = new FileSchema({});
  * Sugar instance allowing a `FILE` or `null`. Equivalent to `NULLABLE(FILE)`.
  *
  * @example NULLABLE_FILE.validate(null); // Returns null
- * @see https://dhoulb.github.io/shelving/schema/FileSchema/NULLABLE_FILE
+ * @see https://shelving.cc/schema/NULLABLE_FILE
  */
 export const NULLABLE_FILE = NULLABLE(FILE);

--- a/modules/schema/KeySchema.ts
+++ b/modules/schema/KeySchema.ts
@@ -15,7 +15,7 @@ const R_NOT_CHAR = /[^a-zA-Z0-9]/g;
  *  const schema = new KeySchema({});
  *  schema.validate("a1b2-c3d4"); // "a1b2c3d4"
  *
- * @see https://dhoulb.github.io/shelving/schema/KeySchema/KeySchema
+ * @see https://shelving.cc/schema/KeySchema
  */
 export class KeySchema extends StringSchema {
 	/**
@@ -31,7 +31,7 @@ export class KeySchema extends StringSchema {
 	 * @param str String to sanitize.
 	 * @returns The sanitized key with non-alphanumeric characters removed.
 	 * @example schema.sanitize("a1b2-c3d4") // "a1b2c3d4"
-	 * @see https://dhoulb.github.io/shelving/schema/KeySchema/KeySchema/sanitize
+	 * @see https://shelving.cc/schema/KeySchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		return str.replace(R_NOT_CHAR, "");
@@ -42,7 +42,7 @@ export class KeySchema extends StringSchema {
  * Sugar instance of `KeySchema` for a database key. Equivalent to `new KeySchema({ title: "ID" })`.
  *
  * @example KEY.validate("a1b2c3") // "a1b2c3"
- * @see https://dhoulb.github.io/shelving/schema/KeySchema/KEY
+ * @see https://shelving.cc/schema/KEY
  */
 export const KEY = new KeySchema({ title: "ID" });
 
@@ -50,6 +50,6 @@ export const KEY = new KeySchema({ title: "ID" });
  * Sugar instance allowing a `KEY` or `null`. Equivalent to `NULLABLE(KEY)`.
  *
  * @example NULLABLE_KEY.validate("") // null
- * @see https://dhoulb.github.io/shelving/schema/KeySchema/NULLABLE_KEY
+ * @see https://shelving.cc/schema/NULLABLE_KEY
  */
 export const NULLABLE_KEY = NULLABLE(KEY);

--- a/modules/schema/NullableSchema.ts
+++ b/modules/schema/NullableSchema.ts
@@ -4,7 +4,7 @@ import { ThroughSchema, type ThroughSchemaOptions } from "./ThroughSchema.js";
 /**
  * Allowed options for `NullableSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NullableSchemaOptions
+ * @see https://shelving.cc/schema/NullableSchemaOptions
  */
 export interface NullableSchemaOptions<T> extends ThroughSchemaOptions<T | null> {
 	/**
@@ -25,7 +25,7 @@ export interface NullableSchemaOptions<T> extends ThroughSchemaOptions<T | null>
  *  schema.validate(""); // Returns null
  *  schema.validate("abc"); // Returns "abc"
  *
- * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NullableSchema
+ * @see https://shelving.cc/schema/NullableSchema
  */
 export class NullableSchema<T> extends ThroughSchema<T | null> {
 	declare readonly value: T | null;
@@ -45,7 +45,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 	 * @example
 	 *  NULLABLE(STRING).validate(""); // Returns null
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NullableSchema/validate
+	 * @see https://shelving.cc/schema/NullableSchema/validate
 	 */
 	override validate(unsafeValue: unknown = this.value): T | null {
 		if (unsafeValue === null || unsafeValue === undefined || unsafeValue === "" || Number.isNaN(unsafeValue)) return null;
@@ -60,7 +60,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
 	 * @example
 	 *  NULLABLE(STRING).format(null); // Returns "No string"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NullableSchema/format
+	 * @see https://shelving.cc/schema/NullableSchema/format
 	 */
 	override format(value: T | null): string {
 		return value === null ? `No ${this.source.one}` : super.format(value);
@@ -78,7 +78,7 @@ export class NullableSchema<T> extends ThroughSchema<T | null> {
  *  const schema = NULLABLE(STRING);
  *  schema.validate(""); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/NullableSchema/NULLABLE
+ * @see https://shelving.cc/schema/NULLABLE
  */
 export function NULLABLE<T>(source: Schema<T>): NullableSchema<T> {
 	return new NullableSchema({ source });

--- a/modules/schema/NumberSchema.ts
+++ b/modules/schema/NumberSchema.ts
@@ -7,7 +7,7 @@ import { Schema } from "./Schema.js";
 /**
  * Allowed options for `NumberSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NumberSchemaOptions
+ * @see https://shelving.cc/schema/NumberSchemaOptions
  */
 export interface NumberSchemaOptions extends SchemaOptions {
 	/** Default number value used when the input is `undefined`. */
@@ -41,7 +41,7 @@ export interface NumberSchemaOptions extends SchemaOptions {
  *  const schema = new NumberSchema({ min: 0, max: 100, step: 1 });
  *  schema.validate("42"); // Returns 42
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NumberSchema
+ * @see https://shelving.cc/schema/NumberSchema
  */
 export class NumberSchema extends Schema<number> {
 	declare readonly value: number | undefined;
@@ -76,7 +76,7 @@ export class NumberSchema extends Schema<number> {
 	 * @example
 	 *  NUMBER.validate("42"); // Returns 42
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NumberSchema/validate
+	 * @see https://shelving.cc/schema/NumberSchema/validate
 	 */
 	override validate(value: unknown = this.value): number {
 		const number = getNumber(value);
@@ -95,7 +95,7 @@ export class NumberSchema extends Schema<number> {
 	 * @example
 	 *  NUMBER.format(2048.5); // Returns "2,048.5"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NumberSchema/format
+	 * @see https://shelving.cc/schema/NumberSchema/format
 	 */
 	override format(value: number): string {
 		return formatNumber(value);
@@ -108,7 +108,7 @@ export class NumberSchema extends Schema<number> {
  * @example
  *  NUMBER.validate("42"); // Returns 42
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NUMBER
+ * @see https://shelving.cc/schema/NUMBER
  */
 export const NUMBER = new NumberSchema({ title: "Number" });
 
@@ -118,7 +118,7 @@ export const NUMBER = new NumberSchema({ title: "Number" });
  * @example
  *  NULLABLE_NUMBER.validate(null); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NULLABLE_NUMBER
+ * @see https://shelving.cc/schema/NULLABLE_NUMBER
  */
 export const NULLABLE_NUMBER = NULLABLE(NUMBER);
 
@@ -128,7 +128,7 @@ export const NULLABLE_NUMBER = NULLABLE(NUMBER);
  * @example
  *  INTEGER.validate("42.7"); // Returns 43 (rounded to step)
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/INTEGER
+ * @see https://shelving.cc/schema/INTEGER
  */
 export const INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER });
 
@@ -138,7 +138,7 @@ export const INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER,
  * @example
  *  POSITIVE_INTEGER.validate(0); // Throws "Required"
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/POSITIVE_INTEGER
+ * @see https://shelving.cc/schema/POSITIVE_INTEGER
  */
 export const POSITIVE_INTEGER = new NumberSchema({ step: 1, min: 1, max: Number.MAX_SAFE_INTEGER });
 
@@ -148,7 +148,7 @@ export const POSITIVE_INTEGER = new NumberSchema({ step: 1, min: 1, max: Number.
  * @example
  *  NON_NEGATIVE_INTEGER.validate(0); // Returns 0
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NON_NEGATIVE_INTEGER
+ * @see https://shelving.cc/schema/NON_NEGATIVE_INTEGER
  */
 export const NON_NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: 0, max: Number.MAX_SAFE_INTEGER });
 
@@ -158,7 +158,7 @@ export const NON_NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: 0, max: Num
  * @example
  *  NEGATIVE_INTEGER.validate(-3); // Returns -3
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NEGATIVE_INTEGER
+ * @see https://shelving.cc/schema/NEGATIVE_INTEGER
  */
 export const NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: -1 });
 
@@ -168,7 +168,7 @@ export const NEGATIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE
  * @example
  *  NON_POSITIVE_INTEGER.validate(0); // Returns 0
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NON_POSITIVE_INTEGER
+ * @see https://shelving.cc/schema/NON_POSITIVE_INTEGER
  */
 export const NON_POSITIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_SAFE_INTEGER, max: 0 });
 
@@ -178,7 +178,7 @@ export const NON_POSITIVE_INTEGER = new NumberSchema({ step: 1, min: Number.MIN_
  * @example
  *  NULLABLE_INTEGER.validate(null); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NULLABLE_INTEGER
+ * @see https://shelving.cc/schema/NULLABLE_INTEGER
  */
 export const NULLABLE_INTEGER = NULLABLE(INTEGER);
 
@@ -188,7 +188,7 @@ export const NULLABLE_INTEGER = NULLABLE(INTEGER);
  * @example
  *  TIMESTAMP.validate(1700000000000); // Returns 1700000000000
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/TIMESTAMP
+ * @see https://shelving.cc/schema/TIMESTAMP
  */
 export const TIMESTAMP = new NumberSchema({
 	title: "Timestamp",
@@ -203,6 +203,6 @@ export const TIMESTAMP = new NumberSchema({
  * @example
  *  NULLABLE_TIMESTAMP.validate(null); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/NumberSchema/NULLABLE_TIMESTAMP
+ * @see https://shelving.cc/schema/NULLABLE_TIMESTAMP
  */
 export const NULLABLE_TIMESTAMP = NULLABLE_INTEGER;

--- a/modules/schema/OptionalSchema.ts
+++ b/modules/schema/OptionalSchema.ts
@@ -4,7 +4,7 @@ import { ThroughSchema, type ThroughSchemaOptions } from "./ThroughSchema.js";
 /**
  * Allowed options for `OptionalSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OptionalSchemaOptions
+ * @see https://shelving.cc/schema/OptionalSchemaOptions
  */
 export interface OptionalSchemaOptions<T> extends ThroughSchemaOptions<T | undefined> {
 	/** Default value is always `undefined` (the default is only used when the input is `undefined`, so otherwise `undefined` could never be returned). */
@@ -23,7 +23,7 @@ export interface OptionalSchemaOptions<T> extends ThroughSchemaOptions<T | undef
  *  schema.validate(undefined); // Returns undefined
  *  schema.validate("abc"); // Returns "abc"
  *
- * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OptionalSchema
+ * @see https://shelving.cc/schema/OptionalSchema
  */
 export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 	/** Default value for an `OptionalSchema` is always `undefined` (default value is only used when a value is `undefined`, so otherwise `undefined` could never be returned as a value). */
@@ -44,7 +44,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 	 * @example
 	 *  OPTIONAL(STRING).validate(undefined); // Returns undefined
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OptionalSchema/validate
+	 * @see https://shelving.cc/schema/OptionalSchema/validate
 	 */
 	override validate(unsafeValue: unknown): T | undefined {
 		if (unsafeValue === undefined) return undefined;
@@ -59,7 +59,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
 	 * @example
 	 *  OPTIONAL(STRING).format(undefined); // Returns "No string"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OptionalSchema/format
+	 * @see https://shelving.cc/schema/OptionalSchema/format
 	 */
 	override format(value: T | undefined): string {
 		return value === undefined ? `No ${this.source.one}` : super.format(value);
@@ -77,7 +77,7 @@ export class OptionalSchema<T> extends ThroughSchema<T | undefined> {
  *  const schema = OPTIONAL(STRING);
  *  schema.validate(undefined); // Returns undefined
  *
- * @see https://dhoulb.github.io/shelving/schema/OptionalSchema/OPTIONAL
+ * @see https://shelving.cc/schema/OPTIONAL
  */
 export function OPTIONAL<T>(source: Schema<T>): OptionalSchema<T> {
 	return new OptionalSchema({ source });

--- a/modules/schema/PasswordSchema.ts
+++ b/modules/schema/PasswordSchema.ts
@@ -7,7 +7,7 @@ import { StringSchema, type StringSchemaOptions } from "./StringSchema.js";
  * - Never formats the value for display (`format()` always returns `""`).
  *
  * @example new PasswordSchema({}).validate("hunter2"); // Returns "hunter2"
- * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PasswordSchema
+ * @see https://shelving.cc/schema/PasswordSchema
  */
 export class PasswordSchema extends StringSchema {
 	/**
@@ -24,7 +24,7 @@ export class PasswordSchema extends StringSchema {
 	 *
 	 * @returns An empty string.
 	 * @example new PasswordSchema({}).format("hunter2"); // Returns ""
-	 * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PasswordSchema/format
+	 * @see https://shelving.cc/schema/PasswordSchema/format
 	 */
 	override format(): string {
 		return ""; // Never format a password for display.
@@ -35,6 +35,6 @@ export class PasswordSchema extends StringSchema {
  * Sugar instance of `PasswordSchema` for a password string. Equivalent to `new PasswordSchema({})`.
  *
  * @example PASSWORD.validate("hunter2"); // Returns "hunter2"
- * @see https://dhoulb.github.io/shelving/schema/PasswordSchema/PASSWORD
+ * @see https://shelving.cc/schema/PASSWORD
  */
 export const PASSWORD = new PasswordSchema({});

--- a/modules/schema/PhoneSchema.ts
+++ b/modules/schema/PhoneSchema.ts
@@ -7,7 +7,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length, format, and single-line constraints are fixed internally, so only the presentation-level string options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PhoneSchemaOptions
+ * @see https://shelving.cc/schema/PhoneSchemaOptions
  */
 export interface PhoneSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -33,7 +33,7 @@ export interface PhoneSchemaOptions extends SchemaOptions {
  * - Falsy values are converted to `""` empty string.
  *
  * @example PHONE.validate("+44 1234 567890"); // Returns "+441234567890"
- * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PhoneSchema
+ * @see https://shelving.cc/schema/PhoneSchema
  */
 export class PhoneSchema extends StringSchema {
 	/**
@@ -64,7 +64,7 @@ export class PhoneSchema extends StringSchema {
 	 * @param insaneString String to sanitize.
 	 * @returns The sanitized phone number.
 	 * @example PHONE.sanitize("+44 (1234) 567890"); // Returns "+441234567890"
-	 * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PhoneSchema/sanitize
+	 * @see https://shelving.cc/schema/PhoneSchema/sanitize
 	 */
 	override sanitize(insaneString: string): string {
 		// Strip characters that aren't 0-9 or `+` plus (including whitespace).
@@ -78,7 +78,7 @@ export class PhoneSchema extends StringSchema {
  * Sugar instance of `PhoneSchema` for a valid phone number. Equivalent to `new PhoneSchema({})`.
  *
  * @example PHONE.validate("+441234567890"); // Returns "+441234567890"
- * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/PHONE
+ * @see https://shelving.cc/schema/PHONE
  */
 export const PHONE = new PhoneSchema({});
 
@@ -86,6 +86,6 @@ export const PHONE = new PhoneSchema({});
  * Sugar instance allowing a `PHONE` or `null`. Equivalent to `NULLABLE(PHONE)`.
  *
  * @example NULLABLE_PHONE.validate(null); // Returns null
- * @see https://dhoulb.github.io/shelving/schema/PhoneSchema/NULLABLE_PHONE
+ * @see https://shelving.cc/schema/NULLABLE_PHONE
  */
 export const NULLABLE_PHONE = NULLABLE(PHONE);

--- a/modules/schema/RequiredSchema.ts
+++ b/modules/schema/RequiredSchema.ts
@@ -11,7 +11,7 @@ import { ThroughSchema } from "./ThroughSchema.js";
  *  schema.validate("abc"); // Returns "abc"
  *  schema.validate(""); // Throws "Required"
  *
- * @see https://dhoulb.github.io/shelving/schema/RequiredSchema/RequiredSchema
+ * @see https://shelving.cc/schema/RequiredSchema
  */
 export class RequiredSchema<T> extends ThroughSchema<T> {
 	/**
@@ -24,7 +24,7 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
 	 * @example
 	 *  REQUIRED(STRING).validate(""); // Throws "Required"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/RequiredSchema/RequiredSchema/validate
+	 * @see https://shelving.cc/schema/RequiredSchema/validate
 	 */
 	override validate(unsafeValue: unknown): T {
 		const safeValue = super.validate(unsafeValue);
@@ -44,7 +44,7 @@ export class RequiredSchema<T> extends ThroughSchema<T> {
  *  const schema = REQUIRED(STRING);
  *  schema.validate(""); // Throws "Required"
  *
- * @see https://dhoulb.github.io/shelving/schema/RequiredSchema/REQUIRED
+ * @see https://shelving.cc/schema/REQUIRED
  */
 export function REQUIRED<T>(source: Schema<T>): RequiredSchema<T> {
 	return new RequiredSchema({ source });

--- a/modules/schema/Schema.ts
+++ b/modules/schema/Schema.ts
@@ -8,7 +8,7 @@ import type { Validator } from "../util/validate.js";
 /**
  * Options allowed by a `Schema` instance.
  *
- * @see https://dhoulb.github.io/shelving/schema/Schema/SchemaOptions
+ * @see https://shelving.cc/schema/SchemaOptions
  */
 export type SchemaOptions = {
 	/** String for one of this thing, e.g. `product` or `item` or `sheep` */
@@ -37,7 +37,7 @@ export type SchemaOptions = {
  *  		return unsafeValue;
  *  	}
  *  }
- * @see https://dhoulb.github.io/shelving/schema/Schema/Schema
+ * @see https://shelving.cc/schema/Schema
  */
 export abstract class Schema<T = unknown> implements Validator<T> {
 	/** String for one of this thing, e.g. `product` or `item` or `sheep` */
@@ -72,7 +72,7 @@ export abstract class Schema<T = unknown> implements Validator<T> {
 	 * @returns The valid value of type `T`.
 	 * @throws `string` error message if the value is invalid.
 	 * @example schema.validate("abc") // "abc"
-	 * @see https://dhoulb.github.io/shelving/schema/Schema/Schema/validate
+	 * @see https://shelving.cc/schema/Schema/validate
 	 */
 	abstract validate(unsafeValue: unknown): T;
 
@@ -82,7 +82,7 @@ export abstract class Schema<T = unknown> implements Validator<T> {
 	 * @param value The valid value to format.
 	 * @returns The value formatted as a human-readable string.
 	 * @example schema.format(value) // "Hello!"
-	 * @see https://dhoulb.github.io/shelving/schema/Schema/Schema/format
+	 * @see https://shelving.cc/schema/Schema/format
 	 */
 	format(value: T): string {
 		return formatValue(value, undefined, this.format);
@@ -93,14 +93,14 @@ export abstract class Schema<T = unknown> implements Validator<T> {
  * Extract the validated value type `T` from a `Schema<T>`.
  *
  * @example type V = SchemaType<typeof STRING> // string
- * @see https://dhoulb.github.io/shelving/schema/Schema/SchemaType
+ * @see https://shelving.cc/schema/SchemaType
  */
 export type SchemaType<X> = X extends Schema<infer Y> ? Y : never;
 
 /**
  * A set of named schemas in `{ name: schema }` format.
  *
- * @see https://dhoulb.github.io/shelving/schema/Schema/Schemas
+ * @see https://shelving.cc/schema/Schemas
  */
 export type Schemas<T extends Data = Data> = { readonly [K in keyof T]: Schema<T[K]> };
 
@@ -108,7 +108,7 @@ export type Schemas<T extends Data = Data> = { readonly [K in keyof T]: Schema<T
  * Unknown validator that always passes through its input value as `unknown`.
  *
  * @example UNKNOWN.validate(anything) // anything
- * @see https://dhoulb.github.io/shelving/schema/Schema/UNKNOWN
+ * @see https://shelving.cc/schema/UNKNOWN
  */
 export const UNKNOWN: Schema<unknown> = {
 	one: "value",
@@ -125,7 +125,7 @@ export const UNKNOWN: Schema<unknown> = {
  * Undefined validator that always returns `undefined`.
  *
  * @example UNDEFINED.validate(anything) // undefined
- * @see https://dhoulb.github.io/shelving/schema/Schema/UNDEFINED
+ * @see https://shelving.cc/schema/UNDEFINED
  */
 export const UNDEFINED: Schema<undefined> = {
 	one: "none",
@@ -142,7 +142,7 @@ export const UNDEFINED: Schema<undefined> = {
  * Null validator that always returns `null`.
  *
  * @example NULL.validate(anything) // null
- * @see https://dhoulb.github.io/shelving/schema/Schema/NULL
+ * @see https://shelving.cc/schema/NULL
  */
 export const NULL: Schema<null> = {
 	one: "none",

--- a/modules/schema/SlugSchema.ts
+++ b/modules/schema/SlugSchema.ts
@@ -8,7 +8,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length and single-line constraints are fixed internally, so only the presentation-level string options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchemaOptions
+ * @see https://shelving.cc/schema/SlugSchemaOptions
  */
 export interface SlugSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -36,7 +36,7 @@ export interface SlugSchemaOptions extends SchemaOptions {
  * @example
  * 	const schema = new SlugSchema({});
  * 	schema.validate("This is a Slug!") // "this-is-a-slug"
- * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchema
+ * @see https://shelving.cc/schema/SlugSchema
  */
 export class SlugSchema extends StringSchema {
 	/**
@@ -57,7 +57,7 @@ export class SlugSchema extends StringSchema {
 	 * @param str The raw string to sanitize.
 	 * @returns The sanitized slug, or an empty string when nothing usable remains.
 	 * @example schema.sanitize("This is a Slug!") // "this-is-a-slug"
-	 * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SlugSchema/sanitize
+	 * @see https://shelving.cc/schema/SlugSchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		return getSlug(str) || "";
@@ -68,7 +68,7 @@ export class SlugSchema extends StringSchema {
  * Sugar instance of `SlugSchema` for a valid slug. Equivalent to `new SlugSchema({})`.
  *
  * @example SLUG.validate("This is a Slug!") // "this-is-a-slug"
- * @see https://dhoulb.github.io/shelving/schema/SlugSchema/SLUG
+ * @see https://shelving.cc/schema/SLUG
  */
 export const SLUG = new SlugSchema({});
 
@@ -76,6 +76,6 @@ export const SLUG = new SlugSchema({});
  * Sugar instance allowing a `SLUG` or `null`. Equivalent to `NULLABLE(SLUG)`.
  *
  * @example NULLABLE_SLUG.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/SlugSchema/NULLABLE_SLUG
+ * @see https://shelving.cc/schema/NULLABLE_SLUG
  */
 export const NULLABLE_SLUG = NULLABLE(SLUG);

--- a/modules/schema/StringSchema.ts
+++ b/modules/schema/StringSchema.ts
@@ -6,14 +6,14 @@ import { Schema } from "./Schema.js";
 /**
  * `type=""` prop for HTML `<input />` tags that are relevant for strings.
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringInputType
+ * @see https://shelving.cc/schema/StringInputType
  */
 export type StringInputType = "text" | "password" | "color" | "email" | "number" | "tel" | "search" | "url";
 
 /**
  * Options for `StringSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchemaOptions
+ * @see https://shelving.cc/schema/StringSchemaOptions
  */
 export interface StringSchemaOptions extends SchemaOptions {
 	/**
@@ -59,7 +59,7 @@ export interface StringSchemaOptions extends SchemaOptions {
  *  schema.validate(1234); // Returns "1234" (numbers are coerced)
  *  schema.validate("j"); // Throws "Minimum 2 characters"
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchema
+ * @see https://shelving.cc/schema/StringSchema
  */
 export class StringSchema extends Schema<string> {
 	declare readonly value: string;
@@ -103,7 +103,7 @@ export class StringSchema extends Schema<string> {
 	 * @example
 	 *  STRING.validate(123); // Returns "123"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchema/validate
+	 * @see https://shelving.cc/schema/StringSchema/validate
 	 */
 	override validate(value: unknown = this.value): string {
 		const str = typeof value === "number" ? value.toString() : value;
@@ -127,7 +127,7 @@ export class StringSchema extends Schema<string> {
 	 * @example
 	 *  STRING.sanitize("  hello  "); // Returns "hello"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchema/sanitize
+	 * @see https://shelving.cc/schema/StringSchema/sanitize
 	 */
 	sanitize(str: string): string {
 		const sane = this.rows > 1 ? sanitizeMultilineText(str) : sanitizeText(str);
@@ -145,7 +145,7 @@ export class StringSchema extends Schema<string> {
 	 * @example
 	 *  STRING.format("abc"); // Returns "abc"
 	 *
-	 * @see https://dhoulb.github.io/shelving/schema/StringSchema/StringSchema/format
+	 * @see https://shelving.cc/schema/StringSchema/format
 	 */
 	override format(str: string): string {
 		return str;
@@ -158,7 +158,7 @@ export class StringSchema extends Schema<string> {
  * @example
  *  STRING.validate(123); // Returns "123"
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/STRING
+ * @see https://shelving.cc/schema/STRING
  */
 export const STRING = new StringSchema({});
 
@@ -168,7 +168,7 @@ export const STRING = new StringSchema({});
  * @example
  *  REQUIRED_STRING.validate(""); // Throws "Required"
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/REQUIRED_STRING
+ * @see https://shelving.cc/schema/REQUIRED_STRING
  */
 export const REQUIRED_STRING = new StringSchema({ min: 1 });
 
@@ -178,7 +178,7 @@ export const REQUIRED_STRING = new StringSchema({ min: 1 });
  * @example
  *  TITLE.validate("My Title"); // Returns "My Title"
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/TITLE
+ * @see https://shelving.cc/schema/TITLE
  */
 export const TITLE = new StringSchema({ one: "title", title: "Title", min: 1, max: 100 });
 
@@ -188,7 +188,7 @@ export const TITLE = new StringSchema({ one: "title", title: "Title", min: 1, ma
  * @example
  *  NULLABLE_TITLE.validate(null); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/NULLABLE_TITLE
+ * @see https://shelving.cc/schema/NULLABLE_TITLE
  */
 export const NULLABLE_TITLE = NULLABLE(TITLE);
 
@@ -198,7 +198,7 @@ export const NULLABLE_TITLE = NULLABLE(TITLE);
  * @example
  *  NAME.validate("Dave"); // Returns "Dave"
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/NAME
+ * @see https://shelving.cc/schema/NAME
  */
 export const NAME = new StringSchema({ one: "name", title: "Name", min: 1, max: 100 });
 
@@ -208,6 +208,6 @@ export const NAME = new StringSchema({ one: "name", title: "Name", min: 1, max: 
  * @example
  *  NULLABLE_NAME.validate(null); // Returns null
  *
- * @see https://dhoulb.github.io/shelving/schema/StringSchema/NULLABLE_NAME
+ * @see https://shelving.cc/schema/NULLABLE_NAME
  */
 export const NULLABLE_NAME = NULLABLE(NAME);

--- a/modules/schema/ThroughSchema.ts
+++ b/modules/schema/ThroughSchema.ts
@@ -5,7 +5,7 @@ import { Schema } from "./Schema.js";
 /**
  * Allowed options for `ThroughSchema`.
  *
- * @see https://dhoulb.github.io/shelving/schema/ThroughSchema/ThroughSchemaOptions
+ * @see https://shelving.cc/schema/ThroughSchemaOptions
  */
 export interface ThroughSchemaOptions<T> extends SchemaOptions {
 	/** The source schema this schema passes through to. */
@@ -17,7 +17,7 @@ export interface ThroughSchemaOptions<T> extends SchemaOptions {
  *
  * @example
  *  class WrapSchema<T> extends ThroughSchema<T> {} // Delegates `validate()` to `this.source`.
- * @see https://dhoulb.github.io/shelving/schema/ThroughSchema/ThroughSchema
+ * @see https://shelving.cc/schema/ThroughSchema
  */
 export abstract class ThroughSchema<T> extends Schema<T> implements Sourceable<Schema<T>> {
 	/** The source schema this schema passes through to. */
@@ -36,7 +36,7 @@ export abstract class ThroughSchema<T> extends Schema<T> implements Sourceable<S
 	 * @returns The valid value of type `T`.
 	 * @throws `string` error message if the value is invalid.
 	 * @example schema.validate(input) // Delegates to source schema.
-	 * @see https://dhoulb.github.io/shelving/schema/ThroughSchema/ThroughSchema/validate
+	 * @see https://shelving.cc/schema/ThroughSchema/validate
 	 */
 	validate(unsafeValue: unknown): T {
 		return this.source.validate(unsafeValue);
@@ -47,7 +47,7 @@ export abstract class ThroughSchema<T> extends Schema<T> implements Sourceable<S
 	 * @param value The valid value to format.
 	 * @returns The value formatted as a human-readable string.
 	 * @example schema.format(value) // Delegates to source schema.
-	 * @see https://dhoulb.github.io/shelving/schema/ThroughSchema/ThroughSchema/format
+	 * @see https://shelving.cc/schema/ThroughSchema/format
 	 */
 	override format(value: T): string {
 		return this.source.format(value);

--- a/modules/schema/TimeSchema.ts
+++ b/modules/schema/TimeSchema.ts
@@ -11,7 +11,7 @@ import { NULLABLE } from "./NullableSchema.js";
  * @example
  *  const schema = new TimeSchema({});
  *  schema.validate("23:59"); // "23:59:00.000"
- * @see https://dhoulb.github.io/shelving/schema/TimeSchema/TimeSchema
+ * @see https://shelving.cc/schema/TimeSchema
  */
 export class TimeSchema extends DateSchema {
 	/**
@@ -26,7 +26,7 @@ export class TimeSchema extends DateSchema {
 	 * @param value The `Date` to convert.
 	 * @returns The time portion as a `hh:mm:ss.fff` string.
 	 * @example schema.stringify(new Date("2005-09-12T23:59:00Z")) // "23:59:00.000"
-	 * @see https://dhoulb.github.io/shelving/schema/TimeSchema/TimeSchema/stringify
+	 * @see https://shelving.cc/schema/TimeSchema/stringify
 	 */
 	override stringify(value: Date): string {
 		return requireTimeString(value);
@@ -37,7 +37,7 @@ export class TimeSchema extends DateSchema {
 	 * @param value The validated time string to format.
 	 * @returns The time formatted for display.
 	 * @example schema.format("23:59") // "23:59"
-	 * @see https://dhoulb.github.io/shelving/schema/TimeSchema/TimeSchema/format
+	 * @see https://shelving.cc/schema/TimeSchema/format
 	 */
 	override format(value: string): string {
 		return formatTime(value, undefined, this.format);
@@ -48,7 +48,7 @@ export class TimeSchema extends DateSchema {
  * Sugar instance of `TimeSchema` for a required abstract time. Equivalent to `new TimeSchema({})`.
  *
  * @example TIME.validate("23:59") // "23:59:00.000"
- * @see https://dhoulb.github.io/shelving/schema/TimeSchema/TIME
+ * @see https://shelving.cc/schema/TIME
  */
 export const TIME = new TimeSchema({});
 
@@ -56,6 +56,6 @@ export const TIME = new TimeSchema({});
  * Sugar instance allowing a `TIME` or `null`. Equivalent to `NULLABLE(TIME)`.
  *
  * @example NULLABLE_TIME.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/TimeSchema/NULLABLE_TIME
+ * @see https://shelving.cc/schema/NULLABLE_TIME
  */
 export const NULLABLE_TIME = NULLABLE(TIME);

--- a/modules/schema/URISchema.ts
+++ b/modules/schema/URISchema.ts
@@ -10,7 +10,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length and single-line constraints are fixed internally, so only the presentation-level string options plus `schemes` are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchemaOptions
+ * @see https://shelving.cc/schema/URISchemaOptions
  */
 export interface URISchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -45,7 +45,7 @@ export interface URISchemaOptions extends SchemaOptions {
  * @example
  * 	const schema = new URISchema({});
  * 	schema.validate("https://www.google.com") // "https://www.google.com/"
- * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchema
+ * @see https://shelving.cc/schema/URISchema
  */
 export class URISchema extends StringSchema {
 	/** Whitelist of allowed URI schemes, e.g. `["https:", "http:"]`. */
@@ -75,7 +75,7 @@ export class URISchema extends StringSchema {
 	 * @returns The valid, normalised URI string.
 	 * @throws `string` error message if the value is empty, malformed, or uses a disallowed scheme.
 	 * @example schema.validate("https://www.google.com") // "https://www.google.com/"
-	 * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchema/validate
+	 * @see https://shelving.cc/schema/URISchema/validate
 	 */
 	override validate(unsafeValue: unknown): URIString {
 		const str = super.validate(unsafeValue);
@@ -93,7 +93,7 @@ export class URISchema extends StringSchema {
 	 * @param str The raw string to sanitize.
 	 * @returns The sanitized string with all whitespace removed.
 	 * @example schema.sanitize(" https://a.com ") // "https://a.com"
-	 * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchema/sanitize
+	 * @see https://shelving.cc/schema/URISchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		// URIs never contain whitespace (a real space must be `%20`-encoded), so strip it entirely.
@@ -106,7 +106,7 @@ export class URISchema extends StringSchema {
 	 * @param value The valid URI string to format.
 	 * @returns The URI formatted as a human-readable string.
 	 * @example schema.format("https://www.google.com/") // "www.google.com"
-	 * @see https://dhoulb.github.io/shelving/schema/URISchema/URISchema/format
+	 * @see https://shelving.cc/schema/URISchema/format
 	 */
 	override format(value: string): string {
 		return formatURI(value, this.format);
@@ -117,7 +117,7 @@ export class URISchema extends StringSchema {
  * Sugar instance of `URISchema` for an absolute URI string. Equivalent to `new URISchema({})`.
  *
  * @example URI_SCHEMA.validate("https://www.google.com") // "https://www.google.com/"
- * @see https://dhoulb.github.io/shelving/schema/URISchema/URI_SCHEMA
+ * @see https://shelving.cc/schema/URI_SCHEMA
  */
 export const URI_SCHEMA = new URISchema({});
 
@@ -125,6 +125,6 @@ export const URI_SCHEMA = new URISchema({});
  * Sugar instance allowing a `URI_SCHEMA` or `null`. Equivalent to `NULLABLE(URI_SCHEMA)`.
  *
  * @example NULLABLE_URI_SCHEMA.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/URISchema/NULLABLE_URI_SCHEMA
+ * @see https://shelving.cc/schema/NULLABLE_URI_SCHEMA
  */
 export const NULLABLE_URI_SCHEMA = NULLABLE(URI_SCHEMA);

--- a/modules/schema/URLSchema.ts
+++ b/modules/schema/URLSchema.ts
@@ -11,7 +11,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length and single-line constraints are fixed internally, so only the presentation-level string options plus `base` and `schemes` are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchemaOptions
+ * @see https://shelving.cc/schema/URLSchemaOptions
  */
 export interface URLSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -48,7 +48,7 @@ export interface URLSchemaOptions extends SchemaOptions {
  * @example
  * 	const schema = new URLSchema({ base: "https://example.com" });
  * 	schema.validate("/page") // "https://example.com/page"
- * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchema
+ * @see https://shelving.cc/schema/URLSchema
  */
 export class URLSchema extends StringSchema {
 	/** Base URL that relative URLs are resolved against, or `undefined` when not set. */
@@ -81,7 +81,7 @@ export class URLSchema extends StringSchema {
 	 * @returns The valid, fully-resolved URL string.
 	 * @throws `string` error message if the value is empty, malformed, or uses a disallowed scheme.
 	 * @example schema.validate("https://www.google.com") // "https://www.google.com/"
-	 * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchema/validate
+	 * @see https://shelving.cc/schema/URLSchema/validate
 	 */
 	override validate(unsafeValue: unknown): URLString {
 		const str = super.validate(unsafeValue);
@@ -99,7 +99,7 @@ export class URLSchema extends StringSchema {
 	 * @param str The raw string to sanitize.
 	 * @returns The sanitized string with all whitespace removed.
 	 * @example schema.sanitize(" https://a.com ") // "https://a.com"
-	 * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchema/sanitize
+	 * @see https://shelving.cc/schema/URLSchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		// URLs never contain whitespace (a real space must be `%20`-encoded), so strip it entirely.
@@ -112,7 +112,7 @@ export class URLSchema extends StringSchema {
 	 * @param value The valid URL string to format.
 	 * @returns The URL formatted as a human-readable string.
 	 * @example schema.format("https://www.google.com/") // "www.google.com"
-	 * @see https://dhoulb.github.io/shelving/schema/URLSchema/URLSchema/format
+	 * @see https://shelving.cc/schema/URLSchema/format
 	 */
 	override format(value: string): string {
 		return formatURL(value, this.base, this.format);
@@ -123,7 +123,7 @@ export class URLSchema extends StringSchema {
  * Sugar instance of `URLSchema` for an absolute or relative URL string. Equivalent to `new URLSchema({})`.
  *
  * @example URL_SCHEMA.validate("https://www.google.com") // "https://www.google.com/"
- * @see https://dhoulb.github.io/shelving/schema/URLSchema/URL_SCHEMA
+ * @see https://shelving.cc/schema/URL_SCHEMA
  */
 export const URL_SCHEMA = new URLSchema({});
 
@@ -131,6 +131,6 @@ export const URL_SCHEMA = new URLSchema({});
  * Sugar instance allowing a `URL_SCHEMA` or `null`. Equivalent to `NULLABLE(URL_SCHEMA)`.
  *
  * @example NULLABLE_URL_SCHEMA.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/URLSchema/NULLABLE_URL_SCHEMA
+ * @see https://shelving.cc/schema/NULLABLE_URL_SCHEMA
  */
 export const NULLABLE_URL_SCHEMA = NULLABLE(URL_SCHEMA);

--- a/modules/schema/UUIDSchema.ts
+++ b/modules/schema/UUIDSchema.ts
@@ -8,7 +8,7 @@ import { type StringInputType, StringSchema } from "./StringSchema.js";
  *
  * - The length, format, and single-line constraints are fixed internally, so only the presentation-level string options are exposed.
  *
- * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchemaOptions
+ * @see https://shelving.cc/schema/UUIDSchemaOptions
  */
 export interface UUIDSchemaOptions extends SchemaOptions {
 	/** Default string value used when the input is `undefined`. */
@@ -33,7 +33,7 @@ export interface UUIDSchemaOptions extends SchemaOptions {
  * @example
  * 	const schema = new UUIDSchema({});
  * 	schema.validate("F47AC10B-58CC-4372-A567-0E02B2C3D479") // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
- * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchema
+ * @see https://shelving.cc/schema/UUIDSchema
  */
 export class UUIDSchema extends StringSchema {
 	/**
@@ -56,7 +56,7 @@ export class UUIDSchema extends StringSchema {
 	 * @param str The raw string to sanitize.
 	 * @returns The sanitized UUID, or an empty string when the input is not a valid UUID.
 	 * @example schema.sanitize("F47AC10B58CC4372A5670E02B2C3D479") // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-	 * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUIDSchema/sanitize
+	 * @see https://shelving.cc/schema/UUIDSchema/sanitize
 	 */
 	override sanitize(str: string): string {
 		return getUUID(str) || "";
@@ -67,7 +67,7 @@ export class UUIDSchema extends StringSchema {
  * Sugar instance of `UUIDSchema` for any valid UUID (versions 1-5). Equivalent to `new UUIDSchema({ title: "ID" })`.
  *
  * @example UUID.validate("F47AC10B-58CC-4372-A567-0E02B2C3D479") // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
- * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/UUID
+ * @see https://shelving.cc/schema/UUID
  */
 export const UUID = new UUIDSchema({ title: "ID" });
 
@@ -75,6 +75,6 @@ export const UUID = new UUIDSchema({ title: "ID" });
  * Sugar instance allowing a `UUID` or `null`. Equivalent to `NULLABLE(UUID)`.
  *
  * @example NULLABLE_UUID.validate(null) // null
- * @see https://dhoulb.github.io/shelving/schema/UUIDSchema/NULLABLE_UUID
+ * @see https://shelving.cc/schema/NULLABLE_UUID
  */
 export const NULLABLE_UUID = NULLABLE(UUID);

--- a/modules/sequence/DeferredSequence.ts
+++ b/modules/sequence/DeferredSequence.ts
@@ -7,14 +7,14 @@ import { Sequence } from "./Sequence.js";
 /**
  * Result representing a rejection in a `DeferredSequence`, carrying the thrown `reason`.
  *
- * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredErrorResult
+ * @see https://shelving.cc/sequence/DeferredErrorResult
  */
 export type DeferredErrorResult = { readonly reason: unknown };
 
 /**
  * Pending result of a `DeferredSequence` — either a standard `IteratorResult` or a `DeferredErrorResult` rejection.
  *
- * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredResult
+ * @see https://shelving.cc/sequence/DeferredResult
  */
 export type DeferredResult<T, R> = IteratorResult<T, R | undefined> | DeferredErrorResult;
 
@@ -31,7 +31,7 @@ export type DeferredResult<T, R> = IteratorResult<T, R | undefined> | DeferredEr
  * 	seq.resolve(1);
  * 	seq.resolve(2);
  * 	seq.done();
- * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence
+ * @see https://shelving.cc/sequence/DeferredSequence
  */
 export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, R, N> implements Deferred<T>, Promise<T> {
 	/** Lazy deferred that stores iterator values. */
@@ -45,7 +45,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	/**
 	 * Next promise to be resolved/rejected with the upcoming value.
 	 *
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/promise
+	 * @see https://shelving.cc/sequence/DeferredSequence/promise
 	 */
 	get promise(): Promise<T> {
 		this._promiseDeferred ||= createDeferred();
@@ -58,7 +58,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	 *
 	 * @param value Value to publish to iterators and awaiting promises.
 	 * @example seq.resolve(123);
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/resolve
+	 * @see https://shelving.cc/sequence/DeferredSequence/resolve
 	 */
 	resolve(value: T): void {
 		this._next = { value };
@@ -71,7 +71,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	 *
 	 * @param reason Error or other thrown value to publish to iterators and awaiting promises.
 	 * @example seq.reject(new Error("Stop"));
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/reject
+	 * @see https://shelving.cc/sequence/DeferredSequence/reject
 	 */
 	reject(reason: unknown): void {
 		this._next = { reason };
@@ -84,7 +84,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	 *
 	 * @param value Optional final return value for the sequence.
 	 * @example seq.done();
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/done
+	 * @see https://shelving.cc/sequence/DeferredSequence/done
 	 */
 	done(value?: R | undefined): void {
 		this._next = { done: true, value };
@@ -96,7 +96,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	 * - Iterators will contain to wait for a next value.
 	 *
 	 * @example seq.cancel();
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/cancel
+	 * @see https://shelving.cc/sequence/DeferredSequence/cancel
 	 */
 	cancel(): void {
 		this._next = undefined;
@@ -128,7 +128,7 @@ export class DeferredSequence<T = void, R = void, N = void> extends Sequence<T, 
 	 * @param sequence Source async iterable to forward values from.
 	 * @returns An async iterator yielding each forwarded value.
 	 * @example for await (const v of seq.through(source)) console.log(v);
-	 * @see https://dhoulb.github.io/shelving/sequence/DeferredSequence/DeferredSequence/through
+	 * @see https://shelving.cc/sequence/DeferredSequence/through
 	 */
 	async *through(sequence: AsyncIterable<T>): AsyncIterator<T> {
 		for await (const item of sequence) {

--- a/modules/sequence/InspectSequence.ts
+++ b/modules/sequence/InspectSequence.ts
@@ -14,13 +14,13 @@ const _NOVALUE: unique symbol = Symbol("shelving/InspectSequence.NOVALUE");
  * 	for await (const next of capture) console.log("YIELDED", next);
  * 	console.log("FIRST", watch.first);
  * 	console.log("RETURNED", watch.returned);
- * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence
+ * @see https://shelving.cc/sequence/InspectSequence
  */
 export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	/**
 	 * The number of values yielded by the source sequence so far.
 	 *
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/count
+	 * @see https://shelving.cc/sequence/InspectSequence/count
 	 */
 	get count() {
 		return this._count;
@@ -30,7 +30,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	/**
 	 * Whether the source sequence has finished iterating (i.e. it has returned).
 	 *
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/done
+	 * @see https://shelving.cc/sequence/InspectSequence/done
 	 */
 	get done() {
 		return this._done;
@@ -43,7 +43,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * - Throws if the iteration yielded no values yet, i.e. `this.count === 0`.
 	 *
 	 * @throws {UnexpectedError} If iteration has not yielded any value yet.
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/first
+	 * @see https://shelving.cc/sequence/InspectSequence/first
 	 */
 	get first(): T {
 		if (this._first === _NOVALUE)
@@ -61,7 +61,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * - Throws if the iteration yielded no values yet, i.e. `this.count === 0`.
 	 *
 	 * @throws {UnexpectedError} If iteration has not yielded any value yet.
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/last
+	 * @see https://shelving.cc/sequence/InspectSequence/last
 	 */
 	get last(): T {
 		if (this._last === _NOVALUE)
@@ -79,7 +79,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * - Throws if the iteration is not done yet, i.e. `this.done === false`.
 	 *
 	 * @throws {UnexpectedError} If iteration is not done yet.
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/returned
+	 * @see https://shelving.cc/sequence/InspectSequence/returned
 	 */
 	get returned(): R | undefined {
 		if (this._returned === _NOVALUE)
@@ -99,7 +99,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * @param value Optional value passed into the source sequence's `next()`.
 	 * @returns Promise resolving to the next `IteratorResult` from the source sequence.
 	 * @example const { value, done } = await watch.next()
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/next
+	 * @see https://shelving.cc/sequence/InspectSequence/next
 	 */
 	override async next(value?: N | undefined): Promise<IteratorResult<T, R | undefined>> {
 		return this._inspect(await super.next(value));
@@ -110,7 +110,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * @param value Optional value to return from the source sequence.
 	 * @returns Promise resolving to the final `IteratorResult` from the source sequence.
 	 * @example await watch.return()
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/return
+	 * @see https://shelving.cc/sequence/InspectSequence/return
 	 */
 	override async return(value?: R | undefined | PromiseLike<R | undefined>): Promise<IteratorResult<T, R | undefined>> {
 		return this._inspect(await super.return(value));
@@ -121,7 +121,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	 * @param reason The reason to throw into the source sequence.
 	 * @returns Promise resolving to the `IteratorResult` produced after throwing.
 	 * @example await watch.throw(new Error("stop"))
-	 * @see https://dhoulb.github.io/shelving/sequence/InspectSequence/InspectSequence/throw
+	 * @see https://shelving.cc/sequence/InspectSequence/throw
 	 */
 	override async throw(reason?: unknown): Promise<IteratorResult<T, R | undefined>> {
 		return this._inspect(await super.throw(reason));

--- a/modules/sequence/LazySequence.ts
+++ b/modules/sequence/LazySequence.ts
@@ -11,7 +11,7 @@ import { ThroughSequence } from "./ThroughSequence.js";
  * 		const timer = setInterval(tick, 1000);
  * 		return () => clearInterval(timer); // Stop callback.
  * 	});
- * @see https://dhoulb.github.io/shelving/sequence/LazySequence/LazySequence
+ * @see https://shelving.cc/sequence/LazySequence
  */
 export class LazySequence<T = void, R = void, N = void> extends ThroughSequence<T, R, N> implements AsyncDisposable {
 	private _iterators = new Set<LazyIterator<T, R, N>>(); // Keep track of the iterators that are iterating.
@@ -20,7 +20,7 @@ export class LazySequence<T = void, R = void, N = void> extends ThroughSequence<
 	/**
 	 * Number of iterators currently registered as iterating.
 	 *
-	 * @see https://dhoulb.github.io/shelving/sequence/LazySequence/LazySequence/iterators
+	 * @see https://shelving.cc/sequence/LazySequence/iterators
 	 */
 	get iterators(): number {
 		return this._iterators.size;
@@ -58,7 +58,7 @@ export class LazySequence<T = void, R = void, N = void> extends ThroughSequence<
 	 *
 	 * @param iterator The iterator that has started iterating.
 	 * @example sequence.start(iterator);
-	 * @see https://dhoulb.github.io/shelving/sequence/LazySequence/LazySequence/start
+	 * @see https://shelving.cc/sequence/LazySequence/start
 	 */
 	start(iterator: LazyIterator<T, R, N>) {
 		const before = this._iterators.size;
@@ -73,7 +73,7 @@ export class LazySequence<T = void, R = void, N = void> extends ThroughSequence<
 	 *
 	 * @param iterator The iterator that has stopped iterating.
 	 * @example sequence.stop(iterator);
-	 * @see https://dhoulb.github.io/shelving/sequence/LazySequence/LazySequence/stop
+	 * @see https://shelving.cc/sequence/LazySequence/stop
 	 */
 	stop(iterator: LazyIterator<T, R, N>) {
 		const before = this._iterators.size;

--- a/modules/sequence/Sequence.ts
+++ b/modules/sequence/Sequence.ts
@@ -11,7 +11,7 @@
  * 	class NumberSequence extends Sequence<number, void, void> {
  * 		async next() { return { done: false, value: Math.random() }; }
  * 	}
- * @see https://dhoulb.github.io/shelving/sequence/Sequence/Sequence
+ * @see https://shelving.cc/sequence/Sequence
  */
 export abstract class Sequence<T, R, N>
 	implements AsyncIterable<T, R | undefined, N | undefined>, AsyncIterator<T, R | undefined, N | undefined>, AsyncDisposable
@@ -27,7 +27,7 @@ export abstract class Sequence<T, R, N>
 	 * - Will be the `N` next value on subsequent calls.
 	 *
 	 * @returns An incomplete iterator result with `done: false` and `value: T`.
-	 * @see https://dhoulb.github.io/shelving/sequence/Sequence/Sequence/next
+	 * @see https://shelving.cc/sequence/Sequence/next
 	 */
 	abstract next(value?: N | undefined): Promise<IteratorResult<T, R | undefined>>;
 
@@ -41,7 +41,7 @@ export abstract class Sequence<T, R, N>
 	 * - Will be `undefined` on the first call.
 	 *
 	 * @returns A completed iterator result with `done: true`.
-	 * @see https://dhoulb.github.io/shelving/sequence/Sequence/Sequence/return
+	 * @see https://shelving.cc/sequence/Sequence/return
 	 */
 	async return(value?: R | undefined | PromiseLike<R | undefined>): Promise<IteratorResult<T, R | undefined>> {
 		// Default behaviour for a generator is to return `done: true` and repeat back input value.
@@ -56,7 +56,7 @@ export abstract class Sequence<T, R, N>
 	 * @param reason Error or other thrown value to send into the iterator.
 	 * @returns A completed iterator result with `done: true` if a subclass recovers from the error.
 	 * @throws The `reason` value by default — subclasses may override to recover instead.
-	 * @see https://dhoulb.github.io/shelving/sequence/Sequence/Sequence/throw
+	 * @see https://shelving.cc/sequence/Sequence/throw
 	 */
 	async throw(reason?: unknown): Promise<IteratorResult<T, R | undefined>> {
 		// Default behaviour for a generator is to throw the error back out of the iterator and not continue.

--- a/modules/sequence/ThroughSequence.ts
+++ b/modules/sequence/ThroughSequence.ts
@@ -9,13 +9,13 @@ import { Sequence } from "./Sequence.js";
  * @example
  * 	const seq = new ThroughSequence(someAsyncIterator);
  * 	for await (const value of seq) console.log(value);
- * @see https://dhoulb.github.io/shelving/sequence/ThroughSequence/ThroughSequence
+ * @see https://shelving.cc/sequence/ThroughSequence
  */
 export class ThroughSequence<T, R, N> extends Sequence<T, R | undefined, N | undefined> {
 	/**
 	 * Source async iterator that this sequence pulls values from.
 	 *
-	 * @see https://dhoulb.github.io/shelving/sequence/ThroughSequence/ThroughSequence/source
+	 * @see https://shelving.cc/sequence/ThroughSequence/source
 	 */
 	readonly source: AsyncIterator<T, R | undefined, N | undefined>;
 

--- a/modules/store/ArrayStore.ts
+++ b/modules/store/ArrayStore.ts
@@ -23,7 +23,7 @@ import { BusyStore } from "./BusyStore.js";
  * const store = new ArrayStore([1, 2, 3]);
  * store.add(4); // [1, 2, 3, 4]
  * store.first; // 1
- * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore
+ * @see https://shelving.cc/store/ArrayStore
  */
 export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>> implements Iterable<T> {
 	// Override to set default value to `[]` and convert possible arrays.
@@ -39,7 +39,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Get the first item in this store, or `undefined` if it has no items.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/optionalFirst
+	 * @see https://shelving.cc/store/ArrayStore/optionalFirst
 	 */
 	get optionalFirst(): T | undefined {
 		return getFirst(this.value);
@@ -48,7 +48,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Get the last item in this store, or `undefined` if it has no items.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/optionalLast
+	 * @see https://shelving.cc/store/ArrayStore/optionalLast
 	 */
 	get optionalLast(): T | undefined {
 		return getLast(this.value);
@@ -57,7 +57,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Get the first item in this store, or throw `RequiredError` if it has no items.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/first
+	 * @see https://shelving.cc/store/ArrayStore/first
 	 */
 	get first(): T {
 		return requireFirst(this.value);
@@ -66,7 +66,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Get the last item in this store, or throw `RequiredError` if it has no items.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/last
+	 * @see https://shelving.cc/store/ArrayStore/last
 	 */
 	get last(): T {
 		return requireLast(this.value);
@@ -75,7 +75,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Whether this store has at least one item.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/exists
+	 * @see https://shelving.cc/store/ArrayStore/exists
 	 */
 	get exists(): boolean {
 		return !!this.value.length;
@@ -84,7 +84,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	/**
 	 * Get the number of items in the current value of this store.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/count
+	 * @see https://shelving.cc/store/ArrayStore/count
 	 */
 	get count(): number {
 		return this.value.length;
@@ -97,7 +97,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	 * @param items The items to add.
 	 * @returns Nothing.
 	 * @example store.add(4, 5);
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/add
+	 * @see https://shelving.cc/store/ArrayStore/add
 	 */
 	add(...items: T[]): void {
 		this.value = withArrayItems(this.value, ...items);
@@ -109,7 +109,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	 * @param items The items to remove.
 	 * @returns Nothing.
 	 * @example store.delete(2, 3);
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/delete
+	 * @see https://shelving.cc/store/ArrayStore/delete
 	 */
 	delete(...items: T[]): void {
 		this.value = omitArrayItems(this.value, ...items);
@@ -121,7 +121,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	 * @param items The items to toggle.
 	 * @returns Nothing.
 	 * @example store.toggle(1, 4);
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/toggle
+	 * @see https://shelving.cc/store/ArrayStore/toggle
 	 */
 	toggle(...items: T[]): void {
 		this.value = toggleArrayItems(this.value, ...items);
@@ -131,7 +131,7 @@ export class ArrayStore<T> extends BusyStore<ImmutableArray<T>, PossibleArray<T>
 	 * Iterate over the items in this store's current array.
 	 *
 	 * @returns An iterator over the items.
-	 * @see https://dhoulb.github.io/shelving/store/ArrayStore/ArrayStore/[Symbol.iterator]
+	 * @see https://shelving.cc/store/ArrayStore/[Symbol.iterator]
 	 */
 	[Symbol.iterator](): Iterator<T, void> {
 		return this.value.values();

--- a/modules/store/BooleanStore.ts
+++ b/modules/store/BooleanStore.ts
@@ -10,7 +10,7 @@ import { Store } from "./Store.js";
  * const store = new BooleanStore();
  * store.value = 1; // true (coerced)
  * store.toggle(); // now false
- * @see https://dhoulb.github.io/shelving/store/BooleanStore/BooleanStore
+ * @see https://shelving.cc/store/BooleanStore
  */
 export class BooleanStore extends Store<boolean, unknown> {
 	// Override to set default value to `false`
@@ -33,7 +33,7 @@ export class BooleanStore extends Store<boolean, unknown> {
 	 *
 	 * @returns Nothing.
 	 * @example store.toggle(); // `true` becomes `false`, `false` becomes `true`
-	 * @see https://dhoulb.github.io/shelving/store/BooleanStore/BooleanStore/toggle
+	 * @see https://shelving.cc/store/BooleanStore/toggle
 	 */
 	toggle(): void {
 		this.value = !this.value;

--- a/modules/store/BusyStore.ts
+++ b/modules/store/BusyStore.ts
@@ -11,13 +11,13 @@ import { Store, type StoreInput } from "./Store.js";
  * const store = new BusyStore(123);
  * store.value = fetchValue();
  * store.busy.value; // true while the promise is pending
- * @see https://dhoulb.github.io/shelving/store/BusyStore/BusyStore
+ * @see https://shelving.cc/store/BusyStore
  */
 export class BusyStore<T, TT = T> extends Store<T, TT> {
 	/**
 	 * Boolean store that is `true` while this store is awaiting a new value.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/BusyStore/BusyStore/busy
+	 * @see https://shelving.cc/store/BusyStore/busy
 	 */
 	readonly busy = new BooleanStore(false);
 

--- a/modules/store/DataStore.ts
+++ b/modules/store/DataStore.ts
@@ -15,14 +15,14 @@ import { BusyStore } from "./BusyStore.js";
  * const store = new DataStore({ name: "Dave", age: 40 });
  * store.set("age", 41);
  * store.get("name"); // "Dave"
- * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore
+ * @see https://shelving.cc/store/DataStore
  */
 export class DataStore<T extends Data> extends BusyStore<T> {
 	/**
 	 * Get the current data of this store.
 	 * - Supports suspense-like reads: throws a `Promise` while loading or the error `reason` on failure (inherited from `Store.value`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore/data
+	 * @see https://shelving.cc/store/DataStore/data
 	 */
 	get data(): T {
 		return this.value;
@@ -31,7 +31,7 @@ export class DataStore<T extends Data> extends BusyStore<T> {
 	/**
 	 * Set the data of this store.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore/data
+	 * @see https://shelving.cc/store/DataStore/data
 	 */
 	set data(data: T) {
 		this.value = data;
@@ -43,7 +43,7 @@ export class DataStore<T extends Data> extends BusyStore<T> {
 	 * @param updates The set of prop updates to apply.
 	 * @returns Nothing.
 	 * @example store.update({ age: 41, "name": "Dave" });
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore/update
+	 * @see https://shelving.cc/store/DataStore/update
 	 */
 	update(updates: Updates<T>): void {
 		this.value = updateData(this.data, updates);
@@ -55,7 +55,7 @@ export class DataStore<T extends Data> extends BusyStore<T> {
 	 * @param name The name of the prop to read.
 	 * @returns The current value of the named prop.
 	 * @example store.get("name"); // "Dave"
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore/get
+	 * @see https://shelving.cc/store/DataStore/get
 	 */
 	get<K extends DataKey<T>>(name: K): T[K] {
 		return this.data[name];
@@ -68,7 +68,7 @@ export class DataStore<T extends Data> extends BusyStore<T> {
 	 * @param value The new value for the prop.
 	 * @returns Nothing.
 	 * @example store.set("age", 41);
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/DataStore/set
+	 * @see https://shelving.cc/store/DataStore/set
 	 */
 	set<K extends DataKey<T>>(name: K, value: T[K]): void {
 		this.value = withProp(this.data, name, value);
@@ -85,14 +85,14 @@ export class DataStore<T extends Data> extends BusyStore<T> {
  * store.exists; // false
  * store.data = { name: "Dave" };
  * store.delete(); // back to undefined
- * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore
+ * @see https://shelving.cc/store/OptionalDataStore
  */
 export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> {
 	/**
 	 * Get the current data of this store, or throw if it is not set.
 	 * - Supports suspense-like reads: throws a `Promise` while loading or the error `reason` on failure (inherited from `Store.value`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/data
+	 * @see https://shelving.cc/store/OptionalDataStore/data
 	 */
 	get data(): T {
 		return this.require(getGetter(this, "data"));
@@ -101,7 +101,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	/**
 	 * Set the data of this store.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/data
+	 * @see https://shelving.cc/store/OptionalDataStore/data
 	 */
 	set data(data: T) {
 		this.value = data;
@@ -110,7 +110,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	/**
 	 * Whether the data currently exists (is not `undefined`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/exists
+	 * @see https://shelving.cc/store/OptionalDataStore/exists
 	 */
 	get exists(): boolean {
 		return !!this.value;
@@ -123,7 +123,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	 * @returns The current data.
 	 * @throws {RequiredError} If the data is `undefined`.
 	 * @example store.require(); // throws if no data is set
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/require
+	 * @see https://shelving.cc/store/OptionalDataStore/require
 	 */
 	require(caller: AnyCaller = this.require): T {
 		const data = this.value;
@@ -138,7 +138,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	 * @returns Nothing.
 	 * @throws {RequiredError} If the data is `undefined`.
 	 * @example store.update({ name: "Dave" });
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/update
+	 * @see https://shelving.cc/store/OptionalDataStore/update
 	 */
 	update(updates: Updates<T>): void {
 		this.value = updateData(this.require(this.update), updates);
@@ -151,7 +151,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	 * @returns The current value of the named prop.
 	 * @throws {RequiredError} If the data is `undefined`.
 	 * @example store.get("name");
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/get
+	 * @see https://shelving.cc/store/OptionalDataStore/get
 	 */
 	get<K extends DataKey<T>>(name: K): T[K] {
 		return this.require(this.get)[name];
@@ -165,7 +165,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	 * @returns Nothing.
 	 * @throws {RequiredError} If the data is `undefined`.
 	 * @example store.set("name", "Dave");
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/set
+	 * @see https://shelving.cc/store/OptionalDataStore/set
 	 */
 	set<K extends DataKey<T>>(name: K, value: T[K]): void {
 		this.value = withProp(this.require(this.set), name, value);
@@ -176,7 +176,7 @@ export class OptionalDataStore<T extends Data> extends BusyStore<T | undefined> 
 	 *
 	 * @returns Nothing.
 	 * @example store.delete();
-	 * @see https://dhoulb.github.io/shelving/store/DataStore/OptionalDataStore/delete
+	 * @see https://shelving.cc/store/OptionalDataStore/delete
 	 */
 	delete(): void {
 		this.value = undefined;

--- a/modules/store/DictionaryStore.ts
+++ b/modules/store/DictionaryStore.ts
@@ -16,7 +16,7 @@ import { BusyStore } from "./BusyStore.js";
  * const store = new DictionaryStore<number>({ a: 1, b: 2 });
  * store.set("c", 3);
  * store.get("a"); // 1
- * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore
+ * @see https://shelving.cc/store/DictionaryStore
  */
 export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, PossibleDictionary<T>> implements Iterable<DictionaryItem<T>> {
 	// Override to set default value to empty dictionary.
@@ -32,7 +32,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	/**
 	 * Get the number of entries in the current value of this store.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/count
+	 * @see https://shelving.cc/store/DictionaryStore/count
 	 */
 	get count(): number {
 		return Object.keys(this.value).length;
@@ -44,7 +44,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * @param updates The set of entry updates to apply.
 	 * @returns Nothing.
 	 * @example store.update({ a: 10, b: 20 });
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/update
+	 * @see https://shelving.cc/store/DictionaryStore/update
 	 */
 	update(updates: Updates<ImmutableDictionary<T>>): void {
 		this.value = updateData(this.value, updates);
@@ -56,7 +56,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * @param keys The keys of the entries to remove.
 	 * @returns Nothing.
 	 * @example store.deleteItems("a", "b");
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/deleteItems
+	 * @see https://shelving.cc/store/DictionaryStore/deleteItems
 	 */
 	deleteItems(...keys: string[]): void {
 		this.value = omitDictionaryItems(this.value, ...keys);
@@ -68,7 +68,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * @param name The key of the item to read.
 	 * @returns The item value, or `undefined` if it is not present.
 	 * @example store.get("a"); // 1
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/get
+	 * @see https://shelving.cc/store/DictionaryStore/get
 	 */
 	get(name: string): T | undefined {
 		return this.value[name];
@@ -81,7 +81,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * @param value The new value for the item.
 	 * @returns Nothing.
 	 * @example store.set("a", 10);
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/set
+	 * @see https://shelving.cc/store/DictionaryStore/set
 	 */
 	set(name: string, value: T): void {
 		this.value = withProp(this.value, name, value);
@@ -94,7 +94,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * @param names Additional keys to delete.
 	 * @returns Nothing.
 	 * @example store.delete("a", "b");
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/delete
+	 * @see https://shelving.cc/store/DictionaryStore/delete
 	 */
 	delete(name: string, ...names: string[]): void {
 		this.value = omitProps(this.value, name, ...names);
@@ -104,7 +104,7 @@ export class DictionaryStore<T> extends BusyStore<ImmutableDictionary<T>, Possib
 	 * Iterate over the `[key, value]` entries of this dictionary.
 	 *
 	 * @returns An iterator over the dictionary's entry tuples.
-	 * @see https://dhoulb.github.io/shelving/store/DictionaryStore/DictionaryStore/[Symbol.iterator]
+	 * @see https://shelving.cc/store/DictionaryStore/[Symbol.iterator]
 	 */
 	[Symbol.iterator](): Iterator<DictionaryItem<T>> {
 		return getDictionaryItems(this.value)[Symbol.iterator]();

--- a/modules/store/FetchStore.ts
+++ b/modules/store/FetchStore.ts
@@ -7,14 +7,14 @@ import type { AsyncStoreInput, StoreInput } from "./Store.js";
 /**
  * `maxAge` of zero passed to `refresh()` means "always refresh this value" (this is the default).
  *
- * @see https://dhoulb.github.io/shelving/store/FetchStore/ALWAYS_REFRESH
+ * @see https://shelving.cc/store/ALWAYS_REFRESH
  */
 export const ALWAYS_REFRESH = 0;
 
 /**
  * `maxAge` of `Infinity` passed to `refresh()` means "only refresh if this value is not loaded or invalid".
  *
- * @see https://dhoulb.github.io/shelving/store/FetchStore/AVOID_REFRESH
+ * @see https://shelving.cc/store/AVOID_REFRESH
  */
 export const AVOID_REFRESH = Infinity;
 
@@ -23,7 +23,7 @@ export const AVOID_REFRESH = Infinity;
  * - Receives the current `AbortSignal` so it can cancel in-flight HTTP requests when the fetch is aborted.
  * - May return a value synchronously or a `PromiseLike` resolving to one (which the store will await).
  *
- * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchCallback
+ * @see https://shelving.cc/store/FetchCallback
  */
 export type FetchCallback<T> = (signal: AbortSignal) => StoreInput<T> | PromiseLike<StoreInput<T>>;
 
@@ -39,7 +39,7 @@ export type FetchCallback<T> = (signal: AbortSignal) => StoreInput<T> | PromiseL
  * @example
  * const store = new FetchStore(NONE, async signal => (await fetch("/api/thing", { signal })).json());
  * store.value; // throws a `Promise` while loading, then resolves to the fetched value
- * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchStore
+ * @see https://shelving.cc/store/FetchStore
  */
 export class FetchStore<T, TT = T> extends BusyStore<T, TT> {
 	// Override to trigger a refresh when `this.loading` is read.
@@ -90,7 +90,7 @@ export class FetchStore<T, TT = T> extends BusyStore<T, TT> {
 	 * @returns `true` if the value was set synchronously, `false` if no refresh happened, or a `Promise` resolving to whether the awaited fetch succeeded.
 	 * @throws {never} Never throws — fetch errors are stored as `reason` instead.
 	 * @example store.refresh(MINUTE); // refresh only if the current value is older than a minute
-	 * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchStore/refresh
+	 * @see https://shelving.cc/store/FetchStore/refresh
 	 */
 	refresh(maxAge: number = ALWAYS_REFRESH): Promise<boolean> | boolean {
 		if (this._pendingRefresh) return this._pendingRefresh;
@@ -113,7 +113,7 @@ export class FetchStore<T, TT = T> extends BusyStore<T, TT> {
 	 * - Reading this triggers `abort()` so any current awaits are cancelled.
 	 *
 	 * @returns A fresh `AbortSignal` for the next fetch.
-	 * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchStore/signal
+	 * @see https://shelving.cc/store/FetchStore/signal
 	 */
 	get signal(): AbortSignal {
 		this.abort();
@@ -136,7 +136,7 @@ export class FetchStore<T, TT = T> extends BusyStore<T, TT> {
 	 * Whether this store has currently been invalidated and needs a refresh.
 	 *
 	 * @returns `true` if a refresh is pending after an `invalidate()` call, otherwise `false`.
-	 * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchStore/invalidated
+	 * @see https://shelving.cc/store/FetchStore/invalidated
 	 */
 	get invalidated(): boolean {
 		return !!this._invalidation;
@@ -148,7 +148,7 @@ export class FetchStore<T, TT = T> extends BusyStore<T, TT> {
 	 *
 	 * @returns Nothing.
 	 * @example store.invalidate(); // next read of `value` refetches
-	 * @see https://dhoulb.github.io/shelving/store/FetchStore/FetchStore/invalidate
+	 * @see https://shelving.cc/store/FetchStore/invalidate
 	 */
 	invalidate(): void {
 		this.abort();

--- a/modules/store/PathStore.ts
+++ b/modules/store/PathStore.ts
@@ -14,13 +14,13 @@ import { BusyStore } from "./BusyStore.js";
  * const store = new PathStore("/a/b");
  * store.isActive("/a/b"); // true
  * store.getPath("c"); // "/a/b/c"
- * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore
+ * @see https://shelving.cc/store/PathStore
  */
 export class PathStore extends BusyStore<AbsolutePath, AbsolutePath | RelativePath> {
 	/**
 	 * Base path that relative inputs are resolved against.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore/base
+	 * @see https://shelving.cc/store/PathStore/base
 	 */
 	readonly base: AbsolutePath;
 
@@ -46,7 +46,7 @@ export class PathStore extends BusyStore<AbsolutePath, AbsolutePath | RelativePa
 	 * @param path The absolute path to test.
 	 * @returns `true` if `path` matches the current path, otherwise `false`.
 	 * @example store.isActive("/a/b");
-	 * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore/isActive
+	 * @see https://shelving.cc/store/PathStore/isActive
 	 */
 	isActive(path: AbsolutePath): boolean {
 		return isPathActive(this.value, path);
@@ -58,7 +58,7 @@ export class PathStore extends BusyStore<AbsolutePath, AbsolutePath | RelativePa
 	 * @param path The absolute path to test.
 	 * @returns `true` if `path` is at or above the current path in the hierarchy, otherwise `false`.
 	 * @example store.isProud("/a"); // true when current path is "/a/b"
-	 * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore/isProud
+	 * @see https://shelving.cc/store/PathStore/isProud
 	 */
 	isProud(path: AbsolutePath): boolean {
 		return isPathProud(this.value, path);
@@ -70,7 +70,7 @@ export class PathStore extends BusyStore<AbsolutePath, AbsolutePath | RelativePa
 	 * @param path The absolute or relative path to resolve.
 	 * @returns The resolved absolute path.
 	 * @example store.getPath("c"); // "/a/b/c" when current path is "/a/b"
-	 * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore/getPath
+	 * @see https://shelving.cc/store/PathStore/getPath
 	 */
 	getPath(path: AbsolutePath | RelativePath): AbsolutePath {
 		return requirePath(path, this.value);
@@ -80,7 +80,7 @@ export class PathStore extends BusyStore<AbsolutePath, AbsolutePath | RelativePa
 	 * Return the current path as a string.
 	 *
 	 * @returns The current absolute path.
-	 * @see https://dhoulb.github.io/shelving/store/PathStore/PathStore/toString
+	 * @see https://shelving.cc/store/PathStore/toString
 	 */
 	override toString(): string {
 		return this.value;

--- a/modules/store/PayloadFetchStore.ts
+++ b/modules/store/PayloadFetchStore.ts
@@ -9,7 +9,7 @@ import { type AsyncStoreInput, Store } from "./Store.js";
  * - Receives the current payload plus the `AbortSignal` so it can cancel in-flight requests.
  * - May return a value synchronously or a `PromiseLike` resolving to one (which the store will await).
  *
- * @see https://dhoulb.github.io/shelving/store/PayloadFetchStore/PayloadFetchCallback
+ * @see https://shelving.cc/store/PayloadFetchCallback
  */
 export type PayloadFetchCallback<P, R> = (payload: P, signal: AbortSignal) => AsyncStoreInput<R>;
 
@@ -25,14 +25,14 @@ export type PayloadFetchCallback<P, R> = (payload: P, signal: AbortSignal) => As
  * @example
  * const store = new PayloadFetchStore("dave", NONE, async (name, signal) => (await fetch(`/api/user/${name}`, { signal })).json());
  * store.payload.value = "sam"; // triggers a new fetch
- * @see https://dhoulb.github.io/shelving/store/PayloadFetchStore/PayloadFetchStore
+ * @see https://shelving.cc/store/PayloadFetchStore
  */
 export class PayloadFetchStore<P, R> extends FetchStore<R> {
 	/**
 	 * Store keeping the current payload to send to the fetch on send.
 	 * - New payloads can be set using `this.payload.value`
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/PayloadFetchStore/PayloadFetchStore/payload
+	 * @see https://shelving.cc/store/PayloadFetchStore/payload
 	 */
 	readonly payload: Store<P>;
 

--- a/modules/store/Store.ts
+++ b/modules/store/Store.ts
@@ -10,7 +10,7 @@ import { getStarter, type PossibleStarter, type Starter, type StopCallback } fro
 /**
  * Any `Store` instance.
  *
- * @see https://dhoulb.github.io/shelving/store/Store/AnyStore
+ * @see https://shelving.cc/store/AnyStore
  */
 // biome-ignore lint/suspicious/noExplicitAny: `unknown` causes edge case matching issues.
 export type AnyStore = Store<any, any>;
@@ -19,7 +19,7 @@ export type AnyStore = Store<any, any>;
  * Synchronous values that a store natively knows how to process as inputs.
  * - A plain input value of type `I`, or the `SKIP` sentinel (ignore this write) or `NONE` sentinel (put the store into a loading state).
  *
- * @see https://dhoulb.github.io/shelving/store/Store/StoreInput
+ * @see https://shelving.cc/store/StoreInput
  */
 export type StoreInput<I> = I | typeof SKIP | typeof NONE;
 
@@ -27,7 +27,7 @@ export type StoreInput<I> = I | typeof SKIP | typeof NONE;
  * Synchronous or asynchronous values that a store natively knows how to process as inputs.
  * - A `StoreInput<I>` or a `PromiseLike` that resolves to one (which the store will await).
  *
- * @see https://dhoulb.github.io/shelving/store/Store/AsyncStoreInput
+ * @see https://shelving.cc/store/AsyncStoreInput
  */
 export type AsyncStoreInput<I> = StoreInput<I> | PromiseLike<StoreInput<I>>;
 
@@ -35,21 +35,21 @@ export type AsyncStoreInput<I> = StoreInput<I> | PromiseLike<StoreInput<I>>;
  * Internal storage value for a store.
  * - The stored output value of type `O`, or the `NONE` sentinel when the store is loading.
  *
- * @see https://dhoulb.github.io/shelving/store/Store/StoreInternal
+ * @see https://shelving.cc/store/StoreInternal
  */
 export type StoreInternal<O> = O | typeof NONE;
 
 /**
  * Callback that sets a store's value (possibly asynchronously).
  *
- * @see https://dhoulb.github.io/shelving/store/Store/StoreCallback
+ * @see https://shelving.cc/store/StoreCallback
  */
 export type StoreCallback<I, A extends Arguments = []> = (...args: A) => AsyncStoreInput<I>;
 
 /**
  * Reducer that receives a store's current value and returns the store's next value (possibly asynchronously).
  *
- * @see https://dhoulb.github.io/shelving/store/Store/StoreReducer
+ * @see https://shelving.cc/store/StoreReducer
  */
 export type StoreReducer<I, O, A extends Arguments = []> = (value: O, ...args: A) => AsyncStoreInput<I>;
 
@@ -76,13 +76,13 @@ export type StoreReducer<I, O, A extends Arguments = []> = (value: O, ...args: A
  * store.value = 456;
  * for await (const value of store) console.log(value); // 456, ...
  *
- * @see https://dhoulb.github.io/shelving/store/Store/Store
+ * @see https://shelving.cc/store/Store
  */
 export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisposable {
 	/**
 	 * Deferred sequence this store uses to issue values as they change.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/next
+	 * @see https://shelving.cc/store/Store/next
 	 */
 	public readonly next = new DeferredSequence<T>();
 
@@ -91,7 +91,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * - Unlike `this.value` this never throws, so it's safe for `useSyncExternalStore()`-style polling.
 	 *
 	 * @returns The current `reason`, or the current value, or `NONE` if neither is set.
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/snapshot
+	 * @see https://shelving.cc/store/Store/snapshot
 	 */
 	get snapshot(): unknown {
 		return this._reason !== undefined ? this._reason : this._value;
@@ -103,7 +103,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * - Calling `this.loading` is a way to check if this store has a value without triggering those throws.
 	 *
 	 * @returns `true` if the store has neither a value nor an error, otherwise `false`.
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/loading
+	 * @see https://shelving.cc/store/Store/loading
 	 */
 	get loading(): boolean {
 		return this._value === NONE && this.reason === undefined;
@@ -120,7 +120,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 *
 	 * @param input The new value, the `NONE` or `SKIP` sentinel, or a `PromiseLike` resolving to one of those.
 	 * @example store.value = 123;
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/value
+	 * @see https://shelving.cc/store/Store/value
 	 */
 	set value(input: AsyncStoreInput<TT>) {
 		if (isAsync(input)) void this.await(input);
@@ -135,7 +135,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * @param input The value to write, or the `SKIP` or `NONE` sentinel.
 	 * @returns Nothing.
 	 * @example store.write(123);
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/write
+	 * @see https://shelving.cc/store/Store/write
 	 */
 	write(input: StoreInput<TT>): void {
 		this.abort();
@@ -185,7 +185,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * @throws {Promise} If this store currently is in a "loading" state (resolves when a value is set).
 	 * @throws {unknown} If this store currently has an error `reason`.
 	 * @example store.value // 123
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/value
+	 * @see https://shelving.cc/store/Store/value
 	 */
 	get value(): T {
 		if (this._reason !== undefined) throw this._reason;
@@ -200,7 +200,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * - Note: doesn't throw `reason` if there is one!
 	 *
 	 * @returns The internal stored value, or the `NONE` sentinel while loading.
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/read
+	 * @see https://shelving.cc/store/Store/read
 	 */
 	read(): StoreInternal<T> {
 		return this._value;
@@ -211,7 +211,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 * - Will be `undefined` if the value is still loading.
 	 *
 	 * @returns The `Date.now()` timestamp of the last write, or `undefined` while loading.
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/time
+	 * @see https://shelving.cc/store/Store/time
 	 */
 	get time(): number | undefined {
 		return this._time;
@@ -224,7 +224,7 @@ export class Store<T, TT = T> implements AsyncIterable<T, void, void>, AsyncDisp
 	 *
 	 * @returns The number of milliseconds since the last write, or `Infinity` while loading.
 	 * @example if (store.age > MINUTE) refreshStore(store);
-	 * @see https://dhoulb.github.io/shelving/store/Store/Store/age
+	 * @see https://shelving.cc/store/Store/age
 	 */
 	get age(): number {
 		const time = this.time;

--- a/modules/store/URLStore.ts
+++ b/modules/store/URLStore.ts
@@ -27,13 +27,13 @@ import { BusyStore } from "./BusyStore.js";
  * const store = new URLStore("https://top.com/a/b/c");
  * store.setParam("page", 2); // https://top.com/a/b/c?page=2
  * store.isActive("https://top.com/a/b/c?page=2"); // true
- * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore
+ * @see https://shelving.cc/store/URLStore
  */
 export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Base URL that relative URL inputs are resolved against, or `undefined` if none was set.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/base
+	 * @see https://shelving.cc/store/URLStore/base
 	 */
 	readonly base: ImmutableURL | undefined;
 
@@ -57,7 +57,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get or set the full URL string (e.g. `https://top.com/a/b/c?x=1`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/href
+	 * @see https://shelving.cc/store/URLStore/href
 	 */
 	get href(): URLString {
 		return this.value.href;
@@ -69,7 +69,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the origin of the URL (e.g. `https://top.com`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/origin
+	 * @see https://shelving.cc/store/URLStore/origin
 	 */
 	get origin(): URLString {
 		return this.value.origin;
@@ -78,7 +78,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the protocol/scheme of the URL (e.g. `https:`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/protocol
+	 * @see https://shelving.cc/store/URLStore/protocol
 	 */
 	get protocol(): URIScheme {
 		return this.value.protocol;
@@ -87,7 +87,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the username component of the URL.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/username
+	 * @see https://shelving.cc/store/URLStore/username
 	 */
 	get username(): string {
 		return this.value.username;
@@ -96,7 +96,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the password component of the URL.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/password
+	 * @see https://shelving.cc/store/URLStore/password
 	 */
 	get password(): string {
 		return this.value.password;
@@ -105,7 +105,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the hostname of the URL (e.g. `top.com`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/hostname
+	 * @see https://shelving.cc/store/URLStore/hostname
 	 */
 	get hostname(): string {
 		return this.value.hostname;
@@ -114,7 +114,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the host of the URL including port (e.g. `top.com:8080`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/host
+	 * @see https://shelving.cc/store/URLStore/host
 	 */
 	get host(): string {
 		return this.value.host;
@@ -123,7 +123,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the port of the URL, or an empty string if none is set.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/port
+	 * @see https://shelving.cc/store/URLStore/port
 	 */
 	get port(): string {
 		return this.value.port;
@@ -132,7 +132,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the absolute pathname of the URL (e.g. `/a/b/c`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/pathname
+	 * @see https://shelving.cc/store/URLStore/pathname
 	 */
 	get pathname(): AbsolutePath {
 		return this.value.pathname;
@@ -141,7 +141,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the URL params as a query string (e.g. `?x=1&y=2`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/search
+	 * @see https://shelving.cc/store/URLStore/search
 	 */
 	get search(): string {
 		return this.value.search;
@@ -150,7 +150,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	/**
 	 * Get the URL params as a dictionary of key/value pairs.
 	 *
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/params
+	 * @see https://shelving.cc/store/URLStore/params
 	 */
 	get params(): URIParams {
 		return getURIParams(this.value.searchParams, getGetter(this, "params"));
@@ -162,7 +162,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param key The name of the param to read.
 	 * @returns The param value, or `undefined` if it is not present.
 	 * @example store.getParam("page"); // "2"
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/getParam
+	 * @see https://shelving.cc/store/URLStore/getParam
 	 */
 	getParam(key: string): string | undefined {
 		return getURIParam(this.value.searchParams, key);
@@ -175,7 +175,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @returns The param value.
 	 * @throws {RequiredError} If the param is not present.
 	 * @example store.requireParam("page");
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/requireParam
+	 * @see https://shelving.cc/store/URLStore/requireParam
 	 */
 	requireParam(key: string): string | undefined {
 		return requireURIParam(this.value.searchParams, key, getSetter(this, "requireParam"));
@@ -187,7 +187,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param params The complete set of params to set.
 	 * @returns Nothing.
 	 * @example store.setParams({ page: 2, sort: "name" });
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/setParams
+	 * @see https://shelving.cc/store/URLStore/setParams
 	 */
 	setParams(params: PossibleURIParams): void {
 		this.value = withURIParams(clearURIParams(this.value, this.setParams), params, this.setParams);
@@ -200,7 +200,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param value The new value for the param.
 	 * @returns Nothing.
 	 * @example store.setParam("page", 2);
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/setParam
+	 * @see https://shelving.cc/store/URLStore/setParam
 	 */
 	setParam(key: string, value: unknown): void {
 		this.value = withURIParam(this.value, key, value, this.setParam);
@@ -212,7 +212,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param params The set of params to merge in.
 	 * @returns Nothing.
 	 * @example store.updateParams({ sort: "name" });
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/updateParams
+	 * @see https://shelving.cc/store/URLStore/updateParams
 	 */
 	updateParams(params: PossibleURIParams): void {
 		this.value = withURIParams(this.value, params, this.updateParams);
@@ -225,7 +225,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param keys Additional param names to delete.
 	 * @returns Nothing.
 	 * @example store.deleteParam("page", "sort");
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/deleteParam
+	 * @see https://shelving.cc/store/URLStore/deleteParam
 	 */
 	deleteParam(key: string, ...keys: string[]): void {
 		this.value = omitURIParams(this.value, key, ...keys);
@@ -238,7 +238,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param keys Additional param names to delete.
 	 * @returns Nothing.
 	 * @example store.deleteParams("page", "sort");
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/deleteParams
+	 * @see https://shelving.cc/store/URLStore/deleteParams
 	 */
 	deleteParams(key: string, ...keys: string[]): void {
 		this.value = omitURIParams(this.value, key, ...keys);
@@ -249,7 +249,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 *
 	 * @returns Nothing.
 	 * @example store.clearParams();
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/clearParams
+	 * @see https://shelving.cc/store/URLStore/clearParams
 	 */
 	clearParams(): void {
 		this.value = clearURIParams(this.value, this.clearParams);
@@ -262,7 +262,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param value The value for the param.
 	 * @returns A new `ImmutableURL` with the param applied.
 	 * @example store.withParam("page", 2);
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/withParam
+	 * @see https://shelving.cc/store/URLStore/withParam
 	 */
 	withParam(key: string, value: unknown): ImmutableURL {
 		return withURIParam(this.value, key, value, this.withParam);
@@ -274,7 +274,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param params The params to add.
 	 * @returns A new `ImmutableURL` with the params applied.
 	 * @example store.withParams({ page: 2, sort: "name" });
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/withParams
+	 * @see https://shelving.cc/store/URLStore/withParams
 	 */
 	withParams(params: PossibleURIParams): ImmutableURL {
 		return withURIParams(this.value, params, this.withParams);
@@ -286,7 +286,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param keys The param names to remove.
 	 * @returns A new `ImmutableURL` with the params removed.
 	 * @example store.omitParams("page", "sort");
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/omitParams
+	 * @see https://shelving.cc/store/URLStore/omitParams
 	 */
 	omitParams(...keys: string[]): ImmutableURL {
 		return omitURIParams(this.value, ...keys);
@@ -298,7 +298,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @param key The param name to remove.
 	 * @returns A new `ImmutableURL` with the param removed.
 	 * @example store.omitParam("page");
-	 * @see https://dhoulb.github.io/shelving/store/URLStore/URLStore/omitParam
+	 * @see https://shelving.cc/store/URLStore/omitParam
 	 */
 	omitParam(key: string): ImmutableURL {
 		return omitURIParams(this.value, key);

--- a/modules/test/basics.ts
+++ b/modules/test/basics.ts
@@ -10,7 +10,7 @@ import type { ValidatorType } from "../util/validate.js";
 /**
  * Schema for a test "basic" fixture, exercising string, number, choice, array, boolean, and nested-data props.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/BASIC_SCHEMA
+ * @see https://shelving.cc/test/BASIC_SCHEMA
  */
 export const BASIC_SCHEMA = DATA({
 	str: STRING,
@@ -25,21 +25,21 @@ export const BASIC_SCHEMA = DATA({
 /**
  * Validated data shape of a test basic, inferred from `BASIC_SCHEMA`.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/BasicData
+ * @see https://shelving.cc/test/BasicData
  */
 export type BasicData = ValidatorType<typeof BASIC_SCHEMA>;
 
 /**
  * A test basic as a stored `Item` — `BasicData` plus a string `id`.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/BasicItem
+ * @see https://shelving.cc/test/BasicItem
  */
 export type BasicItem = Item<string, BasicData>;
 
 /**
  * Test basic fixture: `str: "aaa"`, `num: 100`, group `a`, odd.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic1
+ * @see https://shelving.cc/test/basic1
  */
 export const basic1: BasicItem = {
 	id: "basic1",
@@ -54,7 +54,7 @@ export const basic1: BasicItem = {
 /**
  * Test basic fixture: `str: "bbb"`, `num: 200`, group `a`, even.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic2
+ * @see https://shelving.cc/test/basic2
  */
 export const basic2: BasicItem = {
 	id: "basic2",
@@ -69,7 +69,7 @@ export const basic2: BasicItem = {
 /**
  * Test basic fixture: `str: "ccc"`, `num: 300`, group `a`, odd.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic3
+ * @see https://shelving.cc/test/basic3
  */
 export const basic3: BasicItem = {
 	id: "basic3",
@@ -84,7 +84,7 @@ export const basic3: BasicItem = {
 /**
  * Test basic fixture: `str: "ddd"`, `num: 400`, group `b`, even.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic4
+ * @see https://shelving.cc/test/basic4
  */
 export const basic4: BasicItem = {
 	id: "basic4",
@@ -99,7 +99,7 @@ export const basic4: BasicItem = {
 /**
  * Test basic fixture: `str: "eee"`, `num: 500`, group `b`, odd.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic5
+ * @see https://shelving.cc/test/basic5
  */
 export const basic5: BasicItem = {
 	id: "basic5",
@@ -114,7 +114,7 @@ export const basic5: BasicItem = {
 /**
  * Test basic fixture: `str: "fff"`, `num: 600`, group `b`, even.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic6
+ * @see https://shelving.cc/test/basic6
  */
 export const basic6: BasicItem = {
 	id: "basic6",
@@ -129,7 +129,7 @@ export const basic6: BasicItem = {
 /**
  * Test basic fixture: `str: "ggg"`, `num: 700`, group `c`, odd.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic7
+ * @see https://shelving.cc/test/basic7
  */
 export const basic7: BasicItem = {
 	id: "basic7",
@@ -144,7 +144,7 @@ export const basic7: BasicItem = {
 /**
  * Test basic fixture: `str: "hhh"`, `num: 800`, group `c`, even.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic8
+ * @see https://shelving.cc/test/basic8
  */
 export const basic8: BasicItem = {
 	id: "basic8",
@@ -159,7 +159,7 @@ export const basic8: BasicItem = {
 /**
  * Test basic fixture: `str: "iii"`, `num: 900`, group `c`, odd.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic9
+ * @see https://shelving.cc/test/basic9
  */
 export const basic9: BasicItem = {
 	id: "basic9",
@@ -175,14 +175,14 @@ export const basic9: BasicItem = {
 /**
  * Array of all nine test basic fixtures in a deliberately shuffled order, for exercising sort/query behaviour.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basics
+ * @see https://shelving.cc/test/basics
  */
 export const basics: ReadonlyArray<BasicItem> = [basic3, basic5, basic7, basic4, basic1, basic2, basic8, basic6, basic9];
 
 /**
  * Standalone test basic data (no `id`): `str: "zzz"`, `num: 999`, for use as new/unsaved data.
  *
- * @see https://dhoulb.github.io/shelving/test/basics/basic999
+ * @see https://shelving.cc/test/basic999
  */
 export const basic999: BasicData = {
 	str: "zzz",

--- a/modules/test/people.ts
+++ b/modules/test/people.ts
@@ -7,7 +7,7 @@ import type { ValidatorType } from "../util/validate.js";
 /**
  * Schema for a test "person" fixture, with a nested `name` and a nullable `birthday`.
  *
- * @see https://dhoulb.github.io/shelving/test/people/PERSON_SCHEMA
+ * @see https://shelving.cc/test/PERSON_SCHEMA
  */
 export const PERSON_SCHEMA = DATA({
 	name: DATA({ first: REQUIRED_STRING, last: REQUIRED_STRING }),
@@ -17,55 +17,55 @@ export const PERSON_SCHEMA = DATA({
 /**
  * Validated data shape of a test person, inferred from `PERSON_SCHEMA`.
  *
- * @see https://dhoulb.github.io/shelving/test/people/PersonData
+ * @see https://shelving.cc/test/PersonData
  */
 export type PersonData = ValidatorType<typeof PERSON_SCHEMA>;
 
 /**
  * A test person as a stored `Item` — `PersonData` plus a string `id`.
  *
- * @see https://dhoulb.github.io/shelving/test/people/PersonItem
+ * @see https://shelving.cc/test/PersonItem
  */
 export type PersonItem = Item<string, PersonData>;
 
 /**
  * Test person fixture: Dave Brook, born 1985-12-06.
  *
- * @see https://dhoulb.github.io/shelving/test/people/person1
+ * @see https://shelving.cc/test/person1
  */
 export const person1: PersonItem = { id: "person1", name: { first: "Dave", last: "Brook" }, birthday: "1985-12-06" };
 
 /**
  * Test person fixture: Sally Callister, born 1973-11-19.
  *
- * @see https://dhoulb.github.io/shelving/test/people/person2
+ * @see https://shelving.cc/test/person2
  */
 export const person2: PersonItem = { id: "person2", name: { first: "Sally", last: "Callister" }, birthday: "1973-11-19" };
 
 /**
  * Test person fixture: Sammy Canister, with no birthday (`null`).
  *
- * @see https://dhoulb.github.io/shelving/test/people/person3
+ * @see https://shelving.cc/test/person3
  */
 export const person3: PersonItem = { id: "person3", name: { first: "Sammy", last: "Canister" }, birthday: null };
 
 /**
  * Test person fixture: Jilly Jones, with no birthday (`null`).
  *
- * @see https://dhoulb.github.io/shelving/test/people/person4
+ * @see https://shelving.cc/test/person4
  */
 export const person4: PersonItem = { id: "person4", name: { first: "Jilly", last: "Jones" }, birthday: null };
 
 /**
  * Test person fixture: Terry Times, born 1964-08-01.
  *
- * @see https://dhoulb.github.io/shelving/test/people/person5
+ * @see https://shelving.cc/test/person5
  */
 export const person5: PersonItem = { id: "person5", name: { first: "Terry", last: "Times" }, birthday: "1964-08-01" };
 
 /**
  * Ordered array of all five test person fixtures (`person1` through `person5`).
  *
- * @see https://dhoulb.github.io/shelving/test/people/people
+ * @see https://shelving.cc/test/people
  */
 export const people: ReadonlyArray<PersonItem> = [person1, person2, person3, person4, person5];

--- a/modules/test/util.ts
+++ b/modules/test/util.ts
@@ -8,7 +8,7 @@ import type { NotString } from "../util/string.js";
  * Asymmetric matcher that expects an object matching `PromiseLike` (i.e. has a `.then()` method).
  *
  * @example expect(value).toEqual(EXPECT_PROMISELIKE)
- * @see https://dhoulb.github.io/shelving/test/util/EXPECT_PROMISELIKE
+ * @see https://shelving.cc/test/EXPECT_PROMISELIKE
  */
 export const EXPECT_PROMISELIKE = expect.objectContaining({
 	then: expect.any(Function),
@@ -24,7 +24,7 @@ export const EXPECT_PROMISELIKE = expect.objectContaining({
  * @param keys The exact set of `.id` values expected (order ignored).
  * @throws {Error} If the items' ids don't match `keys`.
  * @example expectUnorderedItems(results, ["person1", "person2"])
- * @see https://dhoulb.github.io/shelving/test/util/expectUnorderedItems
+ * @see https://shelving.cc/test/expectUnorderedItems
  */
 export function expectUnorderedItems<I extends Identifier, T extends Data>(
 	items: Iterable<Item<I, T>>,
@@ -49,7 +49,7 @@ export function expectUnorderedItems<I extends Identifier, T extends Data>(
  * @param keys The exact ordered sequence of `.id` values expected.
  * @throws {Error} If the items' ids don't match `keys` in order.
  * @example expectOrderedItems(results, ["person1", "person2"])
- * @see https://dhoulb.github.io/shelving/test/util/expectOrderedItems
+ * @see https://shelving.cc/test/expectOrderedItems
  */
 export function expectOrderedItems<I extends Identifier, T extends Data>(
 	items: Iterable<Item<I, T>>,

--- a/modules/ui/app/App.tsx
+++ b/modules/ui/app/App.tsx
@@ -6,7 +6,7 @@ import type { ChildProps } from "../util/props.js";
 /**
  * Props for `<App>` — the root `Meta` plus the application `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/app/App/AppProps
+ * @see https://shelving.cc/ui/AppProps
  */
 export interface AppProps extends PossibleMeta, ChildProps {}
 
@@ -20,7 +20,7 @@ export interface AppProps extends PossibleMeta, ChildProps {}
  * @returns The app root element wrapping `children`.
  * @kind component
  * @example <App app="My App" root="https://example.com/"><Navigation>…</Navigation></App>
- * @see https://dhoulb.github.io/shelving/ui/app/App/App
+ * @see https://shelving.cc/ui/App
  */
 export function App({ children, ...meta }: AppProps): ReactElement {
 	return <MetaContext value={requireMeta(meta)}>{children}</MetaContext>;

--- a/modules/ui/block/Address.tsx
+++ b/modules/ui/block/Address.tsx
@@ -15,14 +15,14 @@ const ADDRESS_CLASS = getModuleClass(ADDRESS_CSS, "address");
 /**
  * Props for `Address` — colour, space, and typography variants plus required children.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Address/AddressProps
+ * @see https://shelving.cc/ui/AddressProps
  */
 export interface AddressProps extends ColorVariants, SpaceVariants, TypographyVariants, ChildProps {}
 
 /**
  * Props for `PhysicalAddress` — an optional name and a nullable `AddressData` object.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Address/PhysicalAddressProps
+ * @see https://shelving.cc/ui/PhysicalAddressProps
  */
 export interface PhysicalAddressProps {
 	name?: Nullish<string>;
@@ -32,7 +32,7 @@ export interface PhysicalAddressProps {
 /**
  * Props for `EmailAddress` — an optional name and a nullable email string.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Address/EmailAddressProps
+ * @see https://shelving.cc/ui/EmailAddressProps
  */
 export interface EmailAddressProps {
 	name?: Nullish<string>;
@@ -43,7 +43,7 @@ export interface EmailAddressProps {
  * Show any kind of contact data, rendered as an `<address>`.
  *
  * @example <Address><Strong>Acme</Strong>{"\n"}1 Example St</Address>
- * @see https://dhoulb.github.io/shelving/ui/block/Address/Address
+ * @see https://shelving.cc/ui/Address
  */
 export function Address({ children, ...props }: AddressProps) {
 	return (
@@ -66,7 +66,7 @@ export function Address({ children, ...props }: AddressProps) {
  *
  * @kind component
  * @example <PhysicalAddress name="Acme" address={addressData} />
- * @see https://dhoulb.github.io/shelving/ui/block/Address/PhysicalAddress
+ * @see https://shelving.cc/ui/PhysicalAddress
  */
 export function PhysicalAddress({ name, address }: PhysicalAddressProps): ReactElement {
 	return (
@@ -84,7 +84,7 @@ export function PhysicalAddress({ name, address }: PhysicalAddressProps): ReactE
  *
  * @kind component
  * @example <EmailAddress name="Acme" email="hi@example.com" />
- * @see https://dhoulb.github.io/shelving/ui/block/Address/EmailAddress
+ * @see https://shelving.cc/ui/EmailAddress
  */
 export function EmailAddress({ name, email }: EmailAddressProps): ReactElement {
 	return (

--- a/modules/ui/block/Block.tsx
+++ b/modules/ui/block/Block.tsx
@@ -12,14 +12,14 @@ const BLOCK_CLASS = getModuleClass(BLOCK_CSS, "block");
 /**
  * Semantic element names a block element may render as via its `as` prop.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Block/BlockElement
+ * @see https://shelving.cc/ui/BlockElement
  */
 export type BlockElement = "div" | "section" | "header" | "footer" | "article" | "nav" | "aside" | "figure";
 
 /**
  * Props for `Block` — colour, space, typography, and width variants plus an optional `as` element override.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Block/BlockProps
+ * @see https://shelving.cc/ui/BlockProps
  */
 export interface BlockProps extends ColorVariants, SpaceVariants, TypographyVariants, WidthVariants, OptionalChildProps {
 	/**
@@ -37,7 +37,7 @@ export interface BlockProps extends ColorVariants, SpaceVariants, TypographyVari
  * @param variants Colour, space, typography, and width variants.
  * @returns A space-separated `className` string combining the block class and resolved variant classes.
  * @example getBlockClass({ space: "large" }) // "block tint …"
- * @see https://dhoulb.github.io/shelving/ui/block/Block/getBlockClass
+ * @see https://shelving.cc/ui/getBlockClass
  */
 export function getBlockClass(variants: BlockProps): string {
 	return getClass(
@@ -56,7 +56,7 @@ export function getBlockClass(variants: BlockProps): string {
  * @kind component
  * @example <Block><Paragraph>Hello</Paragraph></Block>
  * @example <Block as="aside" width="narrow"><Paragraph>Sidebar</Paragraph></Block>
- * @see https://dhoulb.github.io/shelving/ui/block/Block/Block
+ * @see https://shelving.cc/ui/Block
  */
 export function Block({ as: Element = "div", children, ...props }: BlockProps): ReactElement {
 	return <Element className={getBlockClass(props)}>{children}</Element>;

--- a/modules/ui/block/Blockquote.tsx
+++ b/modules/ui/block/Blockquote.tsx
@@ -11,7 +11,7 @@ const BLOCKQUOTE_CLASS = getModuleClass(BLOCKQUOTE_CSS, "blockquote");
 /**
  * Props for `Blockquote` — colour, space, and typography variants plus optional children.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Blockquote/BlockquoteProps
+ * @see https://shelving.cc/ui/BlockquoteProps
  */
 export interface BlockquoteProps extends ColorVariants, SpaceVariants, TypographyVariants, OptionalChildProps {}
 
@@ -20,7 +20,7 @@ export interface BlockquoteProps extends ColorVariants, SpaceVariants, Typograph
  *
  * @kind component
  * @example <Blockquote>To be or not to be.</Blockquote>
- * @see https://dhoulb.github.io/shelving/ui/block/Blockquote/Blockquote
+ * @see https://shelving.cc/ui/Blockquote
  */
 export function Blockquote({ children, ...props }: BlockquoteProps): ReactElement {
 	return (

--- a/modules/ui/block/Caption.tsx
+++ b/modules/ui/block/Caption.tsx
@@ -11,7 +11,7 @@ const CAPTION_CLASS = getModuleClass(CAPTION_CSS, "divider");
 /**
  * Props for `Caption` — colour, space, and typography variants plus optional children.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Caption/CaptionProps
+ * @see https://shelving.cc/ui/CaptionProps
  */
 export interface CaptionProps extends ColorVariants, SpaceVariants, TypographyVariants, OptionalChildProps {}
 
@@ -20,7 +20,7 @@ export interface CaptionProps extends ColorVariants, SpaceVariants, TypographyVa
  *
  * @kind component
  * @example <Figure><Image src="/cat.jpg" /><Caption>A cat</Caption></Figure>
- * @see https://dhoulb.github.io/shelving/ui/block/Caption/Caption
+ * @see https://shelving.cc/ui/Caption
  */
 export function Caption({ children, ...props }: CaptionProps): ReactElement {
 	return (

--- a/modules/ui/block/Card.tsx
+++ b/modules/ui/block/Card.tsx
@@ -13,7 +13,7 @@ import CARD_CSS from "./Card.module.css";
 /**
  * Props for `Card` — combines `ClickableProps` (for navigable cards) with colour, status, padding, space, typography, and width variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Card/CardProps
+ * @see https://shelving.cc/ui/CardProps
  */
 export interface CardProps
 	extends ClickableProps,
@@ -41,7 +41,7 @@ export interface CardProps
  * @example <Card><Subheading>Static</Subheading></Card>
  * @example <Card href="/foo" title="Open foo"><Subheading>Clickable</Subheading></Card>
  * @example <Card status="error"><Subheading>Not found</Subheading></Card>
- * @see https://dhoulb.github.io/shelving/ui/block/Card/Card
+ * @see https://shelving.cc/ui/Card
  */
 export function Card({ as: Element = "article", children, href, onClick, title = "Open", ...props }: CardProps): ReactElement {
 	const overlay = (href || onClick) && (

--- a/modules/ui/block/Definitions.tsx
+++ b/modules/ui/block/Definitions.tsx
@@ -12,7 +12,7 @@ const DEFINITIONS_CLASS = getModuleClass(DEFINITIONS_CSS, "definitions");
 /**
  * Props for `Definitions` — colour, gap, space, and typography variants plus optional children.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Definitions/DefinitionsProps
+ * @see https://shelving.cc/ui/DefinitionsProps
  */
 export interface DefinitionsProps extends ColorVariants, GapVariants, SpaceVariants, TypographyVariants, OptionalChildProps {}
 
@@ -23,7 +23,7 @@ export interface DefinitionsProps extends ColorVariants, GapVariants, SpaceVaria
  *
  * @kind component
  * @example <Definitions><dt>Name</dt><dd>Acme</dd></Definitions>
- * @see https://dhoulb.github.io/shelving/ui/block/Definitions/Definitions
+ * @see https://shelving.cc/ui/Definitions
  */
 export function Definitions({ children, ...props }: DefinitionsProps): ReactElement {
 	return (

--- a/modules/ui/block/Divider.tsx
+++ b/modules/ui/block/Divider.tsx
@@ -8,7 +8,7 @@ const DIVIDER_CLASS = getModuleClass(DIVIDER_CSS, "divider");
 /**
  * Props for `Divider` — space and colour variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Divider/DividerProps
+ * @see https://shelving.cc/ui/DividerProps
  */
 export interface DividerProps extends SpaceVariants, ColorVariants {}
 
@@ -16,7 +16,7 @@ export interface DividerProps extends SpaceVariants, ColorVariants {}
  * Horizontal rule separating blocks of content — rendered as `<hr>`.
  *
  * @example <Divider />
- * @see https://dhoulb.github.io/shelving/ui/block/Divider/Divider
+ * @see https://shelving.cc/ui/Divider
  */
 export function Divider(props: DividerProps) {
 	return (

--- a/modules/ui/block/Heading.tsx
+++ b/modules/ui/block/Heading.tsx
@@ -11,7 +11,7 @@ const HEADING_CLASS = getModuleClass(HEADING_CSS, "heading");
 /**
  * Props shared by `<Title>`, `Heading`, and `<Subheading>` — colour, space, and typography variants plus a heading-level override.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Heading/HeadingProps
+ * @see https://shelving.cc/ui/HeadingProps
  */
 export interface HeadingProps extends ColorVariants, SpaceVariants, TypographyVariants, ChildProps {
 	/**
@@ -28,7 +28,7 @@ export interface HeadingProps extends ColorVariants, SpaceVariants, TypographyVa
  * @kind component
  * @returns Rendered `<h2>` heading element.
  * @example <Heading>Section title</Heading>
- * @see https://dhoulb.github.io/shelving/ui/block/Heading/Heading
+ * @see https://shelving.cc/ui/Heading
  */
 export function Heading({ level = "2", children, ...props }: HeadingProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;

--- a/modules/ui/block/Image.tsx
+++ b/modules/ui/block/Image.tsx
@@ -9,7 +9,7 @@ const IMAGE_CLASS = getModuleClass(styles, "image");
 /**
  * Props for `Image` — an `src`, optional `alt` text, plus space and width variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Image/ImageProps
+ * @see https://shelving.cc/ui/ImageProps
  */
 export interface ImageProps extends SpaceVariants, WidthVariants {
 	src: string;
@@ -22,7 +22,7 @@ export interface ImageProps extends SpaceVariants, WidthVariants {
  * @returns Rendered `<img>` element.
  * @kind component
  * @example <Image src="/logo.png" alt="Logo" width="narrow" />
- * @see https://dhoulb.github.io/shelving/ui/block/Image/Image
+ * @see https://shelving.cc/ui/Image
  */
 export function Image({ src, alt, ...variants }: ImageProps): ReactElement {
 	return <img src={src} alt={alt} className={getClass(IMAGE_CLASS, getSpaceClass(variants), getWidthClass(variants))} />;

--- a/modules/ui/block/Label.tsx
+++ b/modules/ui/block/Label.tsx
@@ -11,7 +11,7 @@ const LABEL_CLASS = getModuleClass(LABEL_CSS, "label");
 /**
  * Props for `Label` — identical to `SubheadingProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Label/LabelProps
+ * @see https://shelving.cc/ui/LabelProps
  */
 export interface LabelProps extends SubheadingProps {}
 
@@ -23,7 +23,7 @@ export interface LabelProps extends SubheadingProps {}
  * @returns Rendered `<h3>` label heading element.
  * @kind component
  * @example <Label>Email address</Label>
- * @see https://dhoulb.github.io/shelving/ui/block/Label/Label
+ * @see https://shelving.cc/ui/Label
  */
 export function Label({ level = "3", children, ...props }: LabelProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;

--- a/modules/ui/block/List.tsx
+++ b/modules/ui/block/List.tsx
@@ -12,7 +12,7 @@ const LIST_UNORDERED_CLASS = getModuleClass(LIST_CSS, "unordered");
 /**
  * Props for `List` — colour, gap, space, and typography variants plus its list items and an `ordered` toggle.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/List/ListProps
+ * @see https://shelving.cc/ui/ListProps
  */
 export interface ListProps extends ColorVariants, GapVariants, SpaceVariants, TypographyVariants {
 	children: ReactNode[];
@@ -27,7 +27,7 @@ export interface ListProps extends ColorVariants, GapVariants, SpaceVariants, Ty
  * @returns Rendered `<ul>` or `<ol>` list element.
  * @example <List>{["One", "Two", "Three"]}</List>
  * @example <List ordered>{["First", "Second"]}</List>
- * @see https://dhoulb.github.io/shelving/ui/block/List/List
+ * @see https://shelving.cc/ui/List
  */
 export function List({ children, ordered = false, ...props }: ListProps): ReactElement {
 	const items = children.map((v, i) => <li key={i.toString()}>{v}</li>);

--- a/modules/ui/block/Panel.tsx
+++ b/modules/ui/block/Panel.tsx
@@ -13,7 +13,7 @@ const PANEL_CLASS = getModuleClass(PANEL_CSS, "panel");
 /**
  * Props for `Panel` — colour, status, and typography variants plus optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Panel/PanelProps
+ * @see https://shelving.cc/ui/PanelProps
  */
 export interface PanelProps extends ColorVariants, PaddingVariants, StatusVariants, TypographyVariants, OptionalChildProps {
 	/**
@@ -34,7 +34,7 @@ export interface PanelProps extends ColorVariants, PaddingVariants, StatusVarian
  * @returns Rendered full-width panel region.
  * @example <Panel><Block width="narrow"><Title>Welcome</Title></Block></Panel>
  * @example <Panel padding="xlarge" color="primary"><Title>Welcome</Title></Panel>
- * @see https://dhoulb.github.io/shelving/ui/block/Panel/Panel
+ * @see https://shelving.cc/ui/Panel
  */
 export function Panel({ as: Element = "section", children, ...props }: PanelProps): ReactElement {
 	return (

--- a/modules/ui/block/Paragraph.tsx
+++ b/modules/ui/block/Paragraph.tsx
@@ -11,7 +11,7 @@ const PARAGRAPH_CLASS = getModuleClass(PARAGRAPH_CSS, "paragraph");
 /**
  * Props for `Paragraph` — colour, space, and typography variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/ParagraphProps
+ * @see https://shelving.cc/ui/ParagraphProps
  */
 export interface ParagraphProps extends ColorVariants, SpaceVariants, TypographyVariants, OptionalChildProps {}
 
@@ -23,7 +23,7 @@ export interface ParagraphProps extends ColorVariants, SpaceVariants, Typography
  * @param variants Colour, space, and typography variants.
  * @returns A space-separated `className` string combining the paragraph class and resolved variant classes.
  * @example getParagraphClass({ space: "large" }) // "paragraph …"
- * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/getParagraphClass
+ * @see https://shelving.cc/ui/getParagraphClass
  */
 export function getParagraphClass(variants: ParagraphProps): string {
 	return getClass(
@@ -40,7 +40,7 @@ export function getParagraphClass(variants: ParagraphProps): string {
  * @kind component
  * @returns Rendered `<p>` paragraph element.
  * @example <Paragraph>Hello world.</Paragraph>
- * @see https://dhoulb.github.io/shelving/ui/block/Paragraph/Paragraph
+ * @see https://shelving.cc/ui/Paragraph
  */
 export function Paragraph({ children, ...props }: ParagraphProps): ReactElement {
 	return <p className={getParagraphClass(props)}>{children}</p>;

--- a/modules/ui/block/Preformatted.tsx
+++ b/modules/ui/block/Preformatted.tsx
@@ -11,7 +11,7 @@ import PREFORMATTED_CSS from "./Preformatted.module.css";
 /**
  * Props for `Preformatted` — space, colour, typography, width, and padding variants plus a `wrap` toggle.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/PreformattedProps
+ * @see https://shelving.cc/ui/PreformattedProps
  */
 export interface PreformattedProps
 	extends SpaceVariants,
@@ -32,7 +32,7 @@ export interface PreformattedProps
  * @returns Rendered `<pre>` element.
  * @kind component
  * @example <Preformatted>{"line one\nline two"}</Preformatted>
- * @see https://dhoulb.github.io/shelving/ui/block/Preformatted/Preformatted
+ * @see https://shelving.cc/ui/Preformatted
  */
 export function Preformatted({ children, ...variants }: PreformattedProps): ReactElement {
 	return (

--- a/modules/ui/block/Prose.tsx
+++ b/modules/ui/block/Prose.tsx
@@ -57,7 +57,7 @@ const PROSE_STYLES = getClass(
 /**
  * Props for `Prose` — just the longform `children` to style.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Prose/ProseProps
+ * @see https://shelving.cc/ui/ProseProps
  */
 export interface ProseProps extends OptionalChildProps {}
 
@@ -68,7 +68,7 @@ export interface ProseProps extends OptionalChildProps {}
  * @kind component
  * @returns Rendered `<div>` wrapping the prose content.
  * @example <Prose><Paragraph>First.</Paragraph><Paragraph>Second.</Paragraph></Prose>
- * @see https://dhoulb.github.io/shelving/ui/block/Prose/Prose
+ * @see https://shelving.cc/ui/Prose
  */
 export function Prose({ children }: ProseProps): ReactElement {
 	return <div className={PROSE_STYLES}>{children}</div>;

--- a/modules/ui/block/Section.tsx
+++ b/modules/ui/block/Section.tsx
@@ -13,7 +13,7 @@ const SECTION_CLASS = getModuleClass(SECTION_CSS, "section");
 /**
  * Props for `Section` and its semantic siblings — colour, space, typography, and width variants plus an optional `as` element override.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Section/SectionProps
+ * @see https://shelving.cc/ui/SectionProps
  */
 export interface SectionProps extends ColorVariants, SpaceVariants, TypographyVariants, WidthVariants, OptionalChildProps {
 	/**
@@ -31,7 +31,7 @@ export interface SectionProps extends ColorVariants, SpaceVariants, TypographyVa
  * @param variants Colour, space, typography, and width variants.
  * @returns A space-separated `className` string combining the section class and resolved variant classes.
  * @example getSectionClass({ space: "large" }) // "section …"
- * @see https://dhoulb.github.io/shelving/ui/block/Section/getSectionClass
+ * @see https://shelving.cc/ui/getSectionClass
  */
 export function getSectionClass(variants: SectionProps): string {
 	return getClass(
@@ -50,7 +50,7 @@ export function getSectionClass(variants: SectionProps): string {
  * @kind component
  * @returns Rendered `<section>` element.
  * @example <Section><Heading>About</Heading></Section>
- * @see https://dhoulb.github.io/shelving/ui/block/Section/Section
+ * @see https://shelving.cc/ui/Section
  */
 export function Section({ as: Element = "section", children, ...variants }: SectionProps): ReactElement {
 	return <Element className={getSectionClass(variants)}>{children}</Element>;
@@ -62,7 +62,7 @@ export function Section({ as: Element = "section", children, ...variants }: Sect
  * @kind component
  * @returns Rendered `<header>` element.
  * @example <Header><Title>Welcome</Title></Header>
- * @see https://dhoulb.github.io/shelving/ui/block/Section/Header
+ * @see https://shelving.cc/ui/Header
  */
 export function Header({ as: Element = "section", children, ...variants }: SectionProps): ReactElement {
 	return <Element className={getSectionClass(variants)}>{children}</Element>;
@@ -74,7 +74,7 @@ export function Header({ as: Element = "section", children, ...variants }: Secti
  * @kind component
  * @returns Rendered `<footer>` element.
  * @example <Footer><Small>© 2026</Small></Footer>
- * @see https://dhoulb.github.io/shelving/ui/block/Section/Footer
+ * @see https://shelving.cc/ui/Footer
  */
 export function Footer({ as: Element = "section", children, ...variants }: SectionProps): ReactElement {
 	return <Element className={getSectionClass(variants)}>{children}</Element>;
@@ -86,7 +86,7 @@ export function Footer({ as: Element = "section", children, ...variants }: Secti
  *
  * @kind component
  * @returns Rendered `<article>` element.
- * @see https://dhoulb.github.io/shelving/ui/block/Section/Article
+ * @see https://shelving.cc/ui/Article
  */
 export function Article({ as: Element = "article", children, ...variants }: SectionProps): ReactElement {
 	return <Element className={getSectionClass(variants)}>{children}</Element>;
@@ -99,7 +99,7 @@ export function Article({ as: Element = "article", children, ...variants }: Sect
  * @kind component
  * @returns Rendered `<figure>` element.
  * @example <Figure><Image src="/cat.jpg" /><Caption>A cat</Caption></Figure>
- * @see https://dhoulb.github.io/shelving/ui/block/Section/Figure
+ * @see https://shelving.cc/ui/Figure
  */
 export function Figure({ as: Element = "figure", children, ...variants }: SectionProps): ReactElement {
 	return <Element className={getSectionClass(variants)}>{children}</Element>;

--- a/modules/ui/block/Subheading.tsx
+++ b/modules/ui/block/Subheading.tsx
@@ -11,7 +11,7 @@ const SUBHEADING_CLASS = getModuleClass(SUBHEADING_CSS, "subheading");
 /**
  * Props for `Subheading` — identical to `HeadingProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Subheading/SubheadingProps
+ * @see https://shelving.cc/ui/SubheadingProps
  */
 export type SubheadingProps = HeadingProps;
 
@@ -22,7 +22,7 @@ export type SubheadingProps = HeadingProps;
  * @kind component
  * @returns Rendered `<h3>` heading element.
  * @example <Subheading>Details</Subheading>
- * @see https://dhoulb.github.io/shelving/ui/block/Subheading/Subheading
+ * @see https://shelving.cc/ui/Subheading
  */
 export function Subheading({ level = "3", children, ...props }: SubheadingProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;

--- a/modules/ui/block/Title.tsx
+++ b/modules/ui/block/Title.tsx
@@ -11,7 +11,7 @@ const TITLE_CLASS = getModuleClass(TITLE_CSS, "title");
 /**
  * Props for `Title` — identical to `HeadingProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Title/TitleProps
+ * @see https://shelving.cc/ui/TitleProps
  */
 export type TitleProps = HeadingProps;
 
@@ -22,7 +22,7 @@ export type TitleProps = HeadingProps;
  * @kind component
  * @returns Rendered `<h1>` heading element.
  * @example <Title>Welcome</Title>
- * @see https://dhoulb.github.io/shelving/ui/block/Title/Title
+ * @see https://shelving.cc/ui/Title
  */
 export function Title({ level = "1", children, ...props }: TitleProps): ReactElement {
 	const Element: `h${typeof level}` = `h${level}`;

--- a/modules/ui/block/Video.tsx
+++ b/modules/ui/block/Video.tsx
@@ -11,14 +11,14 @@ const VIDEO_CLASS = getModuleClass(styles, "video");
 /**
  * Props for `Video` — space and width variants plus optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoProps
+ * @see https://shelving.cc/ui/VideoProps
  */
 export interface VideoProps extends SpaceVariants, WidthVariants, OptionalChildProps {}
 
 /**
  * Props for `VideoButtons` — `children` plus an optional `left` alignment flag.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoButtonsProps
+ * @see https://shelving.cc/ui/VideoButtonsProps
  */
 export interface VideoButtonsProps extends ChildProps {
 	left?: boolean;
@@ -27,7 +27,7 @@ export interface VideoButtonsProps extends ChildProps {
 /**
  * Props for `VideoButton` — `children` plus optional `title`, `onClick`, `danger`, and `disabled`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoButtonProps
+ * @see https://shelving.cc/ui/VideoButtonProps
  */
 export interface VideoButtonProps extends ChildProps {
 	title?: string | undefined;
@@ -44,7 +44,7 @@ export interface VideoButtonProps extends ChildProps {
  * @returns Rendered `<figure>` video container.
  * @kind component
  * @example <Video><video src="/clip.mp4" /></Video>
- * @see https://dhoulb.github.io/shelving/ui/block/Video/Video
+ * @see https://shelving.cc/ui/Video
  */
 export function Video({ children, ...variants }: VideoProps): ReactElement {
 	const ref = useRef<HTMLElement | null>(null);
@@ -68,7 +68,7 @@ export function Video({ children, ...variants }: VideoProps): ReactElement {
  *
  * @returns Rendered overlay container for video buttons.
  * @example <VideoButtons><FullscreenVideoButton /></VideoButtons>
- * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoButtons
+ * @see https://shelving.cc/ui/VideoButtons
  */
 export function VideoButtons({ children, ...variants }: VideoButtonsProps) {
 	return <div className={getModuleClass(styles, "buttons", variants)}>{children}</div>;
@@ -80,7 +80,7 @@ export function VideoButtons({ children, ...variants }: VideoButtonsProps) {
  * @returns Rendered `<button>` element overlaid on the video.
  * @kind component
  * @example <VideoButton title="Play" onClick={play}><PlayIcon /></VideoButton>
- * @see https://dhoulb.github.io/shelving/ui/block/Video/VideoButton
+ * @see https://shelving.cc/ui/VideoButton
  */
 export function VideoButton({ children, title, onClick, disabled, ...variants }: VideoButtonProps): ReactElement {
 	return (
@@ -95,7 +95,7 @@ declare const _fullscreenVideoButtonProps: unique symbol;
 /**
  * Props for `FullscreenVideoButton` — an empty marker interface (the component takes no props).
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Video/FullscreenVideoButtonProps
+ * @see https://shelving.cc/ui/FullscreenVideoButtonProps
  */
 export interface FullscreenVideoButtonProps {
 	readonly [_fullscreenVideoButtonProps]?: never;
@@ -109,7 +109,7 @@ export interface FullscreenVideoButtonProps {
  * @returns Rendered fullscreen toggle button, or `null` when fullscreen is unavailable.
  * @kind component
  * @example <Video><video src="/clip.mp4" /><VideoButtons><FullscreenVideoButton /></VideoButtons></Video>
- * @see https://dhoulb.github.io/shelving/ui/block/Video/FullscreenVideoButton
+ * @see https://shelving.cc/ui/FullscreenVideoButton
  */
 export function FullscreenVideoButton(): ReactElement | null {
 	const [isFull, setFull] = useState(() => typeof document !== "undefined" && !!document.fullscreenElement);

--- a/modules/ui/dialog/Dialog.tsx
+++ b/modules/ui/dialog/Dialog.tsx
@@ -9,7 +9,7 @@ import styles from "./Dialog.module.css";
 /**
  * Props for `<Dialog>` — optional `children` content and an `onClose` callback.
  *
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialog/DialogProps
+ * @see https://shelving.cc/ui/DialogProps
  */
 export interface DialogProps extends OptionalChildProps {
 	onClose?: Callback;
@@ -23,7 +23,7 @@ export interface DialogProps extends OptionalChildProps {
  *
  * @kind component
  * @example dialogs.show(<Dialog><p>Are you sure?</p></Dialog>);
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialog/Dialog
+ * @see https://shelving.cc/ui/Dialog
  */
 export const Dialog = memo(({ children, onClose, ...props }: DialogProps) => {
 	const ref = useRef<HTMLDialogElement>(null);
@@ -57,7 +57,7 @@ function _closeOnBackdropClick({ currentTarget, target }: MouseEvent<HTMLDialogE
 /**
  * Props for `<DialogCloseButton>` — button styling variants and optional `children` to override the X icon.
  *
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialog/DialogCloseButtonProps
+ * @see https://shelving.cc/ui/DialogCloseButtonProps
  */
 export interface DialogCloseButtonProps extends ButtonVariants, OptionalChildProps {}
 
@@ -69,7 +69,7 @@ export interface DialogCloseButtonProps extends ButtonVariants, OptionalChildPro
  * @returns The close button element.
  * @kind component
  * @example <DialogCloseButton plain />
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialog/DialogCloseButton
+ * @see https://shelving.cc/ui/DialogCloseButton
  */
 export function DialogCloseButton({ children = <XMarkIcon />, ...variants }: DialogCloseButtonProps): ReactElement {
 	return (

--- a/modules/ui/dialog/Dialogs.tsx
+++ b/modules/ui/dialog/Dialogs.tsx
@@ -15,7 +15,7 @@ const REMOVE_DELAY = 500;
  * - `show()` opens a new dialog; closed dialogs are removed after an animation delay.
  *
  * @example const dialogs = new DialogsStore(); dialogs.show(<p>Hello</p>);
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsStore
+ * @see https://shelving.cc/ui/DialogsStore
  */
 export class DialogsStore extends ArrayStore<ReactElement> {
 	/**
@@ -23,7 +23,7 @@ export class DialogsStore extends ArrayStore<ReactElement> {
 	 *
 	 * @param children The content to show inside the dialog.
 	 * @example dialogs.show(<ConfirmForm />);
-	 * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsStore/show
+	 * @see https://shelving.cc/ui/DialogsStore/show
 	 */
 	show(children: ReactNode) {
 		const dialog = (
@@ -45,7 +45,7 @@ export class DialogsStore extends ArrayStore<ReactElement> {
 	 * Hide all currently visible dialogs.
 	 *
 	 * @example dialogs.hideAll();
-	 * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsStore/hideAll
+	 * @see https://shelving.cc/ui/DialogsStore/hideAll
 	 */
 	hideAll() {
 		this.delete(...this.value);
@@ -61,7 +61,7 @@ _DialogsContext.displayName = "DialogsContext";
  *
  * @returns The current `DialogsStore`.
  * @example requireDialogs().show(<ConfirmForm />);
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/requireDialogs
+ * @see https://shelving.cc/ui/requireDialogs
  */
 export function requireDialogs(): DialogsStore {
 	return use(_DialogsContext);
@@ -72,14 +72,14 @@ declare const _componentProps: unique symbol;
 /**
  * Props for `<DialogsContext>` — the `children` subtree the dialogs store is provided to.
  *
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsContextProps
+ * @see https://shelving.cc/ui/DialogsContextProps
  */
 export interface DialogsContextProps extends ChildProps {}
 
 /**
  * Props for `<Dialogs>` — takes no props (branded empty interface).
  *
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsProps
+ * @see https://shelving.cc/ui/DialogsProps
  */
 export interface DialogsProps {
 	readonly [_componentProps]?: never;
@@ -92,7 +92,7 @@ export interface DialogsProps {
  * @returns The dialogs context provider wrapping `children`.
  * @kind component
  * @example <DialogsContext><App /></DialogsContext>
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/DialogsContext
+ * @see https://shelving.cc/ui/DialogsContext
  */
 export function DialogsContext({ children }: DialogsContextProps): ReactElement {
 	return <_DialogsContext value={useInstance(DialogsStore)}>{children}</_DialogsContext>;
@@ -104,7 +104,7 @@ export function DialogsContext({ children }: DialogsContextProps): ReactElement 
  * @returns The list of open dialog elements, or `null` when there are none.
  * @kind component
  * @example <DialogsContext><App /><Dialogs /></DialogsContext>
- * @see https://dhoulb.github.io/shelving/ui/dialog/Dialogs/Dialogs
+ * @see https://shelving.cc/ui/Dialogs
  */
 export function Dialogs(): ReactNode | null {
 	const dialogs = useStore(requireDialogs());

--- a/modules/ui/dialog/Modal.tsx
+++ b/modules/ui/dialog/Modal.tsx
@@ -6,7 +6,7 @@ import styles from "./Modal.module.css";
 /**
  * Props for `<Modal>` — optional `children` content.
  *
- * @see https://dhoulb.github.io/shelving/ui/dialog/Modal/ModalProps
+ * @see https://shelving.cc/ui/ModalProps
  */
 export interface ModalProps extends OptionalChildProps {}
 
@@ -17,7 +17,7 @@ export interface ModalProps extends OptionalChildProps {}
  * @param children The modal content.
  * @returns The modal container element.
  * @example <Modal><p>Modal content</p></Modal>
- * @see https://dhoulb.github.io/shelving/ui/dialog/Modal/Modal
+ * @see https://shelving.cc/ui/Modal
  */
 export function Modal({ children }: ModalProps): ReactElement {
 	return <aside className={getModuleClass(styles, "modal")}>{children}</aside>;

--- a/modules/ui/docs/DocumentationButtons.tsx
+++ b/modules/ui/docs/DocumentationButtons.tsx
@@ -9,7 +9,7 @@ import { getClass } from "../util/css.js";
 /**
  * Props for `DocumentationButtons` — the relational metadata of a documented symbol (`class`, `extends`, `implements`), plus block-space and flex overrides.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationButtons/DocumentationButtonsProps
+ * @see https://shelving.cc/ui/DocumentationButtonsProps
  */
 export interface DocumentationButtonsProps
 	extends Pick<DocumentationElementProps, "class" | "extends" | "implements">,

--- a/modules/ui/docs/DocumentationCard.tsx
+++ b/modules/ui/docs/DocumentationCard.tsx
@@ -16,7 +16,7 @@ import { DocumentationSignatures } from "./DocumentationSignatures.js";
  * @kind component
  * @returns A `<Card>` linking to the symbol's own page.
  * @example <DocumentationCard {...element.props} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationCard/DocumentationCard
+ * @see https://shelving.cc/ui/DocumentationCard
  */
 export function DocumentationCard({
 	path,

--- a/modules/ui/docs/DocumentationDescription.tsx
+++ b/modules/ui/docs/DocumentationDescription.tsx
@@ -7,7 +7,7 @@ import { TreeMarkup } from "../tree/TreeMarkup.js";
 /**
  * Props for `DocumentationDescription` — a description cell's resolved text, plus an optional default/optionality note.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationDescription/DocumentationDescriptionProps
+ * @see https://shelving.cc/ui/DocumentationDescriptionProps
  */
 export interface DocumentationDescriptionProps {
 	/** Already-resolved description text (hand-written, or fallen back to the referenced type's own description), rendered as inline markup. */
@@ -30,7 +30,7 @@ export interface DocumentationDescriptionProps {
  * @kind component
  * @returns The description and any trailing notes wrapped in a `<Prose>`, or `null` when all are empty.
  * @example <DocumentationDescription description="The `foo` value." optional={false} readonly />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationDescription/DocumentationDescription
+ * @see https://shelving.cc/ui/DocumentationDescription
  */
 export function DocumentationDescription({ description, default: def, optional, readonly }: DocumentationDescriptionProps): ReactNode {
 	const body = description ? <TreeMarkup context="inline">{description}</TreeMarkup> : null;

--- a/modules/ui/docs/DocumentationHomePage.tsx
+++ b/modules/ui/docs/DocumentationHomePage.tsx
@@ -18,7 +18,7 @@ import { TreeMarkup } from "../tree/TreeMarkup.js";
  * @kind component
  * @returns A `<Page>` with a coloured hero panel followed by the module listing.
  * @example <DocumentationHomePage {...root.props} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationHomePage/DocumentationHomePage
+ * @see https://shelving.cc/ui/DocumentationHomePage
  */
 export function DocumentationHomePage({ title, name, description, content, children }: TreeElementProps): ReactNode {
 	return (

--- a/modules/ui/docs/DocumentationKind.tsx
+++ b/modules/ui/docs/DocumentationKind.tsx
@@ -5,7 +5,7 @@ import type { ColorVariant } from "../style/Color.js";
 /**
  * Props for `DocumentationKind` — a `TagProps` plus the documented symbol's `kind`.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKindProps
+ * @see https://shelving.cc/ui/DocumentationKindProps
  */
 export interface DocumentationKindProps extends TagProps {
 	/** The documentation kind (e.g. `"component"`, `"function"`, `"class"`, `"interface"`, `"type"`, `"constant"`, `"method"`, `"static method"`, `"property"`, `"static property"`). */
@@ -38,7 +38,7 @@ const KIND_COLOR: { readonly [K in string]?: ColorVariant } = {
  * @param kind The documented symbol's kind (e.g. `"function"`, `"class"`, `"method"`).
  * @returns The matching `ColorVariant`, or `undefined` when the kind is unrecognised.
  * @example getDocumentationKindColor("class") // "pink"
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/getDocumentationKindColor
+ * @see https://shelving.cc/ui/getDocumentationKindColor
  */
 export function getDocumentationKindColor(kind: string): ColorVariant | undefined {
 	return KIND_COLOR[kind];
@@ -51,7 +51,7 @@ export function getDocumentationKindColor(kind: string): ColorVariant | undefine
  * @returns A `<Tag>` showing the kind, tinted by its colour.
  * @kind component
  * @example <DocumentationKind kind="function" />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationKind/DocumentationKind
+ * @see https://shelving.cc/ui/DocumentationKind
  */
 export function DocumentationKind({ kind = "unknown", ...props }: DocumentationKindProps): ReactElement {
 	return (

--- a/modules/ui/docs/DocumentationPage.tsx
+++ b/modules/ui/docs/DocumentationPage.tsx
@@ -77,7 +77,7 @@ function DocumentationChildren({ elements }: { readonly elements?: TreeElements 
  * @kind component
  * @returns A `<Page>` containing the symbol's full documentation.
  * @example <DocumentationPage {...element.props} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationPage/DocumentationPage
+ * @see https://shelving.cc/ui/DocumentationPage
  */
 export function DocumentationPage({
 	title,

--- a/modules/ui/docs/DocumentationParams.tsx
+++ b/modules/ui/docs/DocumentationParams.tsx
@@ -21,7 +21,7 @@ const FLATTEN_KINDS = new Set(["interface", "type"]);
 /**
  * Props for `DocumentationParams` — the parameter list to render, one row per parameter.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationParams/DocumentationParamsProps
+ * @see https://shelving.cc/ui/DocumentationParamsProps
  */
 export interface DocumentationParamsProps {
 	/** Parameters to render — one row each, with options-bag params flattened into indented child rows. */
@@ -39,7 +39,7 @@ export interface DocumentationParamsProps {
  * @kind component
  * @returns A `<Section>` containing the parameters table, or `null` when there are none.
  * @example <DocumentationParams params={params} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationParams/DocumentationParams
+ * @see https://shelving.cc/ui/DocumentationParams
  */
 export function DocumentationParams({ params }: DocumentationParamsProps): ReactNode {
 	const map = useTreeMap();

--- a/modules/ui/docs/DocumentationProperties.tsx
+++ b/modules/ui/docs/DocumentationProperties.tsx
@@ -15,7 +15,7 @@ const DEFAULT_TYPE = "unknown";
 /**
  * Props for `DocumentationProperties` — the data members of a class/interface/object-literal type to render, one row each.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationProperties/DocumentationPropertiesProps
+ * @see https://shelving.cc/ui/DocumentationPropertiesProps
  */
 export interface DocumentationPropertiesProps {
 	/** Properties to render — one row each. */
@@ -33,7 +33,7 @@ export interface DocumentationPropertiesProps {
  * @kind component
  * @returns A [`<Section>`](/ui/Section) containing the properties table, or `null` when there are none.
  * @example <DocumentationProperties properties={properties} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationProperties/DocumentationProperties
+ * @see https://shelving.cc/ui/DocumentationProperties
  */
 export function DocumentationProperties({ properties }: DocumentationPropertiesProps): ReactNode {
 	const map = useTreeMap();

--- a/modules/ui/docs/DocumentationReferences.tsx
+++ b/modules/ui/docs/DocumentationReferences.tsx
@@ -11,7 +11,7 @@ import { DocumentationDescription } from "./DocumentationDescription.js";
 /**
  * Props for `DocumentationReferences` — the referenced type names to render, one row each.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationReferences/DocumentationReferencesProps
+ * @see https://shelving.cc/ui/DocumentationReferencesProps
  */
 export interface DocumentationReferencesProps {
 	/** Type names referenced by a `type` alias's body — one row each, resolved to links at render time. */
@@ -26,7 +26,7 @@ export interface DocumentationReferencesProps {
  * @kind component
  * @returns A `<Section>` containing the references table, or `null` when there are none.
  * @example <DocumentationReferences types={types} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationReferences/DocumentationReferences
+ * @see https://shelving.cc/ui/DocumentationReferences
  */
 export function DocumentationReferences({ types }: DocumentationReferencesProps): ReactNode {
 	const map = useTreeMap();

--- a/modules/ui/docs/DocumentationReturns.tsx
+++ b/modules/ui/docs/DocumentationReturns.tsx
@@ -14,7 +14,7 @@ const DEFAULT_TYPE = "unknown";
 /**
  * Props for `DocumentationReturns` — the `@returns` entries to render, one row each.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationReturns/DocumentationReturnsProps
+ * @see https://shelving.cc/ui/DocumentationReturnsProps
  */
 export interface DocumentationReturnsProps {
 	/** Return entries to render — one row per documented return type. */
@@ -30,7 +30,7 @@ export interface DocumentationReturnsProps {
  * @kind component
  * @returns A `<Section>` containing the returns table, or `null` when there are none.
  * @example <DocumentationReturns returns={returns} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationReturns/DocumentationReturns
+ * @see https://shelving.cc/ui/DocumentationReturns
  */
 export function DocumentationReturns({ returns }: DocumentationReturnsProps): ReactNode {
 	const map = useTreeMap();

--- a/modules/ui/docs/DocumentationSignatures.tsx
+++ b/modules/ui/docs/DocumentationSignatures.tsx
@@ -5,7 +5,7 @@ import { Preformatted } from "../block/Preformatted.js";
 /**
  * Props for `DocumentationSignatures` — the type signatures to render, one block per overload.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationSignatures/DocumentationSignaturesProps
+ * @see https://shelving.cc/ui/DocumentationSignaturesProps
  */
 export interface DocumentationSignaturesProps {
 	/** Type signatures to render — one block per overload. */
@@ -21,7 +21,7 @@ export interface DocumentationSignaturesProps {
  * @returns One `<Preformatted>` block per signature, or `null` when there are none.
  * @kind component
  * @example <DocumentationSignatures signatures={["getArray<T>(arr: T[]): T"]} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationSignatures/DocumentationSignatures
+ * @see https://shelving.cc/ui/DocumentationSignatures
  */
 export function DocumentationSignatures({ signatures }: DocumentationSignaturesProps): ReactNode {
 	if (!signatures?.length) return null;

--- a/modules/ui/docs/DocumentationThrows.tsx
+++ b/modules/ui/docs/DocumentationThrows.tsx
@@ -14,7 +14,7 @@ const DEFAULT_TYPE = "unknown";
 /**
  * Props for `DocumentationThrows` — the `@throws` entries to render, one row each.
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationThrows/DocumentationThrowsProps
+ * @see https://shelving.cc/ui/DocumentationThrowsProps
  */
 export interface DocumentationThrowsProps {
 	/** Throw entries to render — one row per documented thrown type. */
@@ -30,7 +30,7 @@ export interface DocumentationThrowsProps {
  * @kind component
  * @returns A `<Section>` containing the throws table, or `null` when there are none.
  * @example <DocumentationThrows throws={throws} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationThrows/DocumentationThrows
+ * @see https://shelving.cc/ui/DocumentationThrows
  */
 export function DocumentationThrows({ throws }: DocumentationThrowsProps): ReactNode {
 	const map = useTreeMap();

--- a/modules/ui/docs/DocumentationType.tsx
+++ b/modules/ui/docs/DocumentationType.tsx
@@ -8,7 +8,7 @@ import { TreeLink } from "../tree/TreeLink.js";
  *
  * @param type The type expression to split (e.g. `"Schemas<T> | DataSchema<T>"`).
  * @returns The non-`undefined` members, plus whether an `undefined` member was dropped.
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationType/splitType
+ * @see https://shelving.cc/ui/splitType
  */
 export function splitType(type: string): { readonly members: readonly string[]; readonly optional: boolean } {
 	const parts = type
@@ -22,7 +22,7 @@ export function splitType(type: string): { readonly members: readonly string[]; 
 /**
  * Props for `DocumentationType` — the union members to render (see [`splitType`](/ui/splitType)).
  *
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationType/DocumentationTypeProps
+ * @see https://shelving.cc/ui/DocumentationTypeProps
  */
 export interface DocumentationTypeProps {
 	/** Union members to render — one linked token each, stacked on their own line. */
@@ -36,7 +36,7 @@ export interface DocumentationTypeProps {
  * @kind component
  * @returns One [`TreeLink`](/ui/TreeLink) per member, separated by line breaks.
  * @example <DocumentationType members={["Schemas<T>", "DataSchema<T>"]} />
- * @see https://dhoulb.github.io/shelving/ui/docs/DocumentationType/DocumentationType
+ * @see https://shelving.cc/ui/DocumentationType
  */
 export function DocumentationType({ members }: DocumentationTypeProps): ReactNode {
 	return members.map((member, index) => (

--- a/modules/ui/form/ArrayInput.tsx
+++ b/modules/ui/form/ArrayInput.tsx
@@ -13,7 +13,7 @@ import { SchemaInput } from "./SchemaInput.js";
 /**
  * Props for `ArrayInput`, a repeating input that edits an array of schema-validated items.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ArrayInput/ArrayInputProps
+ * @see https://shelving.cc/ui/ArrayInputProps
  */
 export interface ArrayInputProps<T> extends ValueInputProps<ImmutableArray<T>> {
 	one?: string;
@@ -32,7 +32,7 @@ export interface ArrayInputProps<T> extends ValueInputProps<ImmutableArray<T>> {
  * @returns Element rendering one input row per array item plus add/clear controls.
  * @kind component
  * @example <ArrayInput name="tags" items={STRING} value={tags} onValue={setTags} />
- * @see https://dhoulb.github.io/shelving/ui/form/ArrayInput/ArrayInput
+ * @see https://shelving.cc/ui/ArrayInput
  */
 export function ArrayInput<T>(props: ArrayInputProps<T>): ReactElement;
 export function ArrayInput({

--- a/modules/ui/form/ArrayRadioInputs.tsx
+++ b/modules/ui/form/ArrayRadioInputs.tsx
@@ -8,7 +8,7 @@ import { RadioInput } from "./RadioInput.js";
 /**
  * Props for `ArrayRadioInputs`, which renders a radio for each item in an array of values.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ArrayRadioInputs/ArrayRadioInputsProps
+ * @see https://shelving.cc/ui/ArrayRadioInputsProps
  */
 export interface ArrayRadioInputsProps<T> extends ValueInputProps<T> {
 	/** Array of values to show in the list of radios. */
@@ -24,7 +24,7 @@ export interface ArrayRadioInputsProps<T> extends ValueInputProps<T> {
  *
  * @returns Element rendering one radio per item plus an optional empty placeholder radio.
  * @example <ArrayRadioInputs name="size" items={["s", "m", "l"]} value={size} onValue={setSize} />
- * @see https://dhoulb.github.io/shelving/ui/form/ArrayRadioInputs/ArrayRadioInputs
+ * @see https://shelving.cc/ui/ArrayRadioInputs
  */
 export function ArrayRadioInputs<T>({
 	value,

--- a/modules/ui/form/Button.tsx
+++ b/modules/ui/form/Button.tsx
@@ -10,7 +10,7 @@ import { Clickable, type ClickableProps } from "./Clickable.js";
 /**
  * Styling variants for a `Button`, combining flex, color, status, and typography options with button-specific toggles.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Button/ButtonVariants
+ * @see https://shelving.cc/ui/ButtonVariants
  */
 export interface ButtonVariants extends FlexVariants, ColorVariants, StatusVariants, TypographyVariants {
 	/** This is the default button in a form and should be displayed stronger. */
@@ -31,7 +31,7 @@ export interface ButtonVariants extends FlexVariants, ColorVariants, StatusVaria
  * @param variants The button styling variants (flex, color, status, typography, plus button toggles).
  * @returns A space-separated `className` string combining all the resolved variant classes.
  * @example getButtonClass({ color: "primary", small: true }) // "button …"
- * @see https://dhoulb.github.io/shelving/ui/form/Button/getButtonClass
+ * @see https://shelving.cc/ui/getButtonClass
  */
 export function getButtonClass(variants: ButtonVariants): string {
 	return getClass(
@@ -53,7 +53,7 @@ interface ButtonProps extends ButtonVariants, ClickableProps {}
  * @kind component
  * @example <Button onClick={save} color="primary">Save</Button>
  * @example <Button href="/about">About</Button>
- * @see https://dhoulb.github.io/shelving/ui/form/Button/Button
+ * @see https://shelving.cc/ui/Button
  */
 export function Button(props: ButtonProps): ReactElement {
 	return <Clickable {...props} className={getButtonClass(props)} />;

--- a/modules/ui/form/ButtonInput.tsx
+++ b/modules/ui/form/ButtonInput.tsx
@@ -9,7 +9,7 @@ import INPUT_CSS from "./Input.module.css";
 /**
  * Props for `ButtonInput`, a clickable element styled to match form inputs.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonInput/ButtonInputProps
+ * @see https://shelving.cc/ui/ButtonInputProps
  */
 export interface ButtonInputProps extends InputProps, ClickableProps, FlexVariants, InputVariants {}
 
@@ -20,7 +20,7 @@ export interface ButtonInputProps extends InputProps, ClickableProps, FlexVarian
  * @returns A `Clickable` element styled with the button-input class.
  * @kind component
  * @example <ButtonInput name="choose" onClick={open}>Choose…</ButtonInput>
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonInput/ButtonInput
+ * @see https://shelving.cc/ui/ButtonInput
  */
 export function ButtonInput({ title, placeholder, children = title, ...props }: ButtonInputProps): ReactElement {
 	const hasChildren = notNullish(children);

--- a/modules/ui/form/ButtonInputPopover.tsx
+++ b/modules/ui/form/ButtonInputPopover.tsx
@@ -9,7 +9,7 @@ import { Popover, type PopoverChildren } from "./Popover.js";
 /**
  * Props for `ButtonInputPopover`, an input button that toggles an adjacent popover.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonInputPopover/ButtonInputPopoverProps
+ * @see https://shelving.cc/ui/ButtonInputPopoverProps
  */
 export interface ButtonInputPopoverProps extends InputProps {
 	children: PopoverChildren;
@@ -23,7 +23,7 @@ export interface ButtonInputPopoverProps extends InputProps {
  *
  * @returns A `Popover` wrapping a `ButtonInput` that toggles it open and closed.
  * @example <ButtonInputPopover name="filter">{label}{panel}</ButtonInputPopover>
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonInputPopover/ButtonInputPopover
+ * @see https://shelving.cc/ui/ButtonInputPopover
  */
 export function ButtonInputPopover({
 	children: [buttonChildren, ...popoverChildren], //

--- a/modules/ui/form/ButtonPopover.tsx
+++ b/modules/ui/form/ButtonPopover.tsx
@@ -8,7 +8,7 @@ import { Popover, type PopoverChildren } from "./Popover.js";
 /**
  * Props for `ButtonPopover`, a button that toggles an adjacent popover.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonPopover/ButtonPopoverProps
+ * @see https://shelving.cc/ui/ButtonPopoverProps
  */
 export interface ButtonPopoverProps extends ButtonVariants {
 	children: PopoverChildren;
@@ -22,7 +22,7 @@ export interface ButtonPopoverProps extends ButtonVariants {
  *
  * @returns A `Popover` wrapping a `Button` that toggles it open and closed.
  * @example <ButtonPopover>{label}{panel}</ButtonPopover>
- * @see https://dhoulb.github.io/shelving/ui/form/ButtonPopover/ButtonPopover
+ * @see https://shelving.cc/ui/ButtonPopover
  */
 export function ButtonPopover({
 	children: [buttonChildren, ...popoverChildren], //

--- a/modules/ui/form/CheckboxInput.tsx
+++ b/modules/ui/form/CheckboxInput.tsx
@@ -9,7 +9,7 @@ import INPUT_CSS from "./Input.module.css";
 /**
  * Props for `CheckboxInput`, a boolean-valued checkbox input.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/CheckboxInput/CheckboxProps
+ * @see https://shelving.cc/ui/CheckboxProps
  */
 export interface CheckboxProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants, InputVariants {}
 
@@ -19,7 +19,7 @@ export interface CheckboxProps extends ValueInputProps<boolean>, OptionalChildPr
  *
  * @returns A `<label>` wrapping the checkbox and its label content.
  * @example <CheckboxInput name="agree" value={agree} onValue={setAgree}>I agree</CheckboxInput>
- * @see https://dhoulb.github.io/shelving/ui/form/CheckboxInput/CheckboxInput
+ * @see https://shelving.cc/ui/CheckboxInput
  */
 export function CheckboxInput({
 	name,

--- a/modules/ui/form/ChoiceRadioInputs.tsx
+++ b/modules/ui/form/ChoiceRadioInputs.tsx
@@ -11,7 +11,7 @@ const MAX_ROW_OPTIONS = 2;
 /**
  * Props for `ChoiceRadioInputs`, which renders a radio for each entry in a `ChoiceOptions` set.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/ChoiceRadioInputs/ChoiceRadioInputsProps
+ * @see https://shelving.cc/ui/ChoiceRadioInputsProps
  */
 export interface ChoiceRadioInputsProps<T extends string> extends ValueInputProps<T> {
 	/** Options for the radios. */
@@ -30,7 +30,7 @@ export interface ChoiceRadioInputsProps<T extends string> extends ValueInputProp
  * @returns Element rendering one radio per option plus an optional empty placeholder radio.
  * @kind component
  * @example <ChoiceRadioInputs name="role" options={{ admin: "Admin", user: "User" }} value={role} onValue={setRole} />
- * @see https://dhoulb.github.io/shelving/ui/form/ChoiceRadioInputs/ChoiceRadioInputs
+ * @see https://shelving.cc/ui/ChoiceRadioInputs
  */
 export function ChoiceRadioInputs<T extends string>(props: ChoiceRadioInputsProps<T>): ReactElement;
 export function ChoiceRadioInputs({

--- a/modules/ui/form/Clickable.tsx
+++ b/modules/ui/form/Clickable.tsx
@@ -18,14 +18,14 @@ import type { OptionalChildProps } from "../util/props.js";
  *
  * @param event The `MouseEvent` from the underlying `<button>`.
  * @returns A `ReactNode` (shown as a success notice), nothing, or a promise of either.
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/ClickableCallback
+ * @see https://shelving.cc/ui/ClickableCallback
  */
 export type ClickableCallback = (event: MouseEvent<HTMLButtonElement>) => ReactNode | void | PromiseLike<ReactNode | void>;
 
 /**
  * Props for a thing that can be clicked — either has a string `href` link or an `onClick` callback handler.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/ClickableProps
+ * @see https://shelving.cc/ui/ClickableProps
  */
 export interface ClickableProps extends OptionalChildProps {
 	/** Whether the clickable is currently disabled. */
@@ -45,7 +45,7 @@ export interface ClickableProps extends OptionalChildProps {
 /**
  * Props for a clickable that also accepts a `className` for styling.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/StylableClickableProps
+ * @see https://shelving.cc/ui/StylableClickableProps
  */
 export interface StylableClickableProps extends ClickableProps {
 	className?: string | undefined;
@@ -58,7 +58,7 @@ export interface StylableClickableProps extends ClickableProps {
  * @kind component
  * @example <Clickable href="/about">About</Clickable>
  * @example <Clickable onClick={save}>Save</Clickable>
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/Clickable
+ * @see https://shelving.cc/ui/Clickable
  */
 export function Clickable(props: StylableClickableProps): ReactElement {
 	return "href" in props ? (
@@ -76,7 +76,7 @@ export function Clickable(props: StylableClickableProps): ReactElement {
  * - Sets `aria-current="page"` when the link points at the current URL.
  *
  * @example <LinkClickable href="/about" className="link">About</LinkClickable>
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/LinkClickable
+ * @see https://shelving.cc/ui/LinkClickable
  */
 export function LinkClickable({
 	href,
@@ -114,7 +114,7 @@ export function LinkClickable({
  * - Disabled and ignores clicks while a previous click is still pending.
  *
  * @example <ButtonClickable onClick={save} className="btn">Save</ButtonClickable>
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/ButtonClickable
+ * @see https://shelving.cc/ui/ButtonClickable
  */
 export function ButtonClickable({
 	onClick,
@@ -155,7 +155,7 @@ export function ButtonClickable({
  * Render a non-interactive `<span>` element, used as the fallback when neither `href` nor `onClick` is provided.
  *
  * @example <SpanClickable className="label">Static</SpanClickable>
- * @see https://dhoulb.github.io/shelving/ui/form/Clickable/SpanClickable
+ * @see https://shelving.cc/ui/SpanClickable
  */
 export function SpanClickable({
 	title,

--- a/modules/ui/form/DataInput.tsx
+++ b/modules/ui/form/DataInput.tsx
@@ -10,7 +10,7 @@ import { SchemaInput } from "./SchemaInput.js";
 /**
  * Props for `DataInput`, a composite input that edits an object of schema-validated sub-fields.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/DataInput/DataInputProps
+ * @see https://shelving.cc/ui/DataInputProps
  */
 export interface DataInputProps<T extends Data> extends ValueInputProps<T> {
 	/** Schema for the sub-fields of this input. */
@@ -24,7 +24,7 @@ export interface DataInputProps<T extends Data> extends ValueInputProps<T> {
  * @returns Element rendering one input per property, laid out in a row or column.
  * @kind component
  * @example <DataInput name="address" props={addressSchemas} value={address} onValue={setAddress} />
- * @see https://dhoulb.github.io/shelving/ui/form/DataInput/DataInput
+ * @see https://shelving.cc/ui/DataInput
  */
 export function DataInput<T extends Data>(props: DataInputProps<T>): ReactElement;
 export function DataInput({

--- a/modules/ui/form/DateInput.tsx
+++ b/modules/ui/form/DateInput.tsx
@@ -15,7 +15,7 @@ const _DATE_TO_STRING: { [K in DateInputType]: (d: PossibleDate | undefined) => 
 /**
  * Props for `DateInput`, a date/time `<input>` that emits an ISO string value.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/DateInput/DateInputProps
+ * @see https://shelving.cc/ui/DateInputProps
  */
 export interface DateInputProps extends ValueInputProps<string, PossibleDate>, InputVariants {
 	min?: PossibleDate | undefined;
@@ -30,7 +30,7 @@ export interface DateInputProps extends ValueInputProps<string, PossibleDate>, I
  *
  * @returns A native date/time `<input>` element.
  * @example <DateInput name="dob" input="date" value={dob} onValue={setDob} />
- * @see https://dhoulb.github.io/shelving/ui/form/DateInput/DateInput
+ * @see https://shelving.cc/ui/DateInput
  */
 export function DateInput({
 	name,

--- a/modules/ui/form/DictionaryInput.tsx
+++ b/modules/ui/form/DictionaryInput.tsx
@@ -16,7 +16,7 @@ import { TextInput } from "./TextInput.js";
 /**
  * Props for `DictionaryInput`, a repeating input that edits a dictionary of schema-validated items.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/DictionaryInput/DictionaryInputProps
+ * @see https://shelving.cc/ui/DictionaryInputProps
  */
 export interface DictionaryInputProps<T> extends ValueInputProps<ImmutableDictionary<T>> {
 	one?: string;
@@ -35,7 +35,7 @@ export interface DictionaryInputProps<T> extends ValueInputProps<ImmutableDictio
  * @returns Element rendering one key/value row per entry plus add/clear controls.
  * @kind component
  * @example <DictionaryInput name="meta" items={STRING} value={meta} onValue={setMeta} />
- * @see https://dhoulb.github.io/shelving/ui/form/DictionaryInput/DictionaryInput
+ * @see https://shelving.cc/ui/DictionaryInput
  */
 export function DictionaryInput<T>(props: DictionaryInputProps<T>): ReactElement;
 export function DictionaryInput({

--- a/modules/ui/form/Field.tsx
+++ b/modules/ui/form/Field.tsx
@@ -7,7 +7,7 @@ import styles from "./Field.module.css";
 /**
  * Props for `Field`, a labelled wrapper around a form control.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Field/FieldProps
+ * @see https://shelving.cc/ui/FieldProps
  */
 export interface FieldProps extends ChildProps {
 	title?: ReactNode | undefined;
@@ -22,7 +22,7 @@ export interface FieldProps extends ChildProps {
  * A `<Field>` wraps around a form control/input, to shows a small `<label>` above it.
  *
  * @kind component
- * @see https://dhoulb.github.io/shelving/ui/form/Field/Field
+ * @see https://shelving.cc/ui/Field
  */
 export function Field({ title, description, message, half, children }: FieldProps): ReactElement {
 	return (

--- a/modules/ui/form/FileInput.tsx
+++ b/modules/ui/form/FileInput.tsx
@@ -5,7 +5,7 @@ import { getInputClass, type InputVariants, type ValueInputProps } from "./Input
 /**
  * Props for `FileInput`, an `<input type="file">` that emits the selected `File`.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/FileInput/FileInputProps
+ * @see https://shelving.cc/ui/FileInputProps
  */
 export interface FileInputProps extends ValueInputProps<string | File>, InputVariants {
 	types?: FileTypes | undefined;
@@ -17,7 +17,7 @@ export interface FileInputProps extends ValueInputProps<string | File>, InputVar
  *
  * @returns A native `<input type="file">` element.
  * @example <FileInput name="avatar" types={{ png: "image/png" }} onValue={setFile} />
- * @see https://dhoulb.github.io/shelving/ui/form/FileInput/FileInput
+ * @see https://shelving.cc/ui/FileInput
  */
 export function FileInput({
 	name,

--- a/modules/ui/form/Form.tsx
+++ b/modules/ui/form/Form.tsx
@@ -20,7 +20,7 @@ import { FormStore } from "./FormStore.js";
  * - Returned value (if defined) is notified to the user using `notifySuccess()`.
  * - Thrown value is notified to the user using `notifyError()`.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Form/FormCallback
+ * @see https://shelving.cc/ui/FormCallback
  */
 export type FormCallback<T extends Data> = (
 	data: T,
@@ -30,7 +30,7 @@ export type FormCallback<T extends Data> = (
 /**
  * Props for `Form`, the schema-driven form wrapper component.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Form/FormProps
+ * @see https://shelving.cc/ui/FormProps
  */
 export interface FormProps<T extends Data> extends OptionalChildProps {
 	/** Schema for the form. */
@@ -53,7 +53,7 @@ export interface FormProps<T extends Data> extends OptionalChildProps {
  * @returns A `<form>` element wrapping the fields in a `FormContext` provider.
  * @kind component
  * @example <Form schema={USER_SCHEMA} onSubmit={save} />
- * @see https://dhoulb.github.io/shelving/ui/form/Form/Form
+ * @see https://shelving.cc/ui/Form
  */
 export function Form<T extends Data>(props: FormProps<T>): ReactElement;
 export function Form({
@@ -113,7 +113,7 @@ export function Form({
  * @param args Additional arguments forwarded to the callback.
  * @returns `true` on success, `false` on failure (or a `Promise` resolving to one).
  * @example callNotifiedForm(data, store, formEl, onSubmit, event)
- * @see https://dhoulb.github.io/shelving/ui/form/Form/callNotifiedForm
+ * @see https://shelving.cc/ui/callNotifiedForm
  */
 export function callNotifiedForm<T extends Data, A extends Arguments>(
 	value: T,
@@ -140,7 +140,7 @@ export function callNotifiedForm<T extends Data, A extends Arguments>(
  * @param pending The pending result to await.
  * @returns A `Promise` resolving to `true` on success or `false` on failure.
  * @example await awaitNotifiedForm(store, formEl, pending)
- * @see https://dhoulb.github.io/shelving/ui/form/Form/awaitNotifiedForm
+ * @see https://shelving.cc/ui/awaitNotifiedForm
  */
 export async function awaitNotifiedForm<T extends Data>(
 	store: FormStore<T>,
@@ -165,7 +165,7 @@ export async function awaitNotifiedForm<T extends Data>(
  * @param thrown The value thrown during submit.
  * @returns Always `false`, signalling the submit failed.
  * @example notifyThrownForm(store, formEl, thrown)
- * @see https://dhoulb.github.io/shelving/ui/form/Form/notifyThrownForm
+ * @see https://shelving.cc/ui/notifyThrownForm
  */
 export function notifyThrownForm<T extends Data>(store: FormStore<T>, form: HTMLFormElement, thrown: unknown): false {
 	store.reason = thrown;

--- a/modules/ui/form/FormContext.tsx
+++ b/modules/ui/form/FormContext.tsx
@@ -10,7 +10,7 @@ import { isSchemaRequired, type SchemaInputProps } from "./SchemaInput.js";
 /**
  * React context holding the current `FormStore`, provided by the `Form` component.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/FormContext/FormContext
+ * @see https://shelving.cc/ui/FormContext
  */
 export const FormContext = createContext<FormStore<Data> | undefined>(undefined);
 FormContext.displayName = "FormContext";
@@ -22,7 +22,7 @@ FormContext.displayName = "FormContext";
  * @returns The current `FormStore` instance.
  * @throws `RequiredError` if called outside a `Form` component.
  * @example const form = requireForm();
- * @see https://dhoulb.github.io/shelving/ui/form/FormContext/requireForm
+ * @see https://shelving.cc/ui/requireForm
  */
 export function requireForm<T extends Data = Data>(caller?: AnyCaller): FormStore<T>;
 export function requireForm(): FormStore<Data> {
@@ -37,7 +37,7 @@ export function requireForm(): FormStore<Data> {
  * @param form Form store to read from, defaulting to the current form context.
  * @returns Props (`name`, `schema`, `value`, `onValue`, `message`, `required`) ready to spread onto an input.
  * @example const field = useField("email");
- * @see https://dhoulb.github.io/shelving/ui/form/FormContext/useField
+ * @see https://shelving.cc/ui/useField
  */
 export function useField<T, I = never>(name: string, form?: FormStore<{ [name: string]: T }>): SchemaInputProps<Schema<T>, I>;
 export function useField(name: string, form: FormStore<Data> = requireForm(useField)): SchemaInputProps<Schema<unknown>> {

--- a/modules/ui/form/FormFields.tsx
+++ b/modules/ui/form/FormFields.tsx
@@ -11,7 +11,7 @@ import { SchemaInput } from "./SchemaInput.js";
  * @returns A `<Field>` wrapping a `SchemaInput` bound to the named field.
  * @kind component
  * @example <FormField name="email" />
- * @see https://dhoulb.github.io/shelving/ui/form/FormFields/FormField
+ * @see https://shelving.cc/ui/FormField
  */
 export function FormField({ name, ...props }: InputProps): ReactElement {
 	const field = useField(name);
@@ -30,7 +30,7 @@ export function FormField({ name, ...props }: InputProps): ReactElement {
  * @returns A fragment of `FormField` elements, one per schema property.
  * @kind component
  * @example <FormFields />
- * @see https://dhoulb.github.io/shelving/ui/form/FormFields/FormFields
+ * @see https://shelving.cc/ui/FormFields
  */
 export function FormFields(): ReactElement {
 	const form = useStore(requireForm());

--- a/modules/ui/form/FormFooter.tsx
+++ b/modules/ui/form/FormFooter.tsx
@@ -8,7 +8,7 @@ import { SubmitButton } from "./SubmitButton.js";
 /**
  * Props for `FormFooter`, the submit-button-and-message footer for a form.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/FormFooter/FormFooterProps
+ * @see https://shelving.cc/ui/FormFooterProps
  */
 export interface FormFooterProps extends OptionalChildProps {
 	submit?: ReactNode | undefined;
@@ -22,7 +22,7 @@ export interface FormFooterProps extends OptionalChildProps {
  * @returns A footer element with the submit row and form message.
  * @kind component
  * @example <FormFooter submit="Save" />
- * @see https://dhoulb.github.io/shelving/ui/form/FormFooter/FormFooter
+ * @see https://shelving.cc/ui/FormFooter
  */
 export function FormFooter({ children, submit }: FormFooterProps): ReactElement {
 	return (

--- a/modules/ui/form/FormInput.tsx
+++ b/modules/ui/form/FormInput.tsx
@@ -6,7 +6,7 @@ import { SchemaInput } from "./SchemaInput.js";
 /**
  * Props for `FormInput`, a bare `SchemaInput` bound to a named form field.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/FormInput/FormInputProps
+ * @see https://shelving.cc/ui/FormInputProps
  */
 export interface FormInputProps extends InputProps {}
 
@@ -17,7 +17,7 @@ export interface FormInputProps extends InputProps {}
  * @returns A `SchemaInput` bound to the named field.
  * @kind component
  * @example <FormInput name="email" />
- * @see https://dhoulb.github.io/shelving/ui/form/FormInput/FormInput
+ * @see https://shelving.cc/ui/FormInput
  */
 export function FormInput({ name, ...props }: FormInputProps): ReactElement {
 	const field = useField(name);
@@ -30,7 +30,7 @@ export function FormInput({ name, ...props }: FormInputProps): ReactElement {
  * @returns A fragment of `FormInput` elements, one per schema property.
  * @kind component
  * @example <FormInputs />
- * @see https://dhoulb.github.io/shelving/ui/form/FormInput/FormInputs
+ * @see https://shelving.cc/ui/FormInputs
  */
 export function FormInputs(): ReactElement {
 	return (

--- a/modules/ui/form/FormMessage.tsx
+++ b/modules/ui/form/FormMessage.tsx
@@ -10,7 +10,7 @@ import { requireForm } from "./FormContext.js";
  * @returns A `<Message status="error">` containing the message, or `null` when empty.
  * @kind component
  * @example <FormMessage />
- * @see https://dhoulb.github.io/shelving/ui/form/FormMessage/FormMessage
+ * @see https://shelving.cc/ui/FormMessage
  */
 export function FormMessage(props: Omit<MessageProps, "children">): ReactElement | null {
 	const message = useStore(requireForm().messages).get("");

--- a/modules/ui/form/FormNotice.tsx
+++ b/modules/ui/form/FormNotice.tsx
@@ -10,7 +10,7 @@ import { requireForm } from "./FormContext.js";
  * @returns A `<Notice status="error">` containing the message, or `null` when empty.
  * @kind component
  * @example <FormNotice />
- * @see https://dhoulb.github.io/shelving/ui/form/FormNotice/FormNotice
+ * @see https://shelving.cc/ui/FormNotice
  */
 export function FormNotice(props: Omit<NoticeProps, "children">): ReactElement | null {
 	const message = useStore(requireForm().messages).get("");

--- a/modules/ui/form/FormNotify.tsx
+++ b/modules/ui/form/FormNotify.tsx
@@ -9,7 +9,7 @@ import { requireForm } from "./FormContext.js";
  *
  * @returns Nothing — this component only triggers a side effect.
  * @example <FormNotify />
- * @see https://dhoulb.github.io/shelving/ui/form/FormNotify/FormNotify
+ * @see https://shelving.cc/ui/FormNotify
  */
 export function FormNotify(): void {
 	const message = useStore(requireForm().messages).get("");

--- a/modules/ui/form/FormStore.tsx
+++ b/modules/ui/form/FormStore.tsx
@@ -16,7 +16,7 @@ import { getRandomKey } from "../../util/random.js";
  * - Assigning a string `reason` splits it into per-field messages rather than a global failure.
  *
  * @example const store = new FormStore(USER_SCHEMA, { name: "Dave" });
- * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore
+ * @see https://shelving.cc/ui/FormStore
  */
 export class FormStore<T extends Data> extends DataStore<Partial<T>> implements AsyncDisposable {
 	/** Unique ID for the form. */
@@ -40,7 +40,7 @@ export class FormStore<T extends Data> extends DataStore<Partial<T>> implements 
 	 * The current value validated against the schema, also written back to `this.value`.
 	 *
 	 * @throws A `string` validation message if the current value is invalid.
-	 * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore/validated
+	 * @see https://shelving.cc/ui/FormStore/validated
 	 */
 	get validated(): T {
 		return (this.value = this.schema.validate(this.value));
@@ -65,7 +65,7 @@ export class FormStore<T extends Data> extends DataStore<Partial<T>> implements 
 	 * @param partialData Initial (possibly partial) data for the form.
 	 * @param messages Initial messages as a dictionary, or a string with `fieldName:` style lines.
 	 * @example new FormStore(USER_SCHEMA, { name: "Dave" })
-	 * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore/constructor
+	 * @see https://shelving.cc/ui/FormStore/constructor
 	 */
 	constructor(schema: DataSchema<T>, partialData: Partial<T> = {}, messages?: ImmutableDictionary<string> | string | undefined) {
 		super(partialData);
@@ -81,7 +81,7 @@ export class FormStore<T extends Data> extends DataStore<Partial<T>> implements 
 	 * @returns The `Schema` for that field.
 	 * @throws `RequiredError` if no schema exists for the named field.
 	 * @example store.requireSchema("email")
-	 * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore/requireSchema
+	 * @see https://shelving.cc/ui/FormStore/requireSchema
 	 */
 	requireSchema<K extends DataKey<T>>(name: K): Schema<T[K]> {
 		const schema = this.schema.props[name];
@@ -98,7 +98,7 @@ export class FormStore<T extends Data> extends DataStore<Partial<T>> implements 
 	 * @param unsafeValue The unvalidated value to store for the field.
 	 * @returns Nothing.
 	 * @example store.publish("email", "dave@shax.com")
-	 * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore/publish
+	 * @see https://shelving.cc/ui/FormStore/publish
 	 */
 	publish<K extends DataKey<T>>(name: K, unsafeValue: T[K]): void {
 		this.abort();
@@ -128,7 +128,7 @@ export class FormStore<T extends Data> extends DataStore<Partial<T>> implements 
 	 * @param args Additional arguments forwarded to the callback.
 	 * @returns `true` on success, `false` on validation failure (or a `Promise` resolving to one).
 	 * @example store.submit(saveUser)
-	 * @see https://dhoulb.github.io/shelving/ui/form/FormStore/FormStore/submit
+	 * @see https://shelving.cc/ui/FormStore/submit
 	 */
 	submit<A extends Arguments>(callback?: ((value: T, ...args: A) => void) | undefined, ...args: A): boolean | Promise<boolean> {
 		try {

--- a/modules/ui/form/Input.tsx
+++ b/modules/ui/form/Input.tsx
@@ -11,7 +11,7 @@ import INPUT_CSS from "./Input.module.css";
  * - Extends `WidthVariants` so any input can be sized (e.g. `<CheckboxInput width="fit">` to shrink to its content).
  * - Designed to grow: new cross-cutting input styling props (e.g. spacing) should be added here so every input picks them up consistently.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/InputVariants
+ * @see https://shelving.cc/ui/InputVariants
  */
 export interface InputVariants extends WidthVariants {}
 
@@ -20,7 +20,7 @@ export interface InputVariants extends WidthVariants {}
  *
  * @returns The merged base input `className` string.
  * @example getClass(getInputClass(props), getModuleClass(INPUT_CSS, "text")) // a text input that also honours width variants
- * @see https://dhoulb.github.io/shelving/ui/form/Input/getInputClass
+ * @see https://shelving.cc/ui/getInputClass
  */
 export function getInputClass(props: InputVariants): string {
 	return getClass(getModuleClass(INPUT_CSS, "input"), getWidthClass(props));
@@ -29,7 +29,7 @@ export function getInputClass(props: InputVariants): string {
 /**
  * Base props shared by every form input (name, title, placeholder, required/disabled state, and error message).
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Input/InputProps
+ * @see https://shelving.cc/ui/InputProps
  */
 export interface InputProps {
 	/** The `name=""` prop of the input. */

--- a/modules/ui/form/NumberInput.tsx
+++ b/modules/ui/form/NumberInput.tsx
@@ -10,7 +10,7 @@ type NumberFormatter = (num: number) => string;
 /**
  * Props for `NumberInput`, a text-based numeric input bound to a `number` value.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/NumberInput/NumberInputProps
+ * @see https://shelving.cc/ui/NumberInputProps
  */
 export interface NumberInputProps extends ValueInputProps<number>, InputVariants {
 	min?: number | undefined;
@@ -25,7 +25,7 @@ export interface NumberInputProps extends ValueInputProps<number>, InputVariants
  *
  * @returns A numeric `<input>` element.
  * @example <NumberInput name="age" value={age} onValue={setAge} />
- * @see https://dhoulb.github.io/shelving/ui/form/NumberInput/NumberInput
+ * @see https://shelving.cc/ui/NumberInput
  */
 export function NumberInput({
 	name,

--- a/modules/ui/form/OutputInput.tsx
+++ b/modules/ui/form/OutputInput.tsx
@@ -9,7 +9,7 @@ import INPUT_CSS from "./Input.module.css";
 /**
  * Props for `OutputInput`, a read-only `<output>` styled to match form inputs.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/OutputInput/OutputInputProps
+ * @see https://shelving.cc/ui/OutputInputProps
  */
 export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVariants, InputVariants {}
 
@@ -19,7 +19,7 @@ export interface OutputInputProps extends InputProps, OptionalChildProps, FlexVa
  * @returns An `<output>` element styled like an input.
  * @kind component
  * @example <OutputInput title="Status">Active</OutputInput>
- * @see https://dhoulb.github.io/shelving/ui/form/OutputInput/OutputInput
+ * @see https://shelving.cc/ui/OutputInput
  */
 export function OutputInput({ title, placeholder, children = title, ...props }: OutputInputProps): ReactElement {
 	const hasChildren = notNullish(children);

--- a/modules/ui/form/Popover.tsx
+++ b/modules/ui/form/Popover.tsx
@@ -13,7 +13,7 @@ import styles from "./Popover.module.css";
 /**
  * Children tuple for `Popover`: a leading trigger node followed by the popover's contents.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Popover/PopoverChildren
+ * @see https://shelving.cc/ui/PopoverChildren
  */
 export type PopoverChildren = [
 	/**
@@ -30,7 +30,7 @@ export type PopoverChildren = [
 /**
  * Props for `Popover`, a trigger element that reveals floating content.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Popover/PopoverProps
+ * @see https://shelving.cc/ui/PopoverProps
  */
 export interface PopoverProps {
 	/** Children for the popover. */
@@ -48,7 +48,7 @@ export interface PopoverProps {
  *
  * @returns A wrapper element containing the trigger and (when open) the popover panel.
  * @example <Popover>{trigger}{panelContent}</Popover>
- * @see https://dhoulb.github.io/shelving/ui/form/Popover/Popover
+ * @see https://shelving.cc/ui/Popover
  *
  * @todo DH: Would love to use new HTML `popover="auto"` functionality for this but the anchor positioning it needs is not supported everywhere yet.
  */

--- a/modules/ui/form/Progress.tsx
+++ b/modules/ui/form/Progress.tsx
@@ -5,7 +5,7 @@ import styles from "./Progress.module.css";
 /**
  * Props for `Progress`, a continuous horizontal progress bar.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Progress/ProgressProps
+ * @see https://shelving.cc/ui/ProgressProps
  */
 export interface ProgressProps {
 	value: number;
@@ -20,7 +20,7 @@ export interface ProgressProps {
  * @returns A progress bar element.
  * @kind component
  * @example <Progress value={0.5} />
- * @see https://dhoulb.github.io/shelving/ui/form/Progress/Progress
+ * @see https://shelving.cc/ui/Progress
  */
 export function Progress({ value, success, warning, danger }: ProgressProps): ReactElement | null {
 	const clamped = Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
@@ -44,7 +44,7 @@ export function Progress({ value, success, warning, danger }: ProgressProps): Re
 /**
  * Props for `SegmentedProgress`, a stepped progress bar of discrete segments.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/Progress/SegmentedProgressProps
+ * @see https://shelving.cc/ui/SegmentedProgressProps
  */
 export interface SegmentedProgressProps {
 	total: number;
@@ -60,7 +60,7 @@ export interface SegmentedProgressProps {
  * @returns A segmented progress bar element, or `null` when `total` is not positive.
  * @kind component
  * @example <SegmentedProgress total={4} current={1} />
- * @see https://dhoulb.github.io/shelving/ui/form/Progress/SegmentedProgress
+ * @see https://shelving.cc/ui/SegmentedProgress
  */
 export function SegmentedProgress({ total, current, success, warning, danger }: SegmentedProgressProps): ReactElement | null {
 	if (total <= 0) return null;

--- a/modules/ui/form/QueryInput.tsx
+++ b/modules/ui/form/QueryInput.tsx
@@ -16,7 +16,7 @@ import { SchemaInput } from "./SchemaInput.js";
 /**
  * Props for `QueryInput`, a combo box that queries items of type `O` from an input of type `I`.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/QueryInput/QueryInputProps
+ * @see https://shelving.cc/ui/QueryInputProps
  */
 export interface QueryInputProps<I, O> extends ValueInputProps<O> {
 	/** Schema input */
@@ -49,7 +49,7 @@ export interface QueryInputProps<I, O> extends ValueInputProps<O> {
  *
  * @returns A combo box element wrapping the input and results popover.
  * @example <QueryInput schema={SEARCH} onQuery={search} value={user} onValue={setUser} />
- * @see https://dhoulb.github.io/shelving/ui/form/QueryInput/QueryInput
+ * @see https://shelving.cc/ui/QueryInput
  */
 export function QueryInput<I, O>({
 	empty = "No results",

--- a/modules/ui/form/RadioInput.tsx
+++ b/modules/ui/form/RadioInput.tsx
@@ -9,7 +9,7 @@ import INPUT_CSS from "./Input.module.css";
 /**
  * Props for `RadioInput`, a single labelled radio button styled as an input.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/RadioInput/RadioInputProps
+ * @see https://shelving.cc/ui/RadioInputProps
  */
 export interface RadioInputProps extends ValueInputProps<boolean>, OptionalChildProps, FlexVariants, InputVariants {}
 
@@ -19,7 +19,7 @@ export interface RadioInputProps extends ValueInputProps<boolean>, OptionalChild
  *
  * @returns A `<label>` wrapping the radio button and its label content.
  * @example <RadioInput name="plan" value={isPro} onValue={selectPro}>Pro</RadioInput>
- * @see https://dhoulb.github.io/shelving/ui/form/RadioInput/RadioInput
+ * @see https://shelving.cc/ui/RadioInput
  */
 export function RadioInput({
 	name,

--- a/modules/ui/form/SchemaInput.tsx
+++ b/modules/ui/form/SchemaInput.tsx
@@ -38,7 +38,7 @@ import { TextInput } from "./TextInput.js";
  * @param schema The schema to test.
  * @returns `true` if the schema is required, `false` if it is optional or nullable.
  * @example isSchemaRequired(STRING) // true
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/isSchemaRequired
+ * @see https://shelving.cc/ui/isSchemaRequired
  */
 export function isSchemaRequired(schema: Schema): boolean {
 	return !(schema instanceof OptionalSchema || schema instanceof NullableSchema);
@@ -47,7 +47,7 @@ export function isSchemaRequired(schema: Schema): boolean {
 /**
  * Props for `SchemaInput` and its variants: a `schema` plus the value input props it drives.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/SchemaInputProps
+ * @see https://shelving.cc/ui/SchemaInputProps
  */
 export interface SchemaInputProps<T extends Schema, I = never> extends ValueInputProps<ValidatorType<T>, I> {
 	schema: T;
@@ -63,7 +63,7 @@ export interface SchemaInputProps<T extends Schema, I = never> extends ValueInpu
  * @kind component
  * @example <SchemaInput name="email" schema={EMAIL} /> // Outputs a `<TextInput>` for the "email" property.
  * @example <SchemaInput name="age" schema={AGE} /> // Outputs a `<NumberInput>` for the "age" property.
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/SchemaInput
+ * @see https://shelving.cc/ui/SchemaInput
  */
 export function SchemaInput<T extends Schema>(props: SchemaInputProps<T>): ReactElement;
 export function SchemaInput({
@@ -107,7 +107,7 @@ export function SchemaInput({
 /**
  * Props for `DateSchemaInput`, the `DateSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DateSchemaInputProps
+ * @see https://shelving.cc/ui/DateSchemaInputProps
  */
 export interface DateSchemaInputProps extends SchemaInputProps<DateSchema, unknown> {}
 
@@ -117,7 +117,7 @@ export interface DateSchemaInputProps extends SchemaInputProps<DateSchema, unkno
  * @returns A `DateInput` element bound to the schema.
  * @kind component
  * @example <DateSchemaInput name="dob" schema={DATE} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DateSchemaInput
+ * @see https://shelving.cc/ui/DateSchemaInput
  */
 export function DateSchemaInput({ schema, value, ...props }: DateSchemaInputProps): ReactElement {
 	return <DateInput {...schema} value={getString(value)} {...props} />;
@@ -126,7 +126,7 @@ export function DateSchemaInput({ schema, value, ...props }: DateSchemaInputProp
 /**
  * Props for `NumberSchemaInput`, the `NumberSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/NumberSchemaInputProps
+ * @see https://shelving.cc/ui/NumberSchemaInputProps
  */
 export interface NumberSchemaInputProps extends SchemaInputProps<NumberSchema, unknown> {}
 
@@ -136,7 +136,7 @@ export interface NumberSchemaInputProps extends SchemaInputProps<NumberSchema, u
  * @returns A `NumberInput` element bound to the schema.
  * @kind component
  * @example <NumberSchemaInput name="age" schema={NUMBER} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/NumberSchemaInput
+ * @see https://shelving.cc/ui/NumberSchemaInput
  */
 export function NumberSchemaInput({ schema, value, ...props }: NumberSchemaInputProps): ReactElement {
 	return <NumberInput {...schema} value={getNumber(value)} formatter={num => schema.format(num)} {...props} />;
@@ -145,7 +145,7 @@ export function NumberSchemaInput({ schema, value, ...props }: NumberSchemaInput
 /**
  * Props for `ChoiceSchemaInput`, the `ChoiceSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ChoiceSchemaInputProps
+ * @see https://shelving.cc/ui/ChoiceSchemaInputProps
  */
 export interface ChoiceSchemaInputProps extends SchemaInputProps<ChoiceSchema<string>, unknown> {}
 
@@ -155,7 +155,7 @@ export interface ChoiceSchemaInputProps extends SchemaInputProps<ChoiceSchema<st
  * @returns A `ChoiceRadioInputs` or `SelectInput` element bound to the schema.
  * @kind component
  * @example <ChoiceSchemaInput name="role" schema={ROLE} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ChoiceSchemaInput
+ * @see https://shelving.cc/ui/ChoiceSchemaInput
  */
 export function ChoiceSchemaInput({ schema, value, ...props }: ChoiceSchemaInputProps): ReactElement {
 	const { options } = requireSource(ChoiceSchema, schema);
@@ -166,7 +166,7 @@ export function ChoiceSchemaInput({ schema, value, ...props }: ChoiceSchemaInput
 /**
  * Props for `BooleanSchemaInput`, the `BooleanSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/BooleanSchemaInputProps
+ * @see https://shelving.cc/ui/BooleanSchemaInputProps
  */
 export interface BooleanSchemaInputProps extends SchemaInputProps<BooleanSchema, unknown> {}
 
@@ -176,7 +176,7 @@ export interface BooleanSchemaInputProps extends SchemaInputProps<BooleanSchema,
  * @returns A `CheckboxInput` element bound to the schema.
  * @kind component
  * @example <BooleanSchemaInput name="agree" schema={BOOLEAN} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/BooleanSchemaInput
+ * @see https://shelving.cc/ui/BooleanSchemaInput
  */
 export function BooleanSchemaInput({ schema, value, ...props }: BooleanSchemaInputProps): ReactElement {
 	return <CheckboxInput {...schema} value={!!value} {...props} />;
@@ -185,7 +185,7 @@ export function BooleanSchemaInput({ schema, value, ...props }: BooleanSchemaInp
 /**
  * Props for `StringSchemaInput`, the `StringSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/StringSchemaInputProps
+ * @see https://shelving.cc/ui/StringSchemaInputProps
  */
 export interface StringSchemaInputProps extends SchemaInputProps<StringSchema, unknown> {}
 
@@ -195,7 +195,7 @@ export interface StringSchemaInputProps extends SchemaInputProps<StringSchema, u
  * @returns A `TextInput` element bound to the schema.
  * @kind component
  * @example <StringSchemaInput name="email" schema={EMAIL} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/StringSchemaInput
+ * @see https://shelving.cc/ui/StringSchemaInput
  */
 export function StringSchemaInput({ schema, value, ...props }: StringSchemaInputProps): ReactElement {
 	return <TextInput {...schema} value={getString(value)} formatter={str => schema.format(schema.sanitize(str))} {...props} />;
@@ -204,7 +204,7 @@ export function StringSchemaInput({ schema, value, ...props }: StringSchemaInput
 /**
  * Props for `ArraySchemaInput`, the `ArraySchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ArraySchemaInputProps
+ * @see https://shelving.cc/ui/ArraySchemaInputProps
  */
 export interface ArraySchemaInputProps extends SchemaInputProps<ArraySchema<unknown>, unknown> {}
 
@@ -214,7 +214,7 @@ export interface ArraySchemaInputProps extends SchemaInputProps<ArraySchema<unkn
  * @returns An `ArrayInput` element bound to the schema.
  * @kind component
  * @example <ArraySchemaInput name="tags" schema={TAGS} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/ArraySchemaInput
+ * @see https://shelving.cc/ui/ArraySchemaInput
  */
 export function ArraySchemaInput({ schema, value, ...props }: ArraySchemaInputProps): ReactElement {
 	return <ArrayInput {...schema} value={isArray(value) ? value : undefined} {...props} />;
@@ -223,7 +223,7 @@ export function ArraySchemaInput({ schema, value, ...props }: ArraySchemaInputPr
 /**
  * Props for `DictionarySchemaInput`, the `DictionarySchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DictionarySchemaInputProps
+ * @see https://shelving.cc/ui/DictionarySchemaInputProps
  */
 export interface DictionarySchemaInputProps extends SchemaInputProps<DictionarySchema<unknown>, unknown> {}
 
@@ -233,7 +233,7 @@ export interface DictionarySchemaInputProps extends SchemaInputProps<DictionaryS
  * @returns A `DictionaryInput` element bound to the schema.
  * @kind component
  * @example <DictionarySchemaInput name="meta" schema={META} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DictionarySchemaInput
+ * @see https://shelving.cc/ui/DictionarySchemaInput
  */
 export function DictionarySchemaInput({ schema, value, ...props }: DictionarySchemaInputProps): ReactElement {
 	return <DictionaryInput {...schema} value={isDictionary(value) ? value : undefined} {...props} />;
@@ -242,7 +242,7 @@ export function DictionarySchemaInput({ schema, value, ...props }: DictionarySch
 /**
  * Props for `DataSchemaInput`, the `DataSchema` input variant.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DataSchemaInputProps
+ * @see https://shelving.cc/ui/DataSchemaInputProps
  */
 export interface DataSchemaInputProps extends SchemaInputProps<DataSchema<Data>, unknown> {}
 
@@ -252,7 +252,7 @@ export interface DataSchemaInputProps extends SchemaInputProps<DataSchema<Data>,
  * @returns A `DataInput` element bound to the schema.
  * @kind component
  * @example <DataSchemaInput name="address" schema={ADDRESS} />
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/DataSchemaInput
+ * @see https://shelving.cc/ui/DataSchemaInput
  */
 export function DataSchemaInput({ schema, value, ...props }: DataSchemaInputProps): ReactElement {
 	return <DataInput {...schema} value={isData(value) ? value : undefined} {...props} />;
@@ -261,7 +261,7 @@ export function DataSchemaInput({ schema, value, ...props }: DataSchemaInputProp
 /**
  * Props for `SchemaField`: `SchemaInput` props plus optional `children` to override the input.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/SchemaFieldProps
+ * @see https://shelving.cc/ui/SchemaFieldProps
  */
 export interface SchemaFieldProps extends SchemaInputProps<Schema, unknown>, OptionalChildProps {}
 
@@ -273,7 +273,7 @@ export interface SchemaFieldProps extends SchemaInputProps<Schema, unknown>, Opt
  * @kind component
  * @example <SchemaField name="email" schema={EMAIL} /> // Outputs a `<Field>` wrapping a `<TextInput>`.
  * @example <SchemaField name="age" schema={AGE} /> // Outputs a `<Field>` wrapping a `<NumberInput>`.
- * @see https://dhoulb.github.io/shelving/ui/form/SchemaInput/SchemaField
+ * @see https://shelving.cc/ui/SchemaField
  */
 export function SchemaField({ schema, children, ...props }: SchemaFieldProps): ReactElement {
 	return (

--- a/modules/ui/form/SelectInput.tsx
+++ b/modules/ui/form/SelectInput.tsx
@@ -8,7 +8,7 @@ import INPUT_CSS from "./Input.module.css";
 /**
  * Props for `SelectInput`, a dropdown `<select>` bound to a string value.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SelectInput/SelectProps
+ * @see https://shelving.cc/ui/SelectProps
  */
 export interface SelectProps<T extends string> extends ValueInputProps<T>, InputVariants {
 	/** The options for the select. */
@@ -22,7 +22,7 @@ export interface SelectProps<T extends string> extends ValueInputProps<T>, Input
  * @returns A `<select>` element.
  * @kind component
  * @example <SelectInput name="role" options={ROLES} value={role} onValue={setRole} />
- * @see https://dhoulb.github.io/shelving/ui/form/SelectInput/SelectInput
+ * @see https://shelving.cc/ui/SelectInput
  */
 export function SelectInput<T extends string>(props: SelectProps<T>): ReactElement;
 export function SelectInput({

--- a/modules/ui/form/SubmitButton.tsx
+++ b/modules/ui/form/SubmitButton.tsx
@@ -12,7 +12,7 @@ import { requireForm } from "./FormContext.js";
  *
  * @returns A `<button type="submit">` element bound to the current form.
  * @example <SubmitButton>Save changes</SubmitButton>
- * @see https://dhoulb.github.io/shelving/ui/form/SubmitButton/SubmitButton
+ * @see https://shelving.cc/ui/SubmitButton
  */
 export function SubmitButton({
 	children = SUBMIT_CHILDREN,
@@ -33,7 +33,7 @@ export function SubmitButton({
 /**
  * Props for `SubmitButton`, a form submit button.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/SubmitButton/SubmitButtonProps
+ * @see https://shelving.cc/ui/SubmitButtonProps
  */
 export interface SubmitButtonProps extends ButtonVariants, OptionalChildProps {}
 

--- a/modules/ui/form/TextInput.tsx
+++ b/modules/ui/form/TextInput.tsx
@@ -10,7 +10,7 @@ type TextFormatter = (str: string) => string;
 /**
  * Props for `TextInput`, a single- or multi-line text input bound to a `string` value.
  *
- * @see https://dhoulb.github.io/shelving/ui/form/TextInput/TextInputProps
+ * @see https://shelving.cc/ui/TextInputProps
  */
 export interface TextInputProps extends ValueInputProps<string>, InputVariants {
 	rows?: number | undefined;
@@ -29,7 +29,7 @@ export interface TextInputProps extends ValueInputProps<string>, InputVariants {
  *
  * @returns A text `<input>` or `<textarea>` element.
  * @example <TextInput name="name" value={name} onValue={setName} />
- * @see https://dhoulb.github.io/shelving/ui/form/TextInput/TextInput
+ * @see https://shelving.cc/ui/TextInput
  */
 export function TextInput({
 	name,

--- a/modules/ui/inline/Code.tsx
+++ b/modules/ui/inline/Code.tsx
@@ -12,7 +12,7 @@ const CODE_PLAIN_CLASS = getModuleClass(CODE_CSS, "plain");
 /**
  * Props for `Code` — colour and typography variants, optional `children`, plus a `plain` toggle.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Code/CodeProps
+ * @see https://shelving.cc/ui/CodeProps
  */
 export interface CodeProps extends ColorVariants, TypographyVariants, OptionalChildProps {
 	plain?: boolean | undefined;
@@ -25,7 +25,7 @@ export interface CodeProps extends ColorVariants, TypographyVariants, OptionalCh
  * @kind component
  * @returns Rendered `<code>` element.
  * @example <Code>npm install</Code>
- * @see https://dhoulb.github.io/shelving/ui/inline/Code/Code
+ * @see https://shelving.cc/ui/Code
  */
 export function Code({ children, plain, ...props }: CodeProps): ReactElement {
 	return (

--- a/modules/ui/inline/Deleted.tsx
+++ b/modules/ui/inline/Deleted.tsx
@@ -8,7 +8,7 @@ const DELETED_CLASS = getModuleClass(DELETED_CSS, "definitions");
 /**
  * Props for `Deleted` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Deleted/DeletedProps
+ * @see https://shelving.cc/ui/DeletedProps
  */
 export interface DeletedProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface DeletedProps extends OptionalChildProps {}
  * @returns Rendered `<del>` element.
  * @kind component
  * @example <Deleted>old price</Deleted>
- * @see https://dhoulb.github.io/shelving/ui/inline/Deleted/Deleted
+ * @see https://shelving.cc/ui/Deleted
  */
 export function Deleted({ children }: DeletedProps): ReactElement {
 	return <del className={DELETED_CLASS}>{children}</del>;

--- a/modules/ui/inline/Emphasis.tsx
+++ b/modules/ui/inline/Emphasis.tsx
@@ -8,7 +8,7 @@ const EMPHASIS_CLASS = getModuleClass(EMPHASIS_CSS, "emphasis");
 /**
  * Props for `Emphasis` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Emphasis/EmphasisProps
+ * @see https://shelving.cc/ui/EmphasisProps
  */
 export interface EmphasisProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface EmphasisProps extends OptionalChildProps {}
  * @returns Rendered `<em>` element.
  * @kind component
  * @example <Emphasis>really</Emphasis>
- * @see https://dhoulb.github.io/shelving/ui/inline/Emphasis/Emphasis
+ * @see https://shelving.cc/ui/Emphasis
  */
 export function Emphasis({ children }: EmphasisProps): ReactElement {
 	return <em className={EMPHASIS_CLASS}>{children}</em>;

--- a/modules/ui/inline/Inserted.tsx
+++ b/modules/ui/inline/Inserted.tsx
@@ -8,7 +8,7 @@ const INSERTED_CLASS = getModuleClass(INSERTED_CSS, "inserted");
 /**
  * Props for `Inserted` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Inserted/InsertedProps
+ * @see https://shelving.cc/ui/InsertedProps
  */
 export interface InsertedProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface InsertedProps extends OptionalChildProps {}
  * @returns Rendered `<ins>` element.
  * @kind component
  * @example <Inserted>new price</Inserted>
- * @see https://dhoulb.github.io/shelving/ui/inline/Inserted/Inserted
+ * @see https://shelving.cc/ui/Inserted
  */
 export function Inserted({ children }: InsertedProps): ReactElement {
 	return <ins className={INSERTED_CLASS}>{children}</ins>;

--- a/modules/ui/inline/Link.tsx
+++ b/modules/ui/inline/Link.tsx
@@ -8,7 +8,7 @@ const LINK_CLASS = getModuleClass(LINK_CSS, "link");
 /**
  * Props for `Link` — identical to `ClickableProps` (`href` for navigation or `onClick` for actions).
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Link/LinkProps
+ * @see https://shelving.cc/ui/LinkProps
  */
 export interface LinkProps extends ClickableProps {}
 
@@ -18,7 +18,7 @@ export interface LinkProps extends ClickableProps {}
  * @kind component
  * @returns Rendered inline `<a>` or `<button>` element.
  * @example <Link href="/about">About us</Link>
- * @see https://dhoulb.github.io/shelving/ui/inline/Link/Link
+ * @see https://shelving.cc/ui/Link
  */
 export function Link(props: LinkProps): ReactElement {
 	return <Clickable {...props} className={LINK_CLASS} />;

--- a/modules/ui/inline/Mark.tsx
+++ b/modules/ui/inline/Mark.tsx
@@ -8,7 +8,7 @@ const MARK_CLASS = getModuleClass(MARK_CSS, "mark");
 /**
  * Props for `Mark` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Mark/MarkProps
+ * @see https://shelving.cc/ui/MarkProps
  */
 export interface MarkProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface MarkProps extends OptionalChildProps {}
  * @kind component
  * @returns Rendered `<mark>` element.
  * @example <Mark>search term</Mark>
- * @see https://dhoulb.github.io/shelving/ui/inline/Mark/Mark
+ * @see https://shelving.cc/ui/Mark
  */
 export function Mark({ children }: MarkProps): ReactElement {
 	return <mark className={MARK_CLASS}>{children}</mark>;

--- a/modules/ui/inline/Small.tsx
+++ b/modules/ui/inline/Small.tsx
@@ -8,7 +8,7 @@ const SMALL_CLASS = getModuleClass(SMALL_CSS, "small");
 /**
  * Props for `Small` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Small/SmallProps
+ * @see https://shelving.cc/ui/SmallProps
  */
 export interface SmallProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface SmallProps extends OptionalChildProps {}
  * @returns Rendered `<small>` element.
  * @kind component
  * @example <Small>Terms apply.</Small>
- * @see https://dhoulb.github.io/shelving/ui/inline/Small/Small
+ * @see https://shelving.cc/ui/Small
  */
 export function Small({ children }: SmallProps): ReactElement {
 	return <small className={SMALL_CLASS}>{children}</small>;

--- a/modules/ui/inline/Strong.tsx
+++ b/modules/ui/inline/Strong.tsx
@@ -8,7 +8,7 @@ const STRONG_CLASS = getModuleClass(STRONG_CSS, "strong");
 /**
  * Props for `Strong` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Strong/StrongProps
+ * @see https://shelving.cc/ui/StrongProps
  */
 export interface StrongProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface StrongProps extends OptionalChildProps {}
  * @kind component
  * @returns Rendered `<strong>` element.
  * @example <Strong>Warning</Strong>
- * @see https://dhoulb.github.io/shelving/ui/inline/Strong/Strong
+ * @see https://shelving.cc/ui/Strong
  */
 export function Strong({ children }: StrongProps): ReactElement {
 	return <strong className={STRONG_CLASS}>{children}</strong>;

--- a/modules/ui/inline/Subscript.tsx
+++ b/modules/ui/inline/Subscript.tsx
@@ -8,7 +8,7 @@ const SUBSCRIPT_CLASS = getModuleClass(SUBSCRIPT_CSS, "subscript");
 /**
  * Props for `Subscript` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Subscript/SubscriptProps
+ * @see https://shelving.cc/ui/SubscriptProps
  */
 export interface SubscriptProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface SubscriptProps extends OptionalChildProps {}
  * @returns Rendered `<sub>` element.
  * @kind component
  * @example <>H<Subscript>2</Subscript>O</>
- * @see https://dhoulb.github.io/shelving/ui/inline/Subscript/Subscript
+ * @see https://shelving.cc/ui/Subscript
  */
 export function Subscript({ children }: SubscriptProps): ReactElement {
 	return <sub className={SUBSCRIPT_CLASS}>{children}</sub>;

--- a/modules/ui/inline/Superscript.tsx
+++ b/modules/ui/inline/Superscript.tsx
@@ -8,7 +8,7 @@ const SUPERSCRIPT_CLASS = getModuleClass(SUPERSCRIPT_CSS, "superscript");
 /**
  * Props for `Superscript` — optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/Superscript/SuperscriptProps
+ * @see https://shelving.cc/ui/SuperscriptProps
  */
 export interface SuperscriptProps extends OptionalChildProps {}
 
@@ -18,7 +18,7 @@ export interface SuperscriptProps extends OptionalChildProps {}
  * @returns Rendered `<sup>` element.
  * @kind component
  * @example <>E = mc<Superscript>2</Superscript></>
- * @see https://dhoulb.github.io/shelving/ui/inline/Superscript/Superscript
+ * @see https://shelving.cc/ui/Superscript
  */
 export function Superscript({ children }: SuperscriptProps): ReactElement {
 	return <sup className={SUPERSCRIPT_CLASS}>{children}</sup>;

--- a/modules/ui/inline/When.tsx
+++ b/modules/ui/inline/When.tsx
@@ -26,7 +26,7 @@ function _getWhen(
 /**
  * Props for `When`, `Ago`, and `Until` — a `target` date plus an optional `current` reference date and `full` toggle.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/When/WhenProps
+ * @see https://shelving.cc/ui/WhenProps
  */
 export interface WhenProps extends OptionalChildProps {
 	target: PossibleDate | undefined;
@@ -43,7 +43,7 @@ export interface WhenProps extends OptionalChildProps {
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
  * @kind component
  * @example <When target="2030-01-01" />
- * @see https://dhoulb.github.io/shelving/ui/inline/When/When
+ * @see https://shelving.cc/ui/When
  */
 export function When(props: WhenProps): ReactElement {
 	return _getWhen(formatWhen, props, When);
@@ -52,7 +52,7 @@ export function When(props: WhenProps): ReactElement {
 /**
  * Props for `Ago` — identical to `WhenProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/When/AgoProps
+ * @see https://shelving.cc/ui/AgoProps
  */
 export interface AgoProps extends WhenProps {}
 
@@ -63,7 +63,7 @@ export interface AgoProps extends WhenProps {}
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
  * @kind component
  * @example <Ago target="2020-01-01" />
- * @see https://dhoulb.github.io/shelving/ui/inline/When/Ago
+ * @see https://shelving.cc/ui/Ago
  */
 export function Ago(props: AgoProps): ReactElement {
 	return _getWhen(formatAgo, props, Ago);
@@ -72,7 +72,7 @@ export function Ago(props: AgoProps): ReactElement {
 /**
  * Props for `Until` — identical to `WhenProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/inline/When/UntilProps
+ * @see https://shelving.cc/ui/UntilProps
  */
 export interface UntilProps extends WhenProps {}
 
@@ -83,7 +83,7 @@ export interface UntilProps extends WhenProps {}
  * @throws {RequiredError} If `target` (or `current`) cannot be coerced to a valid date.
  * @kind component
  * @example <Until target="2030-01-01" />
- * @see https://dhoulb.github.io/shelving/ui/inline/When/Until
+ * @see https://shelving.cc/ui/Until
  */
 export function Until(props: UntilProps): ReactElement {
 	return _getWhen(formatUntil, props, Until);

--- a/modules/ui/layout/CenteredLayout.tsx
+++ b/modules/ui/layout/CenteredLayout.tsx
@@ -7,7 +7,7 @@ import CENTERED_LAYOUT_CSS from "./CenteredLayout.module.css";
 /**
  * Props for `<CenteredLayout>` — optional `children` and a `fullWidth` flag to drop the max-width.
  *
- * @see https://dhoulb.github.io/shelving/ui/layout/CenteredLayout/CenteredLayoutProps
+ * @see https://shelving.cc/ui/CenteredLayoutProps
  */
 export interface CenteredLayoutProps extends OptionalChildProps {
 	fullWidth?: boolean;
@@ -22,7 +22,7 @@ export interface CenteredLayoutProps extends OptionalChildProps {
  * @param fullWidth Drop the narrow max-width and let content fill the width (defaults to `false`).
  * @returns The centred layout element.
  * @example <CenteredLayout><LoginForm /></CenteredLayout>
- * @see https://dhoulb.github.io/shelving/ui/layout/CenteredLayout/CenteredLayout
+ * @see https://shelving.cc/ui/CenteredLayout
  */
 export function CenteredLayout({ children, fullWidth = false }: CenteredLayoutProps): ReactElement {
 	// Wrap the scrolling `<main>` in `<RouteCache>` so recently-visited pages stay mounted but hidden,

--- a/modules/ui/layout/Layout.ts
+++ b/modules/ui/layout/Layout.ts
@@ -6,7 +6,7 @@
  * @returns A cleanup function that removes the listeners and property, or `undefined` when `visualViewport` is unavailable.
  * @todo This can be removed once Safari iOS supports interactive-widget viewport property. https://caniuse.com/mdn-html_elements_meta_name_viewport_interactive-widget
  * @example useEffect(useSafeKeyboardArea, []);
- * @see https://dhoulb.github.io/shelving/ui/layout/Layout/useSafeKeyboardArea
+ * @see https://shelving.cc/ui/useSafeKeyboardArea
  */
 export function useSafeKeyboardArea() {
 	const vv = window.visualViewport;

--- a/modules/ui/layout/SidebarLayout.tsx
+++ b/modules/ui/layout/SidebarLayout.tsx
@@ -10,7 +10,7 @@ import SIDEBAR_LAYOUT_CSS from "./SidebarLayout.module.css";
 /**
  * Props for `<SidebarLayout>` — the `sidebar` column content, main `children`, and a `right` placement flag.
  *
- * @see https://dhoulb.github.io/shelving/ui/layout/SidebarLayout/SidebarLayoutProps
+ * @see https://shelving.cc/ui/SidebarLayoutProps
  */
 export interface SidebarLayoutProps extends OptionalChildProps {
 	/** Content rendered in the fixed-width side column. */
@@ -34,7 +34,7 @@ export interface SidebarLayoutProps extends OptionalChildProps {
  * @param right Render the sidebar on the right rather than the left (defaults to `false`).
  * @returns The sidebar layout element.
  * @example <SidebarLayout sidebar={<Menu />}><Page /></SidebarLayout>
- * @see https://dhoulb.github.io/shelving/ui/layout/SidebarLayout/SidebarLayout
+ * @see https://shelving.cc/ui/SidebarLayout
  */
 export function SidebarLayout({ sidebar, children, right = false }: SidebarLayoutProps): ReactElement {
 	const { path } = requireMetaURL();

--- a/modules/ui/menu/Menu.tsx
+++ b/modules/ui/menu/Menu.tsx
@@ -16,7 +16,7 @@ const MENU_ACTIVE_CLASS = getModuleClass(MENU_CSS, "active");
 /**
  * Props for `<Menu>` — optional `<MenuItem>` `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/menu/Menu/MenuProps
+ * @see https://shelving.cc/ui/MenuProps
  */
 export interface MenuProps extends OptionalChildProps {}
 
@@ -29,7 +29,7 @@ export interface MenuProps extends OptionalChildProps {}
  * @param children The `<MenuItem>` entries to list.
  * @returns The menu element.
  * @example <Menu><MenuItem href="/home">Home</MenuItem></Menu>
- * @see https://dhoulb.github.io/shelving/ui/menu/Menu/Menu
+ * @see https://shelving.cc/ui/Menu
  */
 export function Menu({ children }: MenuProps): ReactNode {
 	return <menu className={MENU_CLASS}>{children}</menu>;
@@ -38,7 +38,7 @@ export function Menu({ children }: MenuProps): ReactNode {
 /**
  * Props for `<MenuItem>` — `<Clickable>` props plus `children` whose first node is the label and the rest the submenu.
  *
- * @see https://dhoulb.github.io/shelving/ui/menu/Menu/MenuItemProps
+ * @see https://shelving.cc/ui/MenuItemProps
  */
 export interface MenuItemProps extends ClickableProps {
 	/**
@@ -58,7 +58,7 @@ export interface MenuItemProps extends ClickableProps {
  * @param children The label (first node) and optional submenu (remaining nodes).
  * @returns The menu item element.
  * @example <MenuItem href="/settings">Settings</MenuItem>
- * @see https://dhoulb.github.io/shelving/ui/menu/Menu/MenuItem
+ * @see https://shelving.cc/ui/MenuItem
  */
 export function MenuItem({ href, children, ...props }: MenuItemProps): ReactNode {
 	const { url, root } = requireMeta();

--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -18,7 +18,7 @@ RetryContext.displayName = "RetryContext";
 /**
  * Props for `<RetryButton>` — `<Button>` variants plus optional `children` to override the default "Retry" label.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/RetryButtonProps
+ * @see https://shelving.cc/ui/RetryButtonProps
  */
 export interface RetryButtonProps extends ButtonVariants, OptionalChildProps {}
 
@@ -38,7 +38,7 @@ const RETRY_CHILDREN = (
  * @returns The retry button, or `null` when not inside a `<Catcher>`.
  * @kind component
  * @example <RetryButton small />
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/RetryButton
+ * @see https://shelving.cc/ui/RetryButton
  */
 export function RetryButton({ children = RETRY_CHILDREN, ...props }: RetryButtonProps): ReactElement | null {
 	const retry = use(RetryContext);
@@ -53,7 +53,7 @@ export function RetryButton({ children = RETRY_CHILDREN, ...props }: RetryButton
 /**
  * Props for a component that renders a caught error `reason`.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorComponentProps
+ * @see https://shelving.cc/ui/ErrorComponentProps
  */
 export interface ErrorComponentProps {
 	reason: unknown;
@@ -62,7 +62,7 @@ export interface ErrorComponentProps {
 /**
  * Props for `<Catcher>` — the `children` to guard plus the `as` component used to render any caught error.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/CatcherProps
+ * @see https://shelving.cc/ui/CatcherProps
  */
 export interface CatcherProps extends ChildProps {
 	/** Component to render an error (defaults to `<ErrorNotice />`) */
@@ -83,7 +83,7 @@ type CatcherState = {
  * @kind component
  * @example <Catcher><RiskyComponent /></Catcher>
  * @example <Catcher as={ErrorPage}><RiskyComponent /></Catcher>
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/Catcher
+ * @see https://shelving.cc/ui/Catcher
  */
 export class Catcher extends Component<CatcherProps, CatcherState> {
 	static defaultProps: Pick<CatcherProps, "as"> = {
@@ -114,7 +114,7 @@ export class Catcher extends Component<CatcherProps, CatcherState> {
 /**
  * Props for `<PageCatcher>` — the page `children` to guard.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/PageCatcherProps
+ * @see https://shelving.cc/ui/PageCatcherProps
  */
 export interface PageCatcherProps extends ChildProps {}
 
@@ -125,7 +125,7 @@ export interface PageCatcherProps extends ChildProps {}
  * @returns A `<Catcher>` configured to render `<ErrorPage>` on error.
  * @kind component
  * @example <PageCatcher><SettingsPage /></PageCatcher>
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/PageCatcher
+ * @see https://shelving.cc/ui/PageCatcher
  */
 export function PageCatcher({ children }: PageCatcherProps): ReactElement {
 	return <Catcher as={ErrorPage}>{children}</Catcher>;
@@ -134,7 +134,7 @@ export function PageCatcher({ children }: PageCatcherProps): ReactElement {
 /**
  * Props for `<ErrorNotice>` — the caught error `reason`.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorNoticeProps
+ * @see https://shelving.cc/ui/ErrorNoticeProps
  */
 export interface ErrorNoticeProps extends ErrorComponentProps {}
 
@@ -147,7 +147,7 @@ export interface ErrorNoticeProps extends ErrorComponentProps {}
  * @returns An error `<Notice>` containing the message and a `<RetryButton>`.
  * @kind component
  * @example <ErrorNotice reason={thrown} />
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorNotice
+ * @see https://shelving.cc/ui/ErrorNotice
  */
 export function ErrorNotice({ reason }: ErrorNoticeProps): ReactElement {
 	const message = getMessage(reason) ?? "Unknown error";
@@ -162,7 +162,7 @@ export function ErrorNotice({ reason }: ErrorNoticeProps): ReactElement {
 /**
  * Props for `<ErrorPage>` — the caught error `reason`.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorPageProps
+ * @see https://shelving.cc/ui/ErrorPageProps
  */
 export interface ErrorPageProps extends ErrorComponentProps {}
 
@@ -175,7 +175,7 @@ export interface ErrorPageProps extends ErrorComponentProps {}
  * @returns A centered error page containing the message and a `<RetryButton>`.
  * @kind component
  * @example <ErrorPage reason={thrown} />
- * @see https://dhoulb.github.io/shelving/ui/misc/Catcher/ErrorPage
+ * @see https://shelving.cc/ui/ErrorPage
  */
 export function ErrorPage({ reason }: ErrorPageProps): ReactElement {
 	const message = getMessage(reason) ?? "Unknown error";

--- a/modules/ui/misc/Icon.tsx
+++ b/modules/ui/misc/Icon.tsx
@@ -18,9 +18,9 @@ const STATUS_ICONS: {
 };
 
 /**
- * Props for `<StatusIcon>` — the `status` to represent and optional icon `size`.
+ * Props for `<Icon>` — the `status` to represent and optional icon `size`.
  *
- * @see https://shelving.cc/ui/StatusIconProps
+ * @see https://shelving.cc/ui/IconProps
  */
 export interface IconProps extends ColorVariants, StatusVariants {
 	/**
@@ -40,8 +40,8 @@ export interface IconProps extends ColorVariants, StatusVariants {
  * - Picks a heroicon per status (`success`, `error`, `warning`, etc.), falling back to an info icon, and uses the animated `<Loading>` spinner for `"loading"`.
  *
  * @kind component
- * @example <StatusIcon status="error" size="large" />
- * @see https://shelving.cc/ui/StatusIcon
+ * @example <Icon status="error" size="large" />
+ * @see https://shelving.cc/ui/Icon
  */
 export function Icon(props: IconProps): ReactElement {
 	const { status = "info", icon: Element = STATUS_ICONS[status] ?? InformationCircleIcon } = props;

--- a/modules/ui/misc/Icon.tsx
+++ b/modules/ui/misc/Icon.tsx
@@ -20,7 +20,7 @@ const STATUS_ICONS: {
 /**
  * Props for `<StatusIcon>` — the `status` to represent and optional icon `size`.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/StatusIcon/StatusIconProps
+ * @see https://shelving.cc/ui/StatusIconProps
  */
 export interface IconProps extends ColorVariants, StatusVariants {
 	/**
@@ -41,7 +41,7 @@ export interface IconProps extends ColorVariants, StatusVariants {
  *
  * @kind component
  * @example <StatusIcon status="error" size="large" />
- * @see https://dhoulb.github.io/shelving/ui/misc/StatusIcon/StatusIcon
+ * @see https://shelving.cc/ui/StatusIcon
  */
 export function Icon(props: IconProps): ReactElement {
 	const { status = "info", icon: Element = STATUS_ICONS[status] ?? InformationCircleIcon } = props;

--- a/modules/ui/misc/Loading.tsx
+++ b/modules/ui/misc/Loading.tsx
@@ -7,7 +7,7 @@ declare const _componentProps: unique symbol;
 /**
  * Props for `<Loading>` — takes no props (branded empty interface).
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Loading/LoadingProps
+ * @see https://shelving.cc/ui/LoadingProps
  */
 export interface LoadingProps {
 	readonly [_componentProps]?: never;
@@ -21,7 +21,7 @@ export interface LoadingProps {
  * @returns The spinner element.
  * @kind component
  * @example <Loading />
- * @see https://dhoulb.github.io/shelving/ui/misc/Loading/Loading
+ * @see https://shelving.cc/ui/Loading
  */
 export function Loading(): ReactElement {
 	return (
@@ -54,6 +54,6 @@ export function Loading(): ReactElement {
  * Shared `<Loading>` element with a stable `key`, ready to drop into `Suspense` fallbacks and lists.
  *
  * @example <Suspense fallback={LOADING}>…</Suspense>
- * @see https://dhoulb.github.io/shelving/ui/misc/Loading/LOADING
+ * @see https://shelving.cc/ui/LOADING
  */
 export const LOADING = <Loading key="loading" />;

--- a/modules/ui/misc/Mapper.tsx
+++ b/modules/ui/misc/Mapper.tsx
@@ -8,7 +8,7 @@ import type { ChildProps } from "../util/props.js";
  * - Each entry is optional — unmapped elements fall through and render as themselves (e.g. an unmapped `<tree-foo>` appears as a raw `<tree-foo>` HTML element).
  * - Per-entry component receives `JSX.IntrinsicElements[K] & E` — the declared props for that element type, plus any extra props `E` the mapper is configured to thread through.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Mapper/Mapping
+ * @see https://shelving.cc/ui/Mapping
  */
 export type Mapping<E = unknown> = {
 	[K in keyof JSX.IntrinsicElements]?: ComponentType<JSX.IntrinsicElements[K] & E>;
@@ -17,7 +17,7 @@ export type Mapping<E = unknown> = {
 /**
  * Props for the `Mapping` component returned by `createMapper()`.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Mapper/MappingProps
+ * @see https://shelving.cc/ui/MappingProps
  */
 export interface MappingProps<E = unknown> extends ChildProps {
 	/** Mapping entries that extend or override the inherited mapping inside this subtree. */
@@ -29,7 +29,7 @@ export interface MappingProps<E = unknown> extends ChildProps {
  * - `children` holds the pre-walked elements to dispatch.
  * - All other props are spread onto every mapped child as additional props (`E`).
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Mapper/MapperProps
+ * @see https://shelving.cc/ui/MapperProps
  */
 export type MapperProps<E = unknown> = E & {
 	readonly children?: Elements;
@@ -65,7 +65,7 @@ type AnyMapping = Record<string, ComponentType<any> | undefined>;
  * });
  * <TreeMenuMapper path="/foo">{queryElements(children, query)}</TreeMenuMapper>
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Mapper/createMapper
+ * @see https://shelving.cc/ui/createMapper
  */
 export function createMapper<E = unknown>(
 	defaults: Mapping<E> = {},

--- a/modules/ui/misc/Markup.tsx
+++ b/modules/ui/misc/Markup.tsx
@@ -5,7 +5,7 @@ import { requireMeta } from "./MetaContext.js";
 /**
  * Props for `<Markup>` — extends `MarkupOptions` so callers can override `rules`, `rel`, `url`, `root`, or `schemes` directly.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Markup/MarkupProps
+ * @see https://shelving.cc/ui/MarkupProps
  */
 export interface MarkupProps extends Partial<MarkupOptions> {
 	/** The source string to parse and render. */
@@ -22,7 +22,7 @@ export interface MarkupProps extends Partial<MarkupOptions> {
  * @returns The parsed markup as React nodes, or `null` when `children` is empty.
  * @kind component
  * @example <Prose><Markup>{`A *bold* word with \`code\`.`}</Markup></Prose>
- * @see https://dhoulb.github.io/shelving/ui/misc/Markup/Markup
+ * @see https://shelving.cc/ui/Markup
  */
 export function Markup({ children, ...options }: MarkupProps): ReactNode {
 	if (!children) return null;

--- a/modules/ui/misc/MetaContext.tsx
+++ b/modules/ui/misc/MetaContext.tsx
@@ -10,7 +10,7 @@ import { type Meta, mergeMeta, type PossibleMeta } from "../util/meta.js";
  * React context holding the current `Meta` object (page URL, site root, title, etc.).
  *
  * @example <MetaContext value={meta}>…</MetaContext>
- * @see https://dhoulb.github.io/shelving/ui/misc/MetaContext/MetaContext
+ * @see https://shelving.cc/ui/MetaContext
  */
 export const MetaContext = createContext<Meta>({});
 MetaContext.displayName = "MetaContext";
@@ -23,7 +23,7 @@ MetaContext.displayName = "MetaContext";
  * @param meta A set of new possible meta data to combine into the current meta context.
  * @returns The current `Meta`, with `meta` merged in when provided.
  * @example const { title, url } = requireMeta();
- * @see https://dhoulb.github.io/shelving/ui/misc/MetaContext/requireMeta
+ * @see https://shelving.cc/ui/requireMeta
  */
 export function requireMeta(meta?: PossibleMeta): Meta {
 	const current = use(MetaContext);
@@ -33,7 +33,7 @@ export function requireMeta(meta?: PossibleMeta): Meta {
 /**
  * A `Meta` object with a guaranteed `url`, plus derived `path` and `params` properties.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/MetaContext/MetaURL
+ * @see https://shelving.cc/ui/MetaURL
  */
 export interface MetaURL extends Meta {
 	url: ImmutableURL;
@@ -52,7 +52,7 @@ export interface MetaURL extends Meta {
  * @throws RequiredError If the current meta has no `url`.
  * @throws RequiredError If the current meta `url` does not share an origin with the meta `root`.
  * @example const { path, params } = requireMetaURL();
- * @see https://dhoulb.github.io/shelving/ui/misc/MetaContext/requireMetaURL
+ * @see https://shelving.cc/ui/requireMetaURL
  */
 export function requireMetaURL(meta?: PossibleMeta, caller: AnyCaller = requireMetaURL): MetaURL {
 	const { url, root, ...combined } = requireMeta(meta);

--- a/modules/ui/misc/Tag.tsx
+++ b/modules/ui/misc/Tag.tsx
@@ -11,7 +11,7 @@ const TAG_CLASS = getModuleClass(TAG_CSS, "tag");
 /**
  * Styling variants accepted by `<Tag>` — status, colour, and typography options.
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Tag/TagVariants
+ * @see https://shelving.cc/ui/TagVariants
  */
 export interface TagVariants extends StatusVariants, ColorVariants, TypographyVariants {}
 
@@ -21,7 +21,7 @@ export interface TagVariants extends StatusVariants, ColorVariants, TypographyVa
  * @param variants The status, colour, and typography variants to apply.
  * @returns The merged tag `className` string.
  * @example getTagClass({ success: true }) // "tag … status-success"
- * @see https://dhoulb.github.io/shelving/ui/misc/Tag/getTagClass
+ * @see https://shelving.cc/ui/getTagClass
  */
 export function getTagClass(variants: TagVariants) {
 	return getClass(
@@ -35,7 +35,7 @@ export function getTagClass(variants: TagVariants) {
 /**
  * Props for `<Tag>` — `TagVariants` styling options plus `<Clickable>` props (`href`, `onClick`, `children`, etc.).
  *
- * @see https://dhoulb.github.io/shelving/ui/misc/Tag/TagProps
+ * @see https://shelving.cc/ui/TagProps
  */
 export interface TagProps extends TagVariants, ClickableProps {}
 
@@ -48,7 +48,7 @@ export interface TagProps extends TagVariants, ClickableProps {}
  * @kind component
  * @example <Tag success>Active</Tag>
  * @example <Tag color="purple" href="/beta">Beta</Tag>
- * @see https://dhoulb.github.io/shelving/ui/misc/Tag/Tag
+ * @see https://shelving.cc/ui/Tag
  */
 export function Tag(props: TagProps): ReactElement {
 	return <Clickable {...props} className={getTagClass(props)} />;

--- a/modules/ui/notice/Message.tsx
+++ b/modules/ui/notice/Message.tsx
@@ -10,7 +10,7 @@ const MESSAGE_CLASS = getModuleClass(MESSAGE_CSS, "message");
 /**
  * Props for `<Message>` — paragraph props plus colour and status styling variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/notice/Message/MessageProps
+ * @see https://shelving.cc/ui/MessageProps
  */
 export interface MessageProps extends ParagraphProps, ColorVariants, StatusVariants {}
 
@@ -22,7 +22,7 @@ export interface MessageProps extends ParagraphProps, ColorVariants, StatusVaria
  * @param children The message content.
  * @returns The message paragraph element.
  * @example <Message status="error">Something went wrong</Message>
- * @see https://dhoulb.github.io/shelving/ui/notice/Message/Message
+ * @see https://shelving.cc/ui/Message
  */
 export function Message({ children, ...props }: MessageProps) {
 	const { status } = props;
@@ -44,6 +44,6 @@ export function Message({ children, ...props }: MessageProps) {
  * Shared loading `<Message>` element containing the `<Loading>` spinner.
  *
  * @example return isLoading ? LOADING_MESSAGE : <Message>{text}</Message>;
- * @see https://dhoulb.github.io/shelving/ui/notice/Message/LOADING_MESSAGE
+ * @see https://shelving.cc/ui/LOADING_MESSAGE
  */
 export const LOADING_MESSAGE = <Message status="loading">{LOADING}</Message>;

--- a/modules/ui/notice/Notice.tsx
+++ b/modules/ui/notice/Notice.tsx
@@ -11,7 +11,7 @@ import NOTICE_CSS from "./Notice.module.css";
 /**
  * Props for `<Notice>` — flex/colour/status styling variants, optional `children`, and an optional `icon`.
  *
- * @see https://dhoulb.github.io/shelving/ui/notice/Notice/NoticeProps
+ * @see https://shelving.cc/ui/NoticeProps
  */
 export interface NoticeProps extends FlexVariants, ColorVariants, StatusVariants, OptionalChildProps {
 	/** Icon for the notice (or `null` or `false` to hide the icon, defaults to `<StatusIcon>`). */
@@ -29,7 +29,7 @@ export interface NoticeProps extends FlexVariants, ColorVariants, StatusVariants
  * @returns The notice callout element.
  * @kind component
  * @example <Notice status="success">Saved your changes</Notice>
- * @see https://dhoulb.github.io/shelving/ui/notice/Notice/Notice
+ * @see https://shelving.cc/ui/Notice
  */
 export function Notice({
 	children, //
@@ -52,6 +52,6 @@ export function Notice({
  * Shared loading `<Notice>` element showing the loading spinner.
  *
  * @example <Suspense fallback={LOADING_NOTICE}>…</Suspense>
- * @see https://dhoulb.github.io/shelving/ui/notice/Notice/LOADING_NOTICE
+ * @see https://shelving.cc/ui/LOADING_NOTICE
  */
 export const LOADING_NOTICE = <Notice status="loading" />;

--- a/modules/ui/notice/NoticeStore.ts
+++ b/modules/ui/notice/NoticeStore.ts
@@ -21,7 +21,7 @@ type NoticeData<S extends string> = {
  * - Adds itself to its parent `NoticesStore` on construction and removes itself on `close()` or disposal.
  *
  * @example const notice = notices.show("Saved", "success"); notice.close();
- * @see https://dhoulb.github.io/shelving/ui/notice/NoticeStore/NoticeStore
+ * @see https://shelving.cc/ui/NoticeStore
  */
 export class NoticeStore<S extends string> extends DataStore<NoticeData<S>> {
 	private _notices: NoticesStore<S>;
@@ -48,7 +48,7 @@ export class NoticeStore<S extends string> extends DataStore<NoticeData<S>> {
 	 * @param children The new notice content.
 	 * @param status The new status (defaults to the current status).
 	 * @example notice.show("Updating…", "loading");
-	 * @see https://dhoulb.github.io/shelving/ui/notice/NoticeStore/NoticeStore/show
+	 * @see https://shelving.cc/ui/NoticeStore/show
 	 */
 	show(children?: ReactNode | undefined, status: S | undefined = this.value.status): void {
 		this.value = { children, status };
@@ -58,7 +58,7 @@ export class NoticeStore<S extends string> extends DataStore<NoticeData<S>> {
 	 * Close this notice permanently, removing it from its parent `NoticesStore`.
 	 *
 	 * @example notice.close();
-	 * @see https://dhoulb.github.io/shelving/ui/notice/NoticeStore/NoticeStore/close
+	 * @see https://shelving.cc/ui/NoticeStore/close
 	 */
 	close() {
 		this._notices.delete(this);

--- a/modules/ui/notice/Notices.tsx
+++ b/modules/ui/notice/Notices.tsx
@@ -12,7 +12,7 @@ const NOTICES_CLASS = getModuleClass(NOTICES_CSS, "notices");
 /**
  * Props for `<Notices>` — flex styling variants for the notices container.
  *
- * @see https://dhoulb.github.io/shelving/ui/notice/Notices/NoticesProps
+ * @see https://shelving.cc/ui/NoticesProps
  */
 export interface NoticesProps extends FlexVariants {}
 
@@ -24,7 +24,7 @@ export interface NoticesProps extends FlexVariants {}
  * @returns The notices container element.
  * @kind component
  * @example <Notices column />
- * @see https://dhoulb.github.io/shelving/ui/notice/Notices/Notices
+ * @see https://shelving.cc/ui/Notices
  */
 export function Notices(props: NoticesProps): ReactElement {
 	const notices = useStore(NOTICES).value;

--- a/modules/ui/notice/NoticesStore.ts
+++ b/modules/ui/notice/NoticesStore.ts
@@ -10,7 +10,7 @@ import { NoticeStore } from "./NoticeStore.js";
  * - Disposing the store disposes (and closes) every notice it contains.
  *
  * @example const notices = new NoticesStore(); notices.show("Hello");
- * @see https://dhoulb.github.io/shelving/ui/notice/NoticesStore/NoticesStore
+ * @see https://shelving.cc/ui/NoticesStore
  */
 export class NoticesStore<S extends string> extends ArrayStore<NoticeStore<S>> {
 	/**
@@ -20,7 +20,7 @@ export class NoticesStore<S extends string> extends ArrayStore<NoticeStore<S>> {
 	 * @param status The notice status (optional).
 	 * @returns The newly created `NoticeStore`.
 	 * @example notices.show("Saved your changes", "success");
-	 * @see https://dhoulb.github.io/shelving/ui/notice/NoticesStore/NoticesStore/show
+	 * @see https://shelving.cc/ui/NoticesStore/show
 	 */
 	show(children?: ReactNode | undefined, status?: S | undefined): NoticeStore<S> {
 		return new NoticeStore(this, children, status);
@@ -38,6 +38,6 @@ export class NoticesStore<S extends string> extends ArrayStore<NoticeStore<S>> {
  * Global `NoticesStore` shown by `<Notices>`, accepting any of the default statuses.
  *
  * @example NOTICES.show("Saved your changes", "success");
- * @see https://dhoulb.github.io/shelving/ui/notice/NoticesStore/NOTICES
+ * @see https://shelving.cc/ui/NOTICES
  */
 export const NOTICES = new NoticesStore<Status>();

--- a/modules/ui/page/HTML.tsx
+++ b/modules/ui/page/HTML.tsx
@@ -6,7 +6,7 @@ import type { ChildProps } from "../util/props.js";
 /**
  * Props for `<HTML>` — initial `Meta` (language/root/app) plus the page `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/page/HTML/HTMLProps
+ * @see https://shelving.cc/ui/HTMLProps
  */
 export interface HTMLProps extends PossibleMeta, ChildProps {}
 
@@ -19,7 +19,7 @@ export interface HTMLProps extends PossibleMeta, ChildProps {}
  * @param meta Initial meta (language/root/app) merged with the surrounding `<Meta>` context.
  * @returns The `<html>` document element.
  * @example <HTML app="My App" root="https://example.com/"><App /></HTML>
- * @see https://dhoulb.github.io/shelving/ui/page/HTML/HTML
+ * @see https://shelving.cc/ui/HTML
  */
 export function HTML({ children, ...meta }: HTMLProps): ReactElement {
 	const merged = requireMeta(meta);

--- a/modules/ui/page/Head.tsx
+++ b/modules/ui/page/Head.tsx
@@ -16,7 +16,7 @@ const R_HTTP_EQUIV = /^[A-Z][a-zA-Z0-9]*(-[A-Z][a-zA-Z0-9]*)*$/;
  * @kind component
  * @returns The hoistable head elements derived from the current `<Meta>` context.
  * @example <Page title="Settings"><Head />…</Page>
- * @see https://dhoulb.github.io/shelving/ui/page/Head/Head
+ * @see https://shelving.cc/ui/Head
  */
 export function Head(): ReactElement {
 	const meta = requireMeta();

--- a/modules/ui/page/Page.tsx
+++ b/modules/ui/page/Page.tsx
@@ -7,7 +7,7 @@ import { Head } from "./Head.js";
 /**
  * Props for `<Page>` — per-page `Meta` (title, description, etc.) plus the page `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/page/Page/PageProps
+ * @see https://shelving.cc/ui/PageProps
  */
 export interface PageProps extends PossibleMeta, ChildProps {}
 
@@ -21,7 +21,7 @@ export interface PageProps extends PossibleMeta, ChildProps {}
  * @param meta Per-page meta (title, description, etc.) merged with the surrounding `<Meta>` context.
  * @returns The page element with its meta applied.
  * @example <Page title="Settings"><SettingsForm /></Page>
- * @see https://dhoulb.github.io/shelving/ui/page/Page/Page
+ * @see https://shelving.cc/ui/Page
  */
 export function Page({ children, ...meta }: PageProps): ReactElement {
 	const merged = requireMeta(meta);

--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -10,7 +10,7 @@ import { NavigationStore } from "./NavigationStore.js";
 /**
  * Props for `<Navigation>` — initial `Meta` (url/base) plus optional `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Navigation/NavigationProps
+ * @see https://shelving.cc/ui/NavigationProps
  */
 export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
 
@@ -30,7 +30,7 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
  * @param meta Initial meta (url/base) merged with the surrounding `<Meta>` context.
  * @returns The navigation provider wrapping `children`.
  * @example <Navigation><App /></Navigation>
- * @see https://dhoulb.github.io/shelving/ui/router/Navigation/Navigation
+ * @see https://shelving.cc/ui/Navigation
  */
 export function Navigation({ children, ...meta }: NavigationProps): ReactElement {
 	const { url, root, ...merged } = requireMeta(meta);

--- a/modules/ui/router/NavigationContext.tsx
+++ b/modules/ui/router/NavigationContext.tsx
@@ -6,7 +6,7 @@ import type { NavigationStore } from "./NavigationStore.js";
  * React context holding the current `NavigationStore`, provided by `<Navigation>`.
  *
  * @example <NavigationContext value={store}>…</NavigationContext>
- * @see https://dhoulb.github.io/shelving/ui/router/NavigationContext/NavigationContext
+ * @see https://shelving.cc/ui/NavigationContext
  */
 export const NavigationContext = createContext<NavigationStore | undefined>(undefined);
 NavigationContext.displayName = "NavigationContext";
@@ -17,7 +17,7 @@ NavigationContext.displayName = "NavigationContext";
  * @returns The current `NavigationStore`.
  * @throws RequiredError If no `<Navigation>` provider is present above.
  * @example const nav = requireNavigation(); nav.forward("/home");
- * @see https://dhoulb.github.io/shelving/ui/router/NavigationContext/requireNavigation
+ * @see https://shelving.cc/ui/requireNavigation
  */
 export function requireNavigation(): NavigationStore {
 	return requireContext(NavigationContext, requireNavigation);

--- a/modules/ui/router/NavigationStore.tsx
+++ b/modules/ui/router/NavigationStore.tsx
@@ -9,7 +9,7 @@ import { type PossibleURL, requireURL } from "../../util/url.js";
  * - TODO: switch to the browser Navigation API when broadly supported.
  *
  * @example const nav = new NavigationStore("/"); nav.forward("/home");
- * @see https://dhoulb.github.io/shelving/ui/router/NavigationStore/NavigationStore
+ * @see https://shelving.cc/ui/NavigationStore
  */
 export class NavigationStore extends URLStore {
 	/**
@@ -28,7 +28,7 @@ export class NavigationStore extends URLStore {
 	 * @param possible The destination URL, resolved against `base`.
 	 * @throws RequiredError If `possible` cannot be resolved to a valid URL.
 	 * @example nav.forward("/settings");
-	 * @see https://dhoulb.github.io/shelving/ui/router/NavigationStore/NavigationStore/forward
+	 * @see https://shelving.cc/ui/NavigationStore/forward
 	 */
 	forward(possible: PossibleURL): void {
 		this.value = requireURL(possible, this.base, this.forward);
@@ -41,7 +41,7 @@ export class NavigationStore extends URLStore {
 	 * @param possible The destination URL, resolved against `base`.
 	 * @throws RequiredError If `possible` cannot be resolved to a valid URL.
 	 * @example nav.redirect("/login");
-	 * @see https://dhoulb.github.io/shelving/ui/router/NavigationStore/NavigationStore/redirect
+	 * @see https://shelving.cc/ui/NavigationStore/redirect
 	 */
 	redirect(possible: PossibleURL): void {
 		this.value = requireURL(possible, this.base, this.redirect);

--- a/modules/ui/router/RouteCache.tsx
+++ b/modules/ui/router/RouteCache.tsx
@@ -11,7 +11,7 @@ interface CacheEntry {
 /**
  * Props for `<RouteCache>` — the `maxCached` size and the content `children` to keep alive per URL.
  *
- * @see https://dhoulb.github.io/shelving/ui/router/RouteCache/RouteCacheProps
+ * @see https://shelving.cc/ui/RouteCacheProps
  */
 export interface RouteCacheProps {
 	/**
@@ -47,7 +47,7 @@ export interface RouteCacheProps {
  * @param children The content region to render and cache (typically a layout's scrollable column).
  * @returns The visible current page plus any cached pages kept alive but hidden.
  * @example <SidebarLayout sidebar={<Menu />}><RouteCache><Router … /></RouteCache></SidebarLayout>
- * @see https://dhoulb.github.io/shelving/ui/router/RouteCache/RouteCache
+ * @see https://shelving.cc/ui/RouteCache
  */
 export function RouteCache({ maxCached = 10, children }: RouteCacheProps): ReactNode {
 	// Read the live URL from context; each navigation re-renders this with the new path.

--- a/modules/ui/router/Router.tsx
+++ b/modules/ui/router/Router.tsx
@@ -10,7 +10,7 @@ import type { Routes } from "./Routes.js";
 /**
  * Props for `<Router>` — the `routes` to match against plus an optional `fallback`.
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Router/RouterProps
+ * @see https://shelving.cc/ui/RouterProps
  */
 export interface RouterProps extends PossibleMeta {
 	/** List of routes for the router to match against. */
@@ -38,7 +38,7 @@ export interface RouterProps extends PossibleMeta {
  * @returns The matched route element, or `null`/`fallback` when nothing matches.
  * @throws NotFoundError If no route matches and `fallback` is `undefined`.
  * @example <Router routes={{ "/": HomePage, "/about": AboutPage }} />
- * @see https://dhoulb.github.io/shelving/ui/router/Router/Router
+ * @see https://shelving.cc/ui/Router
  */
 export function Router({ routes, fallback, ...meta }: RouterProps): ReactElement | null {
 	const combined = requireMetaURL(meta);

--- a/modules/ui/router/Routes.tsx
+++ b/modules/ui/router/Routes.tsx
@@ -8,14 +8,14 @@ import type { URIParams } from "../../util/uri.js";
  * - Combines `?query` params from the URL and `{placeholder}` matches from the route template into one flat string dictionary.
  * - Template placeholder values take precedence over query params with the same name.
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Routes/RouteProps
+ * @see https://shelving.cc/ui/RouteProps
  */
 export type RouteProps = URIParams;
 
 /**
  * React component usable as a route value — a function or class component accepting `RouteProps`.
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Routes/RouteComponent
+ * @see https://shelving.cc/ui/RouteComponent
  */
 export type RouteComponent = FunctionComponent<RouteProps> | ComponentClass<RouteProps>;
 
@@ -25,7 +25,7 @@ export type RouteComponent = FunctionComponent<RouteProps> | ComponentClass<Rout
  * - `AbsolutePath` string — triggers a redirect to that path.
  * - `ReactElement` — rendered as-is (use for layout-wrapping a nested `<Router>` inside).
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Routes/Route
+ * @see https://shelving.cc/ui/Route
  */
 export type Route = RouteComponent | AbsolutePath | ReactElement;
 
@@ -35,7 +35,7 @@ export type Route = RouteComponent | AbsolutePath | ReactElement;
  * - Each key is a path starting with `/`, optionally containing `{named}` placeholders passed into the component.
  * - Each value is a `Route` (or a nullish/`false` value to disable that route).
  *
- * @see https://dhoulb.github.io/shelving/ui/router/Routes/Routes
+ * @see https://shelving.cc/ui/Routes
  */
 export type Routes = {
 	[key: AbsolutePath]: Nullish<Route | false>;

--- a/modules/ui/style/Color.tsx
+++ b/modules/ui/style/Color.tsx
@@ -6,7 +6,7 @@ import { TINT_CLASS } from "./Tint.js";
  * Enumerated colour names selectable via the `color="purple"` prop for components that support that support `ColorVariants`
  * - Applies a tint color to the element.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Color/ColorVariant
+ * @see https://shelving.cc/ui/ColorVariant
  */
 export type ColorVariant =
 	| "primary"
@@ -25,7 +25,7 @@ export type ColorVariant =
 /**
  * Variant props for colouring an element, e.g. `color="purple"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Color/ColorVariants
+ * @see https://shelving.cc/ui/ColorVariants
  */
 export interface ColorVariants {
 	/** Colour of the element. */
@@ -42,7 +42,7 @@ export interface ColorVariants {
  * @param variants
  * @returns The combined tint + colour class string, or `undefined` when no `color` is set.
  * @example getColorClass({ color: "purple" }) // "tint color-purple"
- * @see https://dhoulb.github.io/shelving/ui/style/Color/getColorClass
+ * @see https://shelving.cc/ui/getColorClass
  */
 export function getColorClass({ color }: ColorVariants): string | undefined {
 	if (color) return getClass(TINT_CLASS, getModuleClass(COLOR_CSS, color));

--- a/modules/ui/style/Duration.tsx
+++ b/modules/ui/style/Duration.tsx
@@ -4,14 +4,14 @@ import DURATION_CSS from "./Duration.module.css";
 /**
  * Allowed values for transition timing for components that support `DurationVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Duration/DurationValue
+ * @see https://shelving.cc/ui/DurationValue
  */
 export type DurationValue = "fast" | "normal" | "slow";
 
 /**
  * Variant props for the transition duration of an element, e.g. `duration="fast"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Duration/DurationVariants
+ * @see https://shelving.cc/ui/DurationVariants
  */
 export interface DurationVariants {
 	/** Transition duration of the element. */
@@ -24,7 +24,7 @@ export interface DurationVariants {
  * @param variants
  * @returns The duration class string, or `undefined` when no `duration` is set.
  * @example getDurationClass({ duration: "fast" }) // "duration-fast"
- * @see https://dhoulb.github.io/shelving/ui/style/Duration/getDurationClass
+ * @see https://shelving.cc/ui/getDurationClass
  */
 export function getDurationClass({ duration }: DurationVariants): string | undefined {
 	return duration && getModuleClass(DURATION_CSS, `duration-${duration}`);

--- a/modules/ui/style/Flex.tsx
+++ b/modules/ui/style/Flex.tsx
@@ -7,7 +7,7 @@ import { type GapVariants, getGapClass } from "./Gap.js";
 /**
  * Variant props for flex layout — opt-in modifiers any component can mix in via `getFlexClass()`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/FlexVariants
+ * @see https://shelving.cc/ui/FlexVariants
  */
 export interface FlexVariants extends GapVariants {
 	/** Wrap overflowing elements onto the next line. */
@@ -78,7 +78,7 @@ export interface FlexVariants extends GapVariants {
  * @param variants
  * @returns The combined flex + gap class string.
  * @example getFlexClass({ column: true, center: true, gap: "large" })
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/getFlexClass
+ * @see https://shelving.cc/ui/getFlexClass
  */
 export function getFlexClass(variants: FlexVariants): string {
 	return getClass(
@@ -90,7 +90,7 @@ export function getFlexClass(variants: FlexVariants): string {
 /**
  * Props for the `Row` component — flex variants plus optional children.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/RowProps
+ * @see https://shelving.cc/ui/RowProps
  */
 export interface RowProps extends FlexVariants, OptionalChildProps {}
 
@@ -101,7 +101,7 @@ export interface RowProps extends FlexVariants, OptionalChildProps {}
  * @returns A `<div>` element with the computed flex class.
  * @kind component
  * @example <Row gap="small" center>{items}</Row>
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/Row
+ * @see https://shelving.cc/ui/Row
  */
 export function Row({ children, ...props }: RowProps): ReactElement {
 	return <div className={getFlexClass(props)}>{children}</div>;
@@ -110,7 +110,7 @@ export function Row({ children, ...props }: RowProps): ReactElement {
 /**
  * Props for the `Column` component — flex variants plus optional children.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/ColumnProps
+ * @see https://shelving.cc/ui/ColumnProps
  */
 export interface ColumnProps extends FlexVariants, OptionalChildProps {}
 
@@ -121,7 +121,7 @@ export interface ColumnProps extends FlexVariants, OptionalChildProps {}
  * @returns A `<div>` element with the computed flex class.
  * @kind component
  * @example <Column gap="small">{items}</Column>
- * @see https://dhoulb.github.io/shelving/ui/style/Flex/Column
+ * @see https://shelving.cc/ui/Column
  */
 export function Column({ children, column = true, ...props }: ColumnProps): ReactElement {
 	return <div className={getFlexClass({ column, ...props })}>{children}</div>;

--- a/modules/ui/style/Gap.tsx
+++ b/modules/ui/style/Gap.tsx
@@ -4,14 +4,14 @@ import GAP_CSS from "./Gap.module.css";
 /**
  * Allowed values for gap spacing for components that support `GapVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Gap/GapValue
+ * @see https://shelving.cc/ui/GapValue
  */
 export type GapValue = "none" | "xxsmall" | "xsmall" | "small" | "normal" | "large" | "xlarge" | "xxlarge";
 
 /**
  * Variant props for the gap between a component's children, e.g. `gap="large"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Gap/GapVariants
+ * @see https://shelving.cc/ui/GapVariants
  */
 export interface GapVariants {
 	/** Gap between child elements. */
@@ -24,7 +24,7 @@ export interface GapVariants {
  * @param variants
  * @returns The gap class string, or `undefined` when no `gap` is set.
  * @example getGapClass({ gap: "large" }) // "large"
- * @see https://dhoulb.github.io/shelving/ui/style/Gap/getGapClass
+ * @see https://shelving.cc/ui/getGapClass
  */
 export function getGapClass({ gap }: GapVariants): string | undefined {
 	return gap && getModuleClass(GAP_CSS, gap);

--- a/modules/ui/style/Padding.tsx
+++ b/modules/ui/style/Padding.tsx
@@ -4,7 +4,7 @@ import PADDING_CSS from "./Padding.module.css";
 /**
  * Allowed values for padding for components that support `PaddingVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Padding/PaddingVariant
+ * @see https://shelving.cc/ui/PaddingVariant
  */
 export type PaddingVariant =
 	| "none"
@@ -29,7 +29,7 @@ export type PaddingVariant =
 /**
  * Variant props for the block-padding (top + bottom) of a component, e.g. `padding="large"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Padding/PaddingVariants
+ * @see https://shelving.cc/ui/PaddingVariants
  */
 export interface PaddingVariants {
 	/** Block-padding (top + bottom) of the element. */
@@ -42,7 +42,7 @@ export interface PaddingVariants {
  * @param variants
  * @returns The padding class string, or `undefined` when no `padding` is set.
  * @example getPaddingClass({ padding: "large" }) // "large"
- * @see https://dhoulb.github.io/shelving/ui/style/Padding/getPaddingClass
+ * @see https://shelving.cc/ui/getPaddingClass
  */
 export function getPaddingClass({ padding }: PaddingVariants): string | undefined {
 	return padding && getModuleClass(PADDING_CSS, `padding-${padding}`);

--- a/modules/ui/style/Radius.tsx
+++ b/modules/ui/style/Radius.tsx
@@ -4,14 +4,14 @@ import RADIUS_CSS from "./Radius.module.css";
 /**
  * Allowed values for border radius for components that support `RadiusVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Radius/RadiusVariant
+ * @see https://shelving.cc/ui/RadiusVariant
  */
 export type RadiusVariant = "none" | "xxsmall" | "xsmall" | "small" | "normal" | "large" | "xlarge" | "xxlarge";
 
 /**
  * Variant props for the corner radius of an element, e.g. `radius="large"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Radius/RadiusVariants
+ * @see https://shelving.cc/ui/RadiusVariants
  */
 export interface RadiusVariants {
 	/** Corner radius of the element. */
@@ -24,7 +24,7 @@ export interface RadiusVariants {
  * @param variants
  * @returns The radius class string, or `undefined` when no `radius` is set.
  * @example getRadiusClass({ radius: "large" }) // "radius-large"
- * @see https://dhoulb.github.io/shelving/ui/style/Radius/getRadiusClass
+ * @see https://shelving.cc/ui/getRadiusClass
  */
 export function getRadiusClass({ radius }: RadiusVariants): string | undefined {
 	return radius && getModuleClass(RADIUS_CSS, `radius-${radius}`);

--- a/modules/ui/style/Scroll.tsx
+++ b/modules/ui/style/Scroll.tsx
@@ -9,7 +9,7 @@ const SCROLL_VERTICAL_CLASS = getModuleClass(SCROLLABLE_CSS, "vertical");
 /**
  * Variant props selecting which scroll axes are enabled on an element.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/ScrollProps
+ * @see https://shelving.cc/ui/ScrollProps
  */
 export interface ScrollVariants {
 	/** Vertical scrolling (defaults to `false`). */
@@ -24,7 +24,7 @@ export interface ScrollVariants {
  * @param variants
  * @returns The combined scroll class string (empty when neither axis is enabled).
  * @example getScrollClass({ horizontal: true }) // "horizontal"
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/getScrollClass
+ * @see https://shelving.cc/ui/getScrollClass
  */
 export function getScrollClass({ horizontal, vertical }: ScrollVariants): string {
 	return getClass(
@@ -36,7 +36,7 @@ export function getScrollClass({ horizontal, vertical }: ScrollVariants): string
 /**
  * Props for the `Scroll` component — children plus scroll-axis variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/ScrollComponentProps
+ * @see https://shelving.cc/ui/ScrollComponentProps
  */
 export interface ScrollComponentProps extends ChildProps, ScrollVariants {}
 
@@ -46,7 +46,7 @@ export interface ScrollComponentProps extends ChildProps, ScrollVariants {}
  * @returns A `<div>` element with the computed scroll class.
  * @kind component
  * @example <Scroll horizontal>{wideContent}</Scroll>
- * @see https://dhoulb.github.io/shelving/ui/style/Scroll/Scroll
+ * @see https://shelving.cc/ui/Scroll
  */
 export function Scroll({ children, ...props }: ScrollComponentProps): ReactElement {
 	return <div className={getScrollClass(props)}>{children}</div>;

--- a/modules/ui/style/Shadow.tsx
+++ b/modules/ui/style/Shadow.tsx
@@ -4,14 +4,14 @@ import SHADOW_CSS from "./Shadow.module.css";
 /**
  * Enumerated drop-shadow scale selectable via the `shadow="normal"` variant prop.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Shadow/ShadowVariant
+ * @see https://shelving.cc/ui/ShadowVariant
  */
 export type ShadowVariant = "none" | "xxsmall" | "xsmall" | "small" | "normal" | "large" | "xlarge" | "xxlarge";
 
 /**
  * Variant props for the drop shadow of an element, e.g. `shadow="large"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Shadow/ShadowVariants
+ * @see https://shelving.cc/ui/ShadowVariants
  */
 export interface ShadowVariants {
 	/** Drop shadow of the element. */
@@ -24,7 +24,7 @@ export interface ShadowVariants {
  * @param variants
  * @returns The shadow class string, or `undefined` when no `shadow` is set.
  * @example getShadowClass({ shadow: "large" }) // "shadow-large"
- * @see https://dhoulb.github.io/shelving/ui/style/Shadow/getShadowClass
+ * @see https://shelving.cc/ui/getShadowClass
  */
 export function getShadowClass({ shadow }: ShadowVariants): string | undefined {
 	return shadow && getModuleClass(SHADOW_CSS, `shadow-${shadow}`);

--- a/modules/ui/style/Space.tsx
+++ b/modules/ui/style/Space.tsx
@@ -4,7 +4,7 @@ import SPACE_CSS from "./Space.module.css";
 /**
  * Allowed values for block spacing for components that support `SpaceVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Space/SpaceValue
+ * @see https://shelving.cc/ui/SpaceValue
  */
 export type SpaceValue =
 	| "section"
@@ -31,7 +31,7 @@ export type SpaceValue =
 /**
  * Variants to control block spacing on components, e.g. `space="large"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Space/SpaceVariants
+ * @see https://shelving.cc/ui/SpaceVariants
  */
 export interface SpaceVariants {
 	/** Block spacing for this component. */
@@ -44,7 +44,7 @@ export interface SpaceVariants {
  * @param variants
  * @returns The space class string, or `undefined` when no `space` is set.
  * @example getSpaceClass({ space: "large" }) // "large"
- * @see https://dhoulb.github.io/shelving/ui/style/Space/getSpaceClass
+ * @see https://shelving.cc/ui/getSpaceClass
  */
 export function getSpaceClass({ space }: SpaceVariants): string | undefined {
 	return space && getModuleClass(SPACE_CSS, `space-${space}`);

--- a/modules/ui/style/Status.tsx
+++ b/modules/ui/style/Status.tsx
@@ -6,7 +6,7 @@ import { TINT_CLASS } from "./Tint.js";
 /**
  * Tuple of the status names selectable via the `status` variant prop.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Status/STATUSES
+ * @see https://shelving.cc/ui/STATUSES
  */
 export const STATUSES: ImmutableArray<Status> = ["loading", "info", "danger", "error", "warning", "success"];
 
@@ -14,14 +14,14 @@ export const STATUSES: ImmutableArray<Status> = ["loading", "info", "danger", "e
  * Allowed status names selected via the `status="info"` prop for components that support that support `StatusVariants`
  * - Applies a semantic tint color to the element.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Status/Status
+ * @see https://shelving.cc/ui/Status
  */
 export type Status = "loading" | "info" | "danger" | "error" | "warning" | "success";
 
 /**
  * Variant props for the semantic status of an element, e.g. `status="success"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Status/StatusVariants
+ * @see https://shelving.cc/ui/StatusVariants
  */
 export interface StatusVariants {
 	/** Status for the element. */
@@ -37,7 +37,7 @@ export interface StatusVariants {
  * @param variants
  * @returns The combined tint + status class string, or `undefined` when no `status` is set.
  * @example getStatusClass({ status: "success" }) // "tint success"
- * @see https://dhoulb.github.io/shelving/ui/style/Status/getStatusClass
+ * @see https://shelving.cc/ui/getStatusClass
  */
 export function getStatusClass({ status }: StatusVariants): string | undefined {
 	if (status) return getClass(TINT_CLASS, getModuleClass(STATUS_CSS, status));

--- a/modules/ui/style/Stroke.tsx
+++ b/modules/ui/style/Stroke.tsx
@@ -4,14 +4,14 @@ import STROKE_CSS from "./Stroke.module.css";
 /**
  * Allowed values for border thickness for components that support `StrokeVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Stroke/UIStroke
+ * @see https://shelving.cc/ui/UIStroke
  */
 export type StrokeVariant = "normal" | "thick";
 
 /**
  * Variant props for the border thickness of a component, e.g. `stroke="thick"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Stroke/StrokeVariants
+ * @see https://shelving.cc/ui/StrokeVariants
  */
 export interface StrokeVariants {
 	/** Border thickness of the component. */
@@ -24,7 +24,7 @@ export interface StrokeVariants {
  * @param variants
  * @returns The stroke class string, or `undefined` when no `stroke` is set.
  * @example getStrokeClass({ stroke: "thick" }) // "stroke-thick"
- * @see https://dhoulb.github.io/shelving/ui/style/Stroke/getStrokeClass
+ * @see https://shelving.cc/ui/getStrokeClass
  */
 export function getStrokeClass({ stroke }: StrokeVariants): string | undefined {
 	return stroke && getModuleClass(STROKE_CSS, stroke);

--- a/modules/ui/style/Tint.tsx
+++ b/modules/ui/style/Tint.tsx
@@ -4,7 +4,7 @@ import THEME_CSS from "./Tint.module.css";
 /**
  * Shades of the currently selected tint color, from `"00"` (black) through `"50"` (the hue itself) to `"100"` (white).
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Tint/TintVariant
+ * @see https://shelving.cc/ui/TintVariant
  */
 export type TintVariant =
 	| "00"
@@ -34,6 +34,6 @@ export type TintVariant =
  *
  * - Applied by colour/status helpers so an element can compose shades like `--tint-20` and `--tint-95` of the selected hue.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Tint/TINT_CLASS
+ * @see https://shelving.cc/ui/TINT_CLASS
  */
 export const TINT_CLASS = getModuleClass(THEME_CSS, "tint");

--- a/modules/ui/style/Typography.tsx
+++ b/modules/ui/style/Typography.tsx
@@ -5,35 +5,35 @@ import TYPOGRAPHY_CSS from "./Typography.module.css";
 /**
  * Allowed values for font size for components that support `TypographyVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/SizeVariant
+ * @see https://shelving.cc/ui/SizeVariant
  */
 export type SizeVariant = "xxsmall" | "xsmall" | "small" | "normal" | "large" | "xlarge" | "xxlarge";
 
 /**
  * Allowed values for font weight for components that support `TypographyVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/WeightVariant
+ * @see https://shelving.cc/ui/WeightVariant
  */
 export type WeightVariant = "title" | "body" | "label" | "code" | "normal" | "strong";
 
 /**
  * Allowed values for text case for components that support `TypographyVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/CaseVariant
+ * @see https://shelving.cc/ui/CaseVariant
  */
 export type CaseVariant = "title" | "body" | "label" | "code" | "upper" | "lower" | "normal";
 
 /**
  * Allowed values for font family for components that support `TypographyVariants`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/FontVariant
+ * @see https://shelving.cc/ui/FontVariant
  */
 export type FontVariant = "title" | "body" | "label" | "code" | "serif" | "sans" | "monospace";
 
 /**
  * Typographic variant props — font-family, weight, case, size, tint, alignment, and wrap, applied via `getTypographyClass()`
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/TypographyVariants
+ * @see https://shelving.cc/ui/TypographyVariants
  */
 export interface TypographyVariants {
 	/** Font size of the element. */
@@ -65,7 +65,7 @@ export interface TypographyVariants {
  *
  * @returns The combined typography class string, or `undefined` when no variants apply.
  * @example getTypographyClass({ font: "title", size: "large", center: true })
- * @see https://dhoulb.github.io/shelving/ui/style/Typography/getTypographyClass
+ * @see https://shelving.cc/ui/getTypographyClass
  */
 export function getTypographyClass({ tint, weight, font, case: caseValue, size, ...props }: TypographyVariants): string | undefined {
 	return getModuleClass(

--- a/modules/ui/style/Width.tsx
+++ b/modules/ui/style/Width.tsx
@@ -7,14 +7,14 @@ import WIDTH_CSS from "./Width.module.css";
  * - `full` — take the full available width.
  * - `fit` — shrink to fit the content's intrinsic width (`fit-content`).
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Width/WidthVariant
+ * @see https://shelving.cc/ui/WidthVariant
  */
 export type WidthVariant = "xxnarrow" | "xnarrow" | "narrow" | "normal" | "wide" | "xwide" | "xxwide" | "full" | "fit";
 
 /**
  * Variant props that set (or unconstrain) a component's width, e.g. `width="narrow"` or `width="12x"`.
  *
- * @see https://dhoulb.github.io/shelving/ui/style/Width/WidthVariants
+ * @see https://shelving.cc/ui/WidthVariants
  */
 export interface WidthVariants {
 	/** Width of the element. */
@@ -28,7 +28,7 @@ export interface WidthVariants {
  *
  * @returns The width class string, or `undefined` if no width variants are set.
  * @example getWidthClass({ width: "narrow" }) // "width narrow"
- * @see https://dhoulb.github.io/shelving/ui/style/Width/getWidthClass
+ * @see https://shelving.cc/ui/getWidthClass
  */
 export function getWidthClass({ width, grow }: WidthVariants): string | undefined {
 	if (width || grow) return getModuleClass(WIDTH_CSS, "width", width && `width-${width}`, grow && "grow");

--- a/modules/ui/table/Cell.tsx
+++ b/modules/ui/table/Cell.tsx
@@ -7,7 +7,7 @@ import type { OptionalChildProps } from "../util/index.js";
 /**
  * Props for `Cell` — width and typography variants plus `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Cell/CellProps
+ * @see https://shelving.cc/ui/CellProps
  */
 export interface CellProps extends WidthVariants, TypographyVariants, OptionalChildProps {
 	header?: boolean | undefined;
@@ -22,7 +22,7 @@ export interface CellProps extends WidthVariants, TypographyVariants, OptionalCh
  * @kind component
  * @returns Rendered `<td>` element.
  * @example <Cell width="12x" grow>A longer description that wants a sensible minimum width.</Cell>
- * @see https://dhoulb.github.io/shelving/ui/block/Cell/Cell
+ * @see https://shelving.cc/ui/Cell
  */
 export function Cell({ header = false, children, ...props }: CellProps): ReactElement {
 	const Component = header ? "th" : "td";

--- a/modules/ui/table/Table.tsx
+++ b/modules/ui/table/Table.tsx
@@ -12,7 +12,7 @@ const TABLE_CLASS = getModuleClass(TABLE_CSS, "table");
 /**
  * Props for `Table` — colour, space, typography, and width variants plus `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/block/Table/TableProps
+ * @see https://shelving.cc/ui/TableProps
  */
 export interface TableProps extends ColorVariants, SpaceVariants, TypographyVariants, WidthVariants, ChildProps {}
 
@@ -24,7 +24,7 @@ export interface TableProps extends ColorVariants, SpaceVariants, TypographyVari
  * @kind component
  * @returns Rendered `<table>` element.
  * @example <Table><tbody><tr><td>Cell</td></tr></tbody></Table>
- * @see https://dhoulb.github.io/shelving/ui/block/Table/Table
+ * @see https://shelving.cc/ui/Table
  */
 export function Table({ children, ...props }: TableProps): ReactElement {
 	return (

--- a/modules/ui/transition/CollapseTransition.tsx
+++ b/modules/ui/transition/CollapseTransition.tsx
@@ -5,7 +5,7 @@ import { Transition, type TransitionProps } from "./Transition.js";
 /**
  * Props for the `CollapseTransition` component — the shared transition variant props.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/CollapseTransition/CollapseTransitionProps
+ * @see https://shelving.cc/ui/CollapseTransitionProps
  */
 export interface CollapseTransitionProps extends TransitionProps {}
 
@@ -15,7 +15,7 @@ export interface CollapseTransitionProps extends TransitionProps {}
  * @kind component
  * @returns A `<Transition>` element configured with the `collapse` class.
  * @example <CollapseTransition>{visible && <Panel />}</CollapseTransition>
- * @see https://dhoulb.github.io/shelving/ui/transition/CollapseTransition/CollapseTransition
+ * @see https://shelving.cc/ui/CollapseTransition
  */
 export function CollapseTransition(props: CollapseTransitionProps): ReactElement {
 	return <Transition default="collapse" {...props} />;

--- a/modules/ui/transition/FadeTransition.tsx
+++ b/modules/ui/transition/FadeTransition.tsx
@@ -4,7 +4,7 @@ import { Transition, type TransitionProps } from "./Transition.js";
 /**
  * Props for the `FadeTransition` component — the shared transition variant props.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/FadeTransition/FadeTransitionProps
+ * @see https://shelving.cc/ui/FadeTransitionProps
  */
 export interface FadeTransitionProps extends TransitionProps {}
 
@@ -14,7 +14,7 @@ export interface FadeTransitionProps extends TransitionProps {}
  * @kind component
  * @returns A `<Transition>` element configured with the `fade` class.
  * @example <FadeTransition>{visible && <Toast />}</FadeTransition>
- * @see https://dhoulb.github.io/shelving/ui/transition/FadeTransition/FadeTransition
+ * @see https://shelving.cc/ui/FadeTransition
  */
 export function FadeTransition(props: FadeTransitionProps): ReactElement {
 	return <Transition default="fade" {...props} />;

--- a/modules/ui/transition/HorizontalTransition.tsx
+++ b/modules/ui/transition/HorizontalTransition.tsx
@@ -5,7 +5,7 @@ import { Transition, type TransitionProps } from "./Transition.js";
 /**
  * Props for the `HorizontalTransition` component — the shared transition variant props.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/HorizontalTransition/HorizontalTransitionProps
+ * @see https://shelving.cc/ui/HorizontalTransitionProps
  */
 export interface HorizontalTransitionProps extends TransitionProps {}
 
@@ -15,7 +15,7 @@ export interface HorizontalTransitionProps extends TransitionProps {}
  * @kind component
  * @returns A `<Transition>` element configured with the horizontal slide classes.
  * @example <HorizontalTransition>{currentStep}</HorizontalTransition>
- * @see https://dhoulb.github.io/shelving/ui/transition/HorizontalTransition/HorizontalTransition
+ * @see https://shelving.cc/ui/HorizontalTransition
  */
 export function HorizontalTransition(props: HorizontalTransitionProps): ReactElement {
 	return <Transition default="slideRight" forward="slideRight" back="slideLeft" {...props} />;

--- a/modules/ui/transition/Transition.tsx
+++ b/modules/ui/transition/Transition.tsx
@@ -8,7 +8,7 @@ import "./Transition.css";
 /**
  * Variant props shared by every transition component.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/Transition/TransitionProps
+ * @see https://shelving.cc/ui/TransitionProps
  */
 export interface TransitionProps extends ChildProps {
 	/** Render this transition above other transitions (z-index: 100 on the group). */
@@ -26,7 +26,7 @@ export interface TransitionProps extends ChildProps {
  * @param props Transition class overrides (`default`/`forward`/`back`) plus `children` and variant props.
  * @returns A `<ViewTransition>` element wrapping the children.
  * @example <Transition default="fade">{content}</Transition>
- * @see https://dhoulb.github.io/shelving/ui/transition/Transition/Transition
+ * @see https://shelving.cc/ui/Transition
  */
 export function Transition({
 	children,

--- a/modules/ui/transition/VerticalTransition.tsx
+++ b/modules/ui/transition/VerticalTransition.tsx
@@ -5,7 +5,7 @@ import { Transition, type TransitionProps } from "./Transition.js";
 /**
  * Props for the `VerticalTransition` component — the shared transition variant props.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/VerticalTransition/VerticalTransitionProps
+ * @see https://shelving.cc/ui/VerticalTransitionProps
  */
 export interface VerticalTransitionProps extends TransitionProps {}
 
@@ -15,7 +15,7 @@ export interface VerticalTransitionProps extends TransitionProps {}
  * @kind component
  * @returns A `<Transition>` element configured with the vertical slide classes.
  * @example <VerticalTransition>{currentStep}</VerticalTransition>
- * @see https://dhoulb.github.io/shelving/ui/transition/VerticalTransition/VerticalTransition
+ * @see https://shelving.cc/ui/VerticalTransition
  */
 export function VerticalTransition(props: VerticalTransitionProps): ReactElement {
 	return <Transition default="slideDown" forward="slideDown" back="slideUp" {...props} />;

--- a/modules/ui/transition/util.tsx
+++ b/modules/ui/transition/util.tsx
@@ -7,7 +7,7 @@ import { addTransitionType } from "react";
  * - Each key is a "transition type" set with the React `addTransitionType()` API inside a `startTransition()` callback, e.g. `"forward"`.
  * - Each value is a "transition class" that React sets on the element as its `view-transition-class: forward;` CSS property — should correspond to a `::view-transition-old(.slideForward)` rule.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/util/TransitionClasses
+ * @see https://shelving.cc/ui/TransitionClasses
  */
 export type TransitionClasses = {
 	default: string;
@@ -18,7 +18,7 @@ export type TransitionClasses = {
 /**
  * Known view-transition type names that all transitions support — the keys of `TransitionClasses`.
  *
- * @see https://dhoulb.github.io/shelving/ui/transition/util/TransitionType
+ * @see https://shelving.cc/ui/TransitionType
  */
 export type TransitionType = keyof TransitionClasses;
 
@@ -27,7 +27,7 @@ export type TransitionType = keyof TransitionClasses;
  *
  * @param type The transition type to activate, constrained to a known `TransitionType`.
  * @example setTransitionType("forward")
- * @see https://dhoulb.github.io/shelving/ui/transition/util/setTransitionType
+ * @see https://shelving.cc/ui/setTransitionType
  */
 export function setTransitionType(type: TransitionType): void {
 	addTransitionType(type);

--- a/modules/ui/tree/TreeApp.tsx
+++ b/modules/ui/tree/TreeApp.tsx
@@ -13,7 +13,7 @@ import { TreeSidebar } from "./TreeSidebar.js";
 /**
  * Props for the `TreeApp` component — the tree to render plus optional extra routes and app meta.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeApp/TreeAppProps
+ * @see https://shelving.cc/ui/TreeAppProps
  */
 export interface TreeAppProps extends PossibleMeta {
 	/** The tree elements to display. */
@@ -37,7 +37,7 @@ export interface TreeAppProps extends PossibleMeta {
  * @kind component
  * @returns The configured `<App>` element with sidebar layout and tree routing.
  * @example <TreeApp tree={tree} title="Docs" />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeApp/TreeApp
+ * @see https://shelving.cc/ui/TreeApp
  */
 export function TreeApp({ tree, routes: extraRoutes, ...meta }: TreeAppProps): ReactElement {
 	// URLs that don't resolve to a tree element fall through to this router: the built-in index page plus any extra routes.

--- a/modules/ui/tree/TreeBreadcrumbs.tsx
+++ b/modules/ui/tree/TreeBreadcrumbs.tsx
@@ -13,7 +13,7 @@ import { useTreeMap } from "./TreeContext.js";
 /**
  * Props for the `TreeBreadcrumbs` component — typography, space, and flex variant props.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeBreadcrumbs/TreeBreadcrumbsProps
+ * @see https://shelving.cc/ui/TreeBreadcrumbsProps
  */
 export interface TreeBreadcrumbsProps extends TypographyVariants, SpaceVariants, FlexVariants {}
 
@@ -29,7 +29,7 @@ export interface TreeBreadcrumbsProps extends TypographyVariants, SpaceVariants,
  * @returns A `<nav>` of breadcrumb links, or `null` at the tree root.
  * @kind component
  * @example <TreeBreadcrumbs />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeBreadcrumbs/TreeBreadcrumbs
+ * @see https://shelving.cc/ui/TreeBreadcrumbs
  */
 export function TreeBreadcrumbs({ tint = "70", left = true, wrap = true, ...variants }: TreeBreadcrumbsProps): ReactElement | null {
 	const map = useTreeMap();

--- a/modules/ui/tree/TreeButton.tsx
+++ b/modules/ui/tree/TreeButton.tsx
@@ -5,7 +5,7 @@ import { getTreeElement, useTreeMap } from "./TreeContext.js";
 /**
  * Props for the `TreeButton` component — the element reference plus button variants.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeButton/TreeButtonProps
+ * @see https://shelving.cc/ui/TreeButtonProps
  */
 export interface TreeButtonProps extends ButtonVariants {
 	/** Reference to an element in the tree — a flat key (`"Store"`, `"Store.get"`) or a canonical path (`"/schema/BooleanSchema"`). */
@@ -24,7 +24,7 @@ export interface TreeButtonProps extends ButtonVariants {
  * @returns A `<Button>` element linking to the resolved element, or a plain label on a miss.
  * @kind component
  * @example <TreeButton name="Store.get">Store.get()</TreeButton>
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeButton/TreeButton
+ * @see https://shelving.cc/ui/TreeButton
  */
 export function TreeButton({ name, children, small = true, plain = true, ...variants }: TreeButtonProps): ReactElement {
 	const element = getTreeElement(useTreeMap(), name);

--- a/modules/ui/tree/TreeCard.tsx
+++ b/modules/ui/tree/TreeCard.tsx
@@ -10,7 +10,7 @@ import { Subheading } from "../block/Subheading.js";
  * @returns A `<Card>` linking to the element's canonical `path`.
  * @kind component
  * @example <TreeCard {...element.props} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeCard/TreeCard
+ * @see https://shelving.cc/ui/TreeCard
  */
 export function TreeCard({ path, name, title, description }: TreeElementProps): ReactNode {
 	// `path` is the element's own canonical URL, stamped by `flattenTree()` — link straight to it.

--- a/modules/ui/tree/TreeCards.tsx
+++ b/modules/ui/tree/TreeCards.tsx
@@ -8,7 +8,7 @@ import { TreeCard } from "./TreeCard.js";
 /**
  * Mapping + Mapper pair for tree cards — wrap children in `<TreeCardMapping>` to override the per-type card renderers.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeCards/TreeCardMapping
+ * @see https://shelving.cc/ui/TreeCardMapping
  */
 export const [TreeCardMapping, TreeCardMapper] = createMapper({
 	"tree-element": TreeCard,
@@ -18,7 +18,7 @@ export const [TreeCardMapping, TreeCardMapper] = createMapper({
 /**
  * Props for the `TreeCards` component — the tree elements to render as cards.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeCards/TreeCardsProps
+ * @see https://shelving.cc/ui/TreeCardsProps
  */
 export interface TreeCardsProps {
 	/** The children to render as cards. */
@@ -34,7 +34,7 @@ export interface TreeCardsProps {
  * @returns A `<TreeCardMapper>` rendering each element as a card.
  * @kind component
  * @example <TreeCards>{element.props.children}</TreeCards>
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeCards/TreeCards
+ * @see https://shelving.cc/ui/TreeCards
  */
 export function TreeCards({ children }: TreeCardsProps): ReactNode {
 	return <TreeCardMapper>{walkElements(children)}</TreeCardMapper>;

--- a/modules/ui/tree/TreeContext.tsx
+++ b/modules/ui/tree/TreeContext.tsx
@@ -6,7 +6,7 @@ import { flattenTree, type TreeElement } from "../../util/tree.js";
  *
  * - Keyed by flat name (`"BooleanSchema"`, `"Class.member"`) and canonical path (`"/schema/BooleanSchema"`) for fast cross-reference lookup.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/TreeContext
+ * @see https://shelving.cc/ui/TreeContext
  */
 export const TreeContext = createContext<ReadonlyMap<string, TreeElement>>(new Map());
 TreeContext.displayName = "TreeContext";
@@ -21,7 +21,7 @@ TreeContext.displayName = "TreeContext";
  * @returns A `<TreeContext>` provider wrapping the children with the flattened map.
  * @kind component
  * @example <TreeProvider tree={tree}>{children}</TreeProvider>
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/TreeProvider
+ * @see https://shelving.cc/ui/TreeProvider
  */
 export function TreeProvider({ tree, children }: { readonly tree: TreeElement; readonly children: ReactNode }): ReactNode {
 	const parent = use(TreeContext);
@@ -36,7 +36,7 @@ export function TreeProvider({ tree, children }: { readonly tree: TreeElement; r
  *
  * @returns The flattened `key` → `element` map, or an empty map when no `<TreeProvider>` is present.
  * @example const element = useTreeMap().get("Store.get");
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/useTreeMap
+ * @see https://shelving.cc/ui/useTreeMap
  */
 export function useTreeMap(): ReadonlyMap<string, TreeElement> {
 	return use(TreeContext);
@@ -54,7 +54,7 @@ export function useTreeMap(): ReadonlyMap<string, TreeElement> {
  * @param ref The reference string — a flat key, canonical path, or token written in its display form.
  * @returns The resolved element, or `undefined` on a miss.
  * @example getTreeElement(useTreeMap(), "formatDate()") // the `formatDate` element
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeContext/getTreeElement
+ * @see https://shelving.cc/ui/getTreeElement
  */
 export function getTreeElement(map: ReadonlyMap<string, TreeElement>, ref: string): TreeElement | undefined {
 	const exact = map.get(ref);

--- a/modules/ui/tree/TreeIndexPage.tsx
+++ b/modules/ui/tree/TreeIndexPage.tsx
@@ -41,7 +41,7 @@ const INDEX_LIMIT = 100;
  * @kind component
  * @returns A `<Page>` with a search input, kind checkboxes, and a flat card listing of results.
  * @example <Router routes={{ [TREE_INDEX_PATH]: TreeIndexPage }} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeIndexPage/TreeIndexPage
+ * @see https://shelving.cc/ui/TreeIndexPage
  */
 export function TreeIndexPage(): ReactNode {
 	const [query, setQuery] = useState("");

--- a/modules/ui/tree/TreeLink.tsx
+++ b/modules/ui/tree/TreeLink.tsx
@@ -6,7 +6,7 @@ import { getTreeElement, useTreeMap } from "./TreeContext.js";
 /**
  * Props for the `TreeLink` component — the element reference plus an optional label.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeLink/TreeLinkProps
+ * @see https://shelving.cc/ui/TreeLinkProps
  */
 export interface TreeLinkProps extends CodeProps {
 	/** Reference to an element in the tree — a flat key (`"BooleanSchema"`, `"Store.get"`) or a canonical path (`"/schema/BooleanSchema"`). */
@@ -23,7 +23,7 @@ export interface TreeLinkProps extends CodeProps {
  * @kind component
  * @returns A `<Code>` token, wrapped in a `<Link>` when the reference resolves.
  * @example <TreeLink name="BooleanSchema" />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeLink/TreeLink
+ * @see https://shelving.cc/ui/TreeLink
  */
 export function TreeLink({ name, children, ...props }: TreeLinkProps): ReactElement {
 	const href = getTreeElement(useTreeMap(), name)?.props.path;

--- a/modules/ui/tree/TreeMarkup.tsx
+++ b/modules/ui/tree/TreeMarkup.tsx
@@ -10,7 +10,7 @@ import { TreeLink } from "./TreeLink.js";
  * - Reuses `CODE_RULE`'s regexp, contexts, and priority — only the renderer changes — so it masks and matches identically to the default inline-code rule.
  * - The span's text becomes the link `name`: a hit links to the token's canonical page, a miss falls back to a plain code token (see `TreeLink`), so unknown spans (`bun run fix`, `string`, …) stay code.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMarkup/TREE_CODE_RULE
+ * @see https://shelving.cc/ui/TREE_CODE_RULE
  */
 export const TREE_CODE_RULE: MarkupRule = {
 	...CODE_RULE,
@@ -21,7 +21,7 @@ export const TREE_CODE_RULE: MarkupRule = {
  * Default markup rules with the inline-code rule swapped for `TREE_CODE_RULE` — every backtick span auto-links to its documented token.
  * - Identical to `MARKUP_RULES` with only `CODE_RULE` replaced, so any future change to the default rule set flows through.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMarkup/TREE_MARKUP_RULES
+ * @see https://shelving.cc/ui/TREE_MARKUP_RULES
  */
 export const TREE_MARKUP_RULES: MarkupRules = MARKUP_RULES.map(rule => (rule === CODE_RULE ? TREE_CODE_RULE : rule));
 
@@ -35,7 +35,7 @@ export const TREE_MARKUP_RULES: MarkupRules = MARKUP_RULES.map(rule => (rule ===
  * @returns The parsed markup as React nodes, or `null` when `children` is empty.
  * @kind component
  * @example <Prose><TreeMarkup>{`Use \`BooleanSchema\` to validate.`}</TreeMarkup></Prose>
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMarkup/TreeMarkup
+ * @see https://shelving.cc/ui/TreeMarkup
  */
 export function TreeMarkup({ rules = TREE_MARKUP_RULES, ...props }: MarkupProps): ReactNode {
 	return <Markup rules={rules} {...props} />;

--- a/modules/ui/tree/TreeMenu.tsx
+++ b/modules/ui/tree/TreeMenu.tsx
@@ -14,7 +14,7 @@ import { createMapper } from "../misc/Mapper.js";
  * @param element The element to test.
  * @returns `true` when the element should appear in the menu, `false` otherwise.
  * @example matchMenuElement(element) // true
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/matchMenuElement
+ * @see https://shelving.cc/ui/matchMenuElement
  */
 export function matchMenuElement(element: Element): boolean {
 	const { type, props } = element;
@@ -39,7 +39,7 @@ interface TreeMenuExtras {
  * @returns A `<MenuItem>` for the element, with a nested `<Menu>` when it has menu-eligible children.
  * @kind component
  * @example <TreeMenuItem {...element.props} path="/" />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/TreeMenuItem
+ * @see https://shelving.cc/ui/TreeMenuItem
  */
 export function TreeMenuItem({ path = "/", name, title, children }: TreeElementProps & TreeMenuExtras): ReactNode {
 	const href = joinPath(path, name);
@@ -59,7 +59,7 @@ export function TreeMenuItem({ path = "/", name, title, children }: TreeElementP
 /**
  * Mapping + Mapper pair for the menu — wrap children in `<TreeMenuMapping>` to override the per-type menu-item renderers.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/TreeMenuMapping
+ * @see https://shelving.cc/ui/TreeMenuMapping
  */
 export const [TreeMenuMapping, TreeMenuMapper] = createMapper<TreeMenuExtras>({
 	"tree-element": TreeMenuItem,
@@ -69,7 +69,7 @@ export const [TreeMenuMapping, TreeMenuMapper] = createMapper<TreeMenuExtras>({
 /**
  * Props for the `TreeMenu` component — the root tree element plus its URL path.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/TreeMenuProps
+ * @see https://shelving.cc/ui/TreeMenuProps
  */
 export interface TreeMenuProps {
 	/** Root element whose children become the navigation links. */
@@ -88,7 +88,7 @@ export interface TreeMenuProps {
  * @kind component
  * @returns A `<Menu>` of navigation links to the root's children.
  * @example <TreeMenu tree={tree} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeMenu/TreeMenu
+ * @see https://shelving.cc/ui/TreeMenu
  */
 export function TreeMenu({ path = "/", tree }: TreeMenuProps): ReactNode {
 	return (

--- a/modules/ui/tree/TreePage.tsx
+++ b/modules/ui/tree/TreePage.tsx
@@ -16,7 +16,7 @@ import { TreeMarkup } from "./TreeMarkup.js";
  * @returns A `<Page>` with the title, prose content, and a stack of child cards.
  * @kind component
  * @example <TreePage {...element.props} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreePage/TreePage
+ * @see https://shelving.cc/ui/TreePage
  */
 export function TreePage({ title, name, description, content, children }: TreeElementProps): ReactNode {
 	return (

--- a/modules/ui/tree/TreeRouter.tsx
+++ b/modules/ui/tree/TreeRouter.tsx
@@ -12,7 +12,7 @@ import { TreePage } from "./TreePage.js";
 /**
  * Mapping + Mapper pair for tree routers — wrap children in `<TreeRouterMapping>` to override the per-type page renderers.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeRouter/TreeRouterMapping
+ * @see https://shelving.cc/ui/TreeRouterMapping
  */
 export const [TreeRouterMapping, TreeRouterMapper] = createMapper({
 	"tree-element": TreePage,
@@ -22,7 +22,7 @@ export const [TreeRouterMapping, TreeRouterMapper] = createMapper({
 /**
  * Props for the `TreeRouter` component — the tree to route plus an optional fallback and app meta.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeRouter/TreeRouterProps
+ * @see https://shelving.cc/ui/TreeRouterProps
  */
 export interface TreeRouterProps extends PossibleMeta {
 	/** The tree of elements to match routes for. */
@@ -47,7 +47,7 @@ export interface TreeRouterProps extends PossibleMeta {
  * @throws `NotFoundError` When no element matches the URL and no `fallback` is given.
  * @kind component
  * @example <TreeRouter tree={tree} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeRouter/TreeRouter
+ * @see https://shelving.cc/ui/TreeRouter
  */
 export function TreeRouter({ tree, fallback, ...meta }: TreeRouterProps): ReactNode {
 	const { path, ...combined } = requireMetaURL(meta);

--- a/modules/ui/tree/TreeSidebar.tsx
+++ b/modules/ui/tree/TreeSidebar.tsx
@@ -11,7 +11,7 @@ import { matchMenuElement, TreeMenuMapper } from "./TreeMenu.js";
 /**
  * Props for the `TreeSidebar` component — the root tree element plus its URL path.
  *
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeSidebar/TreeSidebarProps
+ * @see https://shelving.cc/ui/TreeSidebarProps
  */
 export interface TreeSidebarProps {
 	/** Root element of the tree. */
@@ -32,7 +32,7 @@ export interface TreeSidebarProps {
  * @kind component
  * @returns The sectioned sidebar — home/index links, a search input, and either the tree menu or search results.
  * @example <TreeSidebar tree={tree} />
- * @see https://dhoulb.github.io/shelving/ui/tree/TreeSidebar/TreeSidebar
+ * @see https://shelving.cc/ui/TreeSidebar
  */
 export function TreeSidebar({ tree, path = "/" as AbsolutePath }: TreeSidebarProps): ReactNode {
 	const [query, setQuery] = useState("");

--- a/modules/ui/util/context.ts
+++ b/modules/ui/util/context.ts
@@ -14,7 +14,7 @@ import { type Nullish, notNullish } from "../../util/null.js";
  * @returns The current context value, guaranteed non-nullish.
  * @throws RequiredError If the context value is `null` or `undefined` (i.e. used outside its provider).
  * @example const theme = requireContext(ThemeContext);
- * @see https://dhoulb.github.io/shelving/ui/util/context/requireContext
+ * @see https://shelving.cc/ui/requireContext
  */
 export function requireContext<T>(context: Context<T | null>, caller?: AnyCaller): T;
 export function requireContext<T>(context: Context<T | undefined>, caller?: AnyCaller): T;

--- a/modules/ui/util/css.ts
+++ b/modules/ui/util/css.ts
@@ -8,7 +8,7 @@ import { getDictionaryItems, type ImmutableDictionary, isDictionary } from "../.
  * - `null` or `undefined` — ignored.
  * - Array of classnames — recursively parsed.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/css/Classes
+ * @see https://shelving.cc/ui/Classes
  */
 export type Classes = string | null | undefined | readonly Classes[] | Variants;
 
@@ -21,7 +21,7 @@ export type Classes = string | null | undefined | readonly Classes[] | Variants;
  * Typed as `object` (not `Data`/`Record<string, unknown>`) so plain `interface` types are accepted —
  * interfaces lack an implicit string index signature, so they don't satisfy index-signature types.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/css/Variants
+ * @see https://shelving.cc/ui/Variants
  */
 export interface Variants {
 	readonly [key: string]: boolean;
@@ -30,7 +30,7 @@ export interface Variants {
 /**
  * CSS modules mapping of local class names to hashed runtime class names.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/css/CSSModule
+ * @see https://shelving.cc/ui/CSSModule
  */
 export type CSSModule = ImmutableDictionary<string | undefined>;
 
@@ -41,7 +41,7 @@ export type CSSModule = ImmutableDictionary<string | undefined>;
  * @param classes The input set of classes to merge.
  * @returns The merged string classname.
  * @example getClass("button", { active: true, disabled: false }) // "button active"
- * @see https://dhoulb.github.io/shelving/ui/util/css/getClass
+ * @see https://shelving.cc/ui/getClass
  */
 export function getClass(...classes: unknown[]): string {
 	return Array.from(getClasses(classes)).join(" ");
@@ -80,7 +80,7 @@ function* getClasses(classes: unknown): Iterable<string> {
  * @param classes Class keys/values to merge.
  * @returns The merged string classname, or `undefined` when `module` is a string (unprocessed CSS module).
  * @example getModuleClass(styles, "base", { active: true }) // "base_x7q active_p2k"
- * @see https://dhoulb.github.io/shelving/ui/util/css/getModuleClass
+ * @see https://shelving.cc/ui/getModuleClass
  */
 export function getModuleClass(module: CSSModule | string, ...classes: unknown[]): string | undefined {
 	if (isDictionary(module)) return Array.from(getModuleClasses(module, classes)).join(" ");

--- a/modules/ui/util/event.ts
+++ b/modules/ui/util/event.ts
@@ -5,7 +5,7 @@
  *
  * @param e The event to suppress the default action of.
  * @example <form onSubmit={eventPreventDefault}>…</form>
- * @see https://dhoulb.github.io/shelving/ui/util/event/eventPreventDefault
+ * @see https://shelving.cc/ui/eventPreventDefault
  */
 export function eventPreventDefault(e: Pick<Event, "preventDefault">) {
 	e.preventDefault();

--- a/modules/ui/util/focus.ts
+++ b/modules/ui/util/focus.ts
@@ -8,7 +8,7 @@ import type { Nullish } from "../../util/null.js";
  *
  * @param el The container element to focus the first focusable descendant of.
  * @example focusFirstFocusable(dialogRef.current);
- * @see https://dhoulb.github.io/shelving/ui/util/focus/focusFirstFocusable
+ * @see https://shelving.cc/ui/focusFirstFocusable
  */
 export function focusFirstFocusable(el: Nullish<Element>): void {
 	if (el instanceof HTMLElement) getFirstFocusable(el)?.focus();
@@ -22,7 +22,7 @@ export function focusFirstFocusable(el: Nullish<Element>): void {
  * @param element The container to keep focus within.
  * @param nextTarget The element focus is moving to.
  * @example loopFocus(dialog, document.activeElement);
- * @see https://dhoulb.github.io/shelving/ui/util/focus/loopFocus
+ * @see https://shelving.cc/ui/loopFocus
  */
 export function loopFocus(element: Nullish<Element>, nextTarget: Nullish<Element>): void {
 	if (element && nextTarget && !element.contains(nextTarget)) focusFirstFocusable(element);
@@ -35,7 +35,7 @@ export function loopFocus(element: Nullish<Element>, nextTarget: Nullish<Element
  *
  * @param event The `blur` event, providing `currentTarget` (the container) and `relatedTarget` (the new focus target).
  * @example <div onBlur={eventLoopFocus}>…</div>
- * @see https://dhoulb.github.io/shelving/ui/util/focus/eventLoopFocus
+ * @see https://shelving.cc/ui/eventLoopFocus
  */
 export function eventLoopFocus({ currentTarget, relatedTarget }: { currentTarget: Element; relatedTarget: Element | null }): void {
 	loopFocus(currentTarget, relatedTarget);

--- a/modules/ui/util/meta.ts
+++ b/modules/ui/util/meta.ts
@@ -9,49 +9,49 @@ import { type ImmutableURL, type PossibleURL, requireURL } from "../../util/url.
 /**
  * Set of named meta `<meta />` tags in `{ name: content }` format.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/MetaTags
+ * @see https://shelving.cc/ui/MetaTags
  */
 export type MetaTags = ImmutableDictionary<string | boolean | null | undefined>;
 
 /**
  * Set of resolved meta `<link />` tags in `{ rel: href }` format (hrefs already absolutified to `ImmutableURI`).
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/MetaLinks
+ * @see https://shelving.cc/ui/MetaLinks
  */
 export type MetaLinks = ImmutableDictionary<ImmutableURI>;
 
 /**
  * Set of input meta `<link />` tags in `{ rel: href }` format, before hrefs are resolved.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/PossibleMetaLinks
+ * @see https://shelving.cc/ui/PossibleMetaLinks
  */
 export type PossibleMetaLinks = ImmutableDictionary<Nullish<PossibleLink>>;
 
 /**
  * Set of resolved linked assets in `(href)[]` format (hrefs already absolutified to `ImmutableURI`).
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/MetaAssets
+ * @see https://shelving.cc/ui/MetaAssets
  */
 export type MetaAssets = ImmutableArray<ImmutableURI>;
 
 /**
  * Set of input linked assets in `(href)[]` format, before hrefs are resolved.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/PossibleMetaAssets
+ * @see https://shelving.cc/ui/PossibleMetaAssets
  */
 export type PossibleMetaAssets = ImmutableArray<Nullish<PossibleLink>>;
 
 /**
  * Type for a meta `Content-Security-Policy` tag in `{ resource: string[] }` format.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/MetaCSP
+ * @see https://shelving.cc/ui/MetaCSP
  */
 export type MetaCSP = { readonly [resource: string]: string[] };
 
 /**
  * Combined meta data for a website page — title, URLs, description, CSP, tags, links, and assets.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/Meta
+ * @see https://shelving.cc/ui/Meta
  */
 export interface Meta {
 	/** Base URL for the app (used to resolve `url` and set as `<base>` tag in `<Head>`). */
@@ -82,7 +82,7 @@ export interface Meta {
 /**
  * Input metadata that can be parsed and converted to a fully-resolved `Meta`.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/meta/PossibleMeta
+ * @see https://shelving.cc/ui/PossibleMeta
  */
 export interface PossibleMeta extends Omit<Meta, "root" | "url" | "links" | "scripts" | "modules" | "stylesheets"> {
 	/** Base URL for the app — accepts a string or `URL`, resolved with `requireURL()`. */
@@ -114,7 +114,7 @@ export interface PossibleMeta extends Omit<Meta, "root" | "url" | "links" | "scr
  * @param csp The CSP to join, as a `{ resource: string[] }` object or a ready-made string.
  * @returns The joined CSP string, or `undefined` if `csp` was nullish.
  * @example joinMetaCSP({ "default-src": ["'self'"], "img-src": ["*"] }) // "default-src 'self'; img-src *"
- * @see https://dhoulb.github.io/shelving/ui/util/meta/joinMetaCSP
+ * @see https://shelving.cc/ui/joinMetaCSP
  */
 export function joinMetaCSP(csp: Nullish<MetaCSP>): string | undefined {
 	if (typeof csp === "string") return csp;
@@ -128,7 +128,7 @@ const _mapCSP = ([key, content]: [string, string[]]) => `${key} ${content.join("
  * @param titles Title segments to join, most-specific first.
  * @returns The joined title string.
  * @example joinTitles("Messages", "Manchester Runners") // "Messages - Manchester Runners"
- * @see https://dhoulb.github.io/shelving/ui/util/meta/joinTitles
+ * @see https://shelving.cc/ui/joinTitles
  */
 export function joinTitles(...titles: (string | undefined)[]): string {
 	return titles.filter(Boolean).join(" - ");
@@ -146,7 +146,7 @@ export function joinTitles(...titles: (string | undefined)[]): string {
  * @param caller Function to attribute thrown URL-resolution errors to (defaults to `mergeMeta`).
  * @returns A new fully-resolved `Meta` combining both inputs.
  * @example mergeMeta(currentMeta, { title: "Messages", url: "./messages" })
- * @see https://dhoulb.github.io/shelving/ui/util/meta/mergeMeta
+ * @see https://shelving.cc/ui/mergeMeta
  */
 export function mergeMeta(meta1: Meta, meta2: PossibleMeta, caller: AnyCaller = mergeMeta): Meta {
 	const title = joinTitles(meta2.title, meta1.title);
@@ -177,7 +177,7 @@ export function mergeMeta(meta1: Meta, meta2: PossibleMeta, caller: AnyCaller = 
  * @param caller Function to attribute thrown URL-resolution errors to (defaults to `createMeta`).
  * @returns A new fully-resolved `Meta`.
  * @example createMeta({ app: "Manchester Runners", url: "https://run.com" })
- * @see https://dhoulb.github.io/shelving/ui/util/meta/createMeta
+ * @see https://shelving.cc/ui/createMeta
  */
 export function createMeta(meta: PossibleMeta, caller: AnyCaller = createMeta): Meta {
 	return mergeMeta({}, meta, caller);
@@ -194,7 +194,7 @@ export function createMeta(meta: PossibleMeta, caller: AnyCaller = createMeta): 
  * @param params URI params to set on the resolved URL (replaces existing params).
  * @param caller Function to attribute thrown URL-resolution errors to (defaults to `mergeMetaURL`).
  * @returns The resolved URL, or `undefined` if neither `next` nor `current` was set.
- * @see https://dhoulb.github.io/shelving/ui/util/meta/mergeMetaURL
+ * @see https://shelving.cc/ui/mergeMetaURL
  */
 export function mergeMetaURL(
 	base: ImmutableURL | undefined,
@@ -213,7 +213,7 @@ export function mergeMetaURL(
  * @param current The existing tags.
  * @param next The new tags to merge on top.
  * @returns The merged tags, or `undefined` if both inputs were unset.
- * @see https://dhoulb.github.io/shelving/ui/util/meta/mergeMetaTags
+ * @see https://shelving.cc/ui/mergeMetaTags
  */
 export function mergeMetaTags(current: MetaTags | undefined, next: MetaTags | undefined): MetaTags | undefined {
 	return current && next ? { ...current, ...next } : current || next;
@@ -230,7 +230,7 @@ export function mergeMetaTags(current: MetaTags | undefined, next: MetaTags | un
  * @param root The root URL, used to resolve absolute hrefs.
  * @param caller Function to attribute thrown URL-resolution errors to (defaults to `mergeMetaLinks`).
  * @returns The merged resolved links, or `undefined` if there was nothing to merge.
- * @see https://dhoulb.github.io/shelving/ui/util/meta/mergeMetaLinks
+ * @see https://shelving.cc/ui/mergeMetaLinks
  */
 export function mergeMetaLinks(
 	current: MetaLinks | undefined,
@@ -261,7 +261,7 @@ function* _yieldMetaLinkEntries(
  * @param root The root URL, used to resolve absolute hrefs.
  * @param caller Function to attribute thrown URL-resolution errors to (defaults to `mergeMetaAssets`).
  * @returns The combined resolved asset list, or `undefined` if there was nothing to merge.
- * @see https://dhoulb.github.io/shelving/ui/util/meta/mergeMetaAssets
+ * @see https://shelving.cc/ui/mergeMetaAssets
  */
 export function mergeMetaAssets(
 	current: MetaAssets | undefined,

--- a/modules/ui/util/notice.ts
+++ b/modules/ui/util/notice.ts
@@ -20,7 +20,7 @@ class NoticeEvent extends CustomEvent<{ message: ReactNode; status: Status | und
  * @param status Optional status (`"success"`, `"error"`, etc.) controlling how the notice is styled.
  * @param el Element to dispatch the event on (defaults to `window`).
  * @example notify("Saved your changes", "success");
- * @see https://dhoulb.github.io/shelving/ui/util/notice/notify
+ * @see https://shelving.cc/ui/notify
  */
 export function notify(message: ReactNode, status?: Status | undefined, el: EventTarget = window): void {
 	el.dispatchEvent(
@@ -37,7 +37,7 @@ export function notify(message: ReactNode, status?: Status | undefined, el: Even
  * @param message The success message to show, as a React node.
  * @param el Element to dispatch the event on (defaults to `window`).
  * @example notifySuccess("Profile updated");
- * @see https://dhoulb.github.io/shelving/ui/util/notice/notifySuccess
+ * @see https://shelving.cc/ui/notifySuccess
  */
 export function notifySuccess(message: ReactNode, el?: EventTarget) {
 	notify(message, "success", el);
@@ -49,7 +49,7 @@ export function notifySuccess(message: ReactNode, el?: EventTarget) {
  * @param message The error message to show, as a React node.
  * @param el Element to dispatch the event on (defaults to `window`).
  * @example notifyError("Could not save your changes");
- * @see https://dhoulb.github.io/shelving/ui/util/notice/notifyError
+ * @see https://shelving.cc/ui/notifyError
  */
 export function notifyError(message: ReactNode, el?: EventTarget) {
 	notify(message, "error", el);
@@ -64,7 +64,7 @@ export function notifyError(message: ReactNode, el?: EventTarget) {
  * @param thrown The thrown value to report.
  * @param el Element to dispatch the event on (defaults to `window`).
  * @example try { await save(); } catch (thrown) { notifyThrown(thrown); }
- * @see https://dhoulb.github.io/shelving/ui/util/notice/notifyThrown
+ * @see https://shelving.cc/ui/notifyThrown
  */
 export function notifyThrown(thrown: unknown, el?: EventTarget) {
 	const message = getMessage(thrown);
@@ -85,7 +85,7 @@ export function notifyThrown(thrown: unknown, el?: EventTarget) {
  * @param el Element to subscribe on (defaults to `window`).
  * @returns An unsubscribe function that removes the listener.
  * @example const stop = subscribeNotices((message, status) => show(message, status));
- * @see https://dhoulb.github.io/shelving/ui/util/notice/subscribeNotices
+ * @see https://shelving.cc/ui/subscribeNotices
  */
 export function subscribeNotices(
 	callback: (message: ReactNode, status?: Status | undefined) => void,
@@ -102,7 +102,7 @@ export function subscribeNotices(
 /**
  * Callback that can return or throw a value, triggering a success or error notice accordingly.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/notice/NoticeCallback
+ * @see https://shelving.cc/ui/NoticeCallback
  */
 export type NoticeCallback<A extends Arguments> = (...args: A) => PromiseLike<ReactNode | undefined | void> | ReactNode | undefined | void;
 
@@ -116,7 +116,7 @@ export type NoticeCallback<A extends Arguments> = (...args: A) => PromiseLike<Re
  * @param args Arguments forwarded to the callback.
  * @returns `true` if the callback succeeded, `false` if it threw (a `Promise` of the same when async).
  * @example callNotified(() => save()); // notifies "success" or "error"
- * @see https://dhoulb.github.io/shelving/ui/util/notice/callNotified
+ * @see https://shelving.cc/ui/callNotified
  */
 export function callNotified<A extends Arguments>(callback: NoticeCallback<A>, ...args: A): boolean | Promise<boolean> {
 	return callNotifiedElement(window, callback, ...args);
@@ -130,7 +130,7 @@ export function callNotified<A extends Arguments>(callback: NoticeCallback<A>, .
  * @param pending The promise-like value to await.
  * @returns `true` if the value resolved, `false` if it rejected.
  * @example await awaitNotified(save());
- * @see https://dhoulb.github.io/shelving/ui/util/notice/awaitNotified
+ * @see https://shelving.cc/ui/awaitNotified
  */
 export function awaitNotified(pending: PromiseLike<ReactNode | undefined | void>): Promise<boolean> {
 	return awaitNotifiedElement(window, pending);
@@ -147,7 +147,7 @@ export function awaitNotified(pending: PromiseLike<ReactNode | undefined | void>
  * @param args Arguments forwarded to the callback.
  * @returns `true` if the callback succeeded, `false` if it threw (a `Promise` of the same when async).
  * @example callNotifiedElement(formEl, () => save());
- * @see https://dhoulb.github.io/shelving/ui/util/notice/callNotifiedElement
+ * @see https://shelving.cc/ui/callNotifiedElement
  */
 export function callNotifiedElement<A extends Arguments>(
 	el: EventTarget | undefined,
@@ -174,7 +174,7 @@ export function callNotifiedElement<A extends Arguments>(
  * @param pending The promise-like value to await.
  * @returns `true` if the value resolved, `false` if it rejected.
  * @example await awaitNotifiedElement(formEl, save());
- * @see https://dhoulb.github.io/shelving/ui/util/notice/awaitNotifiedElement
+ * @see https://shelving.cc/ui/awaitNotifiedElement
  */
 export async function awaitNotifiedElement(
 	el: EventTarget | undefined,

--- a/modules/ui/util/props.ts
+++ b/modules/ui/util/props.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 /**
  * Props for a component that requires `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/props/ChildProps
+ * @see https://shelving.cc/ui/ChildProps
  */
 export interface ChildProps {
 	readonly children: ReactNode;
@@ -12,7 +12,7 @@ export interface ChildProps {
 /**
  * Props for a component that optionally accepts `children`.
  *
- * @see https://dhoulb.github.io/shelving/ui/util/props/OptionalChildProps
+ * @see https://shelving.cc/ui/OptionalChildProps
  */
 export interface OptionalChildProps {
 	readonly children?: ReactNode | undefined;

--- a/modules/ui/util/refresh.ts
+++ b/modules/ui/util/refresh.ts
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
  *
  * @param interval The refresh period in milliseconds.
  * @example useRefresh(1000); // re-renders once per second, e.g. for a live clock
- * @see https://dhoulb.github.io/shelving/ui/util/refresh/useRefresh
+ * @see https://shelving.cc/ui/useRefresh
  */
 export function useRefresh(interval: number): void {
 	const [_currentTime, setCurrentTime] = useState<number>(() => Date.now());

--- a/modules/ui/util/scroll.ts
+++ b/modules/ui/util/scroll.ts
@@ -12,7 +12,7 @@ import type { Nullish } from "../../util/null.js";
  * @param onLeave Called when the element stops being fully visible.
  * @returns A React `ref` to attach to the element to observe.
  * @example const ref = useScrollIntersect(loadMore); return <div ref={ref} />;
- * @see https://dhoulb.github.io/shelving/ui/util/scroll/useScrollIntersect
+ * @see https://shelving.cc/ui/useScrollIntersect
  */
 export function useScrollIntersect<T extends HTMLElement>(onEnter?: Nullish<Callback>, onLeave?: Nullish<Callback>): RefObject<T | null> {
 	const ref = useRef<T | null>(null);
@@ -43,7 +43,7 @@ export function useScrollIntersect<T extends HTMLElement>(onEnter?: Nullish<Call
  * @param entries The observer entries to compare (e.g. from an `IntersectionObserver` callback).
  * @returns The entry with the largest visible ratio, or `undefined` when `entries` is empty.
  * @example getMostVisibleObserverEntry(entries)?.target;
- * @see https://dhoulb.github.io/shelving/ui/util/scroll/getMostVisibleObserverEntry
+ * @see https://shelving.cc/ui/getMostVisibleObserverEntry
  */
 export function getMostVisibleObserverEntry(entries: IntersectionObserverEntry[]): IntersectionObserverEntry | undefined {
 	return entries.reduce<IntersectionObserverEntry | undefined>(_reduceMostVisibleObserverEntry, undefined);

--- a/modules/ui/util/state.ts
+++ b/modules/ui/util/state.ts
@@ -9,7 +9,7 @@ import { useEffect, useRef, useState } from "react";
  * @param delay The debounce delay in milliseconds (defaults to `500`).
  * @returns A `[state, setState]` tuple, where `setState` defers the update by `delay`.
  * @example const [query, setQuery] = useDebouncedState("");
- * @see https://dhoulb.github.io/shelving/ui/util/state/useDebouncedState
+ * @see https://shelving.cc/ui/useDebouncedState
  */
 export function useDebouncedState<T>(initial: T, delay = 500): [T, (v: T) => void] {
 	const [state, setState] = useState(initial);
@@ -33,7 +33,7 @@ export function useDebouncedState<T>(initial: T, delay = 500): [T, (v: T) => voi
  * @param delay The debounce delay in milliseconds (defaults to `500`).
  * @returns A debounced function that schedules `callback` after `delay`.
  * @example const submit = useDebouncedCallback(() => form.submit());
- * @see https://dhoulb.github.io/shelving/ui/util/state/useDebouncedCallback
+ * @see https://shelving.cc/ui/useDebouncedCallback
  */
 export function useDebouncedCallback(callback: (() => void) | undefined, delay = 500): () => void {
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/modules/util/ansi.ts
+++ b/modules/util/ansi.ts
@@ -7,63 +7,63 @@ import { getEnvBoolean } from "./env.js";
 /**
  * ANSI escape code that resets the foreground colour to the terminal default.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_DEFAULT
+ * @see https://shelving.cc/util/ansi/ANSI_DEFAULT
  */
 export const ANSI_DEFAULT = "\x1b[39m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to black.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_BLACK
+ * @see https://shelving.cc/util/ansi/ANSI_BLACK
  */
 export const ANSI_BLACK = "\x1b[30m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to red.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_RED
+ * @see https://shelving.cc/util/ansi/ANSI_RED
  */
 export const ANSI_RED = "\x1b[31m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to green.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_GREEN
+ * @see https://shelving.cc/util/ansi/ANSI_GREEN
  */
 export const ANSI_GREEN = "\x1b[32m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to yellow.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_YELLOW
+ * @see https://shelving.cc/util/ansi/ANSI_YELLOW
  */
 export const ANSI_YELLOW = "\x1b[33m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to blue.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_BLUE
+ * @see https://shelving.cc/util/ansi/ANSI_BLUE
  */
 export const ANSI_BLUE = "\x1b[34m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to magenta.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_MAGENTA
+ * @see https://shelving.cc/util/ansi/ANSI_MAGENTA
  */
 export const ANSI_MAGENTA = "\x1b[35m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to cyan.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_CYAN
+ * @see https://shelving.cc/util/ansi/ANSI_CYAN
  */
 export const ANSI_CYAN = "\x1b[36m" as const;
 
 /**
  * ANSI escape code that sets the foreground colour to white.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_WHITE
+ * @see https://shelving.cc/util/ansi/ANSI_WHITE
  */
 export const ANSI_WHITE = "\x1b[37m" as const;
 
@@ -72,35 +72,35 @@ export const ANSI_WHITE = "\x1b[37m" as const;
 /**
  * ANSI escape code that enables bold text.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_BOLD
+ * @see https://shelving.cc/util/ansi/ANSI_BOLD
  */
 export const ANSI_BOLD = "\x1b[1m" as const;
 
 /**
  * ANSI escape code that enables italic text.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_ITALIC
+ * @see https://shelving.cc/util/ansi/ANSI_ITALIC
  */
 export const ANSI_ITALIC = "\x1b[3m" as const;
 
 /**
  * ANSI escape code that enables underlined text.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_UNDERLINE
+ * @see https://shelving.cc/util/ansi/ANSI_UNDERLINE
  */
 export const ANSI_UNDERLINE = "\x1b[4m" as const;
 
 /**
  * ANSI escape code that enables strikethrough text.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_STRIKE
+ * @see https://shelving.cc/util/ansi/ANSI_STRIKE
  */
 export const ANSI_STRIKE = "\x1b[9m" as const;
 
 /**
  * ANSI escape code that enables inverse (swapped foreground/background) text.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_INVERSE
+ * @see https://shelving.cc/util/ansi/ANSI_INVERSE
  */
 export const ANSI_INVERSE = "\x1b[7m" as const;
 
@@ -109,7 +109,7 @@ export const ANSI_INVERSE = "\x1b[7m" as const;
 /**
  * ANSI escape code that resets all colour and style attributes.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_RESET
+ * @see https://shelving.cc/util/ansi/ANSI_RESET
  */
 export const ANSI_RESET = "\x1b[0m";
 
@@ -122,7 +122,7 @@ export const ANSI_RESET = "\x1b[0m";
  * @param wrappers Any number of ANSI escape codes (e.g. `ANSI_RED`, `ANSI_BOLD`) to prepend before `input`.
  * @returns The wrapped string, or `input` unchanged when the `NO_COLOR` environment variable is set.
  * @example ansiWrap("hello", ANSI_RED, ANSI_BOLD) // "\x1b[31m\x1b[1mhello\x1b[0m"
- * @see https://dhoulb.github.io/shelving/util/ansi/ansiWrap
+ * @see https://shelving.cc/util/ansi/ansiWrap
  */
 export function ansiWrap(input: string, ...wrappers: ImmutableArray<string>) {
 	if (getEnvBoolean("NO_COLOR")) return input;
@@ -134,7 +134,7 @@ export function ansiWrap(input: string, ...wrappers: ImmutableArray<string>) {
  *
  * - Used directly inside template literals (`${ANSI_SUCCESS}`), where JavaScript invokes `toString()` automatically, so the icon is coloured at use-time, not at module-load time.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/AnsiIcon
+ * @see https://shelving.cc/util/ansi/AnsiIcon
  */
 export type AnsiIcon = { toString(): string };
 
@@ -152,48 +152,48 @@ function _createAnsiIcon(icon: string, ...wrappers: ImmutableArray<string>): Ans
 /**
  * Lazily blue-coloured waiting icon (`⋯`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_WAITING
+ * @see https://shelving.cc/util/ansi/ANSI_WAITING
  */
 export const ANSI_WAITING = _createAnsiIcon(WAITING, ANSI_BLUE);
 
 /**
  * Lazily green-coloured success icon (`✓`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_SUCCESS
+ * @see https://shelving.cc/util/ansi/ANSI_SUCCESS
  */
 export const ANSI_SUCCESS = _createAnsiIcon(SUCCESS, ANSI_GREEN);
 
 /**
  * Lazily red-coloured failure icon (`✗`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_FAILURE
+ * @see https://shelving.cc/util/ansi/ANSI_FAILURE
  */
 export const ANSI_FAILURE = _createAnsiIcon(FAILURE, ANSI_RED);
 
 /**
  * Lazily blue-coloured up arrow icon (`↑`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_UP
+ * @see https://shelving.cc/util/ansi/ANSI_UP
  */
 export const ANSI_UP = _createAnsiIcon(UP, ANSI_BLUE);
 
 /**
  * Lazily blue-coloured down arrow icon (`↓`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_DOWN
+ * @see https://shelving.cc/util/ansi/ANSI_DOWN
  */
 export const ANSI_DOWN = _createAnsiIcon(DOWN, ANSI_BLUE);
 
 /**
  * Lazily blue-coloured right arrow icon (`→`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_RIGHT
+ * @see https://shelving.cc/util/ansi/ANSI_RIGHT
  */
 export const ANSI_RIGHT = _createAnsiIcon(RIGHT, ANSI_BLUE);
 
 /**
  * Lazily blue-coloured left arrow icon (`←`) for use in template literals.
  *
- * @see https://dhoulb.github.io/shelving/util/ansi/ANSI_LEFT
+ * @see https://shelving.cc/util/ansi/ANSI_LEFT
  */
 export const ANSI_LEFT = _createAnsiIcon(LEFT, ANSI_BLUE);

--- a/modules/util/array.ts
+++ b/modules/util/array.ts
@@ -6,7 +6,7 @@ import { interleaveItems, isIterable, omitItems, pickItems } from "./iterate.js"
  * Mutable array: an array that can be changed.
  * - Consistency with `MutableObject<T>` and `ImmutableArray<T>`
  *
- * @see https://dhoulb.github.io/shelving/util/array/MutableArray
+ * @see https://shelving.cc/util/array/MutableArray
  */
 export type MutableArray<T = unknown> = T[];
 
@@ -14,21 +14,21 @@ export type MutableArray<T = unknown> = T[];
  * Immutable array: an array that cannot be changed.
  * - Consistency with `ImmutableObject<T>` and `MutableArray<T>`
  *
- * @see https://dhoulb.github.io/shelving/util/array/ImmutableArray
+ * @see https://shelving.cc/util/array/ImmutableArray
  */
 export type ImmutableArray<T = unknown> = readonly T[];
 
 /**
  * Get the type of the _items_ in an array.
  *
- * @see https://dhoulb.github.io/shelving/util/array/ArrayItem
+ * @see https://shelving.cc/util/array/ArrayItem
  */
 export type ArrayItem<T extends ImmutableArray> = T[number];
 
 /**
  * Things that can be converted to arrays.
  *
- * @see https://dhoulb.github.io/shelving/util/array/PossibleArray
+ * @see https://shelving.cc/util/array/PossibleArray
  */
 export type PossibleArray<T> = ImmutableArray<T> | Iterable<T>;
 
@@ -43,7 +43,7 @@ export type PossibleArray<T> = ImmutableArray<T> | Iterable<T>;
  * @example isArray([1, 2, 3]); // true
  * @example isArray([1], 2, 2); // false
  *
- * @see https://dhoulb.github.io/shelving/util/array/isArray
+ * @see https://shelving.cc/util/array/isArray
  */
 export function isArray<T>(arr: MutableArray<T>, min: 1, max: 1): arr is [T];
 export function isArray<T>(arr: MutableArray<T>, min: 2, max: 2): arr is [T, T];
@@ -75,7 +75,7 @@ export function isArray(value: unknown, min = 0, max = Number.POSITIVE_INFINITY)
  * @example assertArray([1, 2, 3]); // (passes)
  * @example assertArray("nope"); // throws RequiredError
  *
- * @see https://dhoulb.github.io/shelving/util/array/assertArray
+ * @see https://shelving.cc/util/array/assertArray
  */
 export function assertArray<T>(arr: MutableArray<T>, min: 1, max: 1, caller?: AnyCaller): asserts arr is [T];
 export function assertArray<T>(arr: MutableArray<T>, min: 2, max: 2, caller?: AnyCaller): asserts arr is [T, T];
@@ -108,7 +108,7 @@ export function assertArray(value: unknown, min?: number, max?: number, caller: 
  * @example getArray(new Set([1, 2])); // [1, 2]
  * @example getArray(123); // undefined
  *
- * @see https://dhoulb.github.io/shelving/util/array/getArray
+ * @see https://shelving.cc/util/array/getArray
  */
 export function getArray(list: unknown): ImmutableArray<unknown> | undefined {
 	return Array.isArray(list) ? list : isIterable(list) ? Array.from(list) : undefined;
@@ -127,7 +127,7 @@ export function getArray(list: unknown): ImmutableArray<unknown> | undefined {
  * @example requireArray(new Set([1, 2])); // [1, 2]
  * @example requireArray([], 1); // throws RequiredError
  *
- * @see https://dhoulb.github.io/shelving/util/array/requireArray
+ * @see https://shelving.cc/util/array/requireArray
  */
 export function requireArray<T>(arr: MutableArray<T>, min: 1, max: 1, caller?: AnyCaller): [T];
 export function requireArray<T>(arr: MutableArray<T>, min: 2, max: 2, caller?: AnyCaller): [T, T];
@@ -159,7 +159,7 @@ export function requireArray<T>(list: PossibleArray<T>, min?: number, max?: numb
  * @example isArrayItem([1, 2, 3], 2); // true
  * @example isArrayItem([1, 2, 3], 9); // false
  *
- * @see https://dhoulb.github.io/shelving/util/array/isArrayItem
+ * @see https://shelving.cc/util/array/isArrayItem
  */
 export function isArrayItem<T>(list: PossibleArray<T>, item: unknown): item is T {
 	if (isArray(list)) list.includes(item as T);
@@ -178,7 +178,7 @@ export function isArrayItem<T>(list: PossibleArray<T>, item: unknown): item is T
  * @example assertArrayItem([1, 2, 3], 2); // (passes)
  * @example assertArrayItem([1, 2, 3], 9); // throws RequiredError
  *
- * @see https://dhoulb.github.io/shelving/util/array/assertArrayItem
+ * @see https://shelving.cc/util/array/assertArrayItem
  */
 export function assertArrayItem<T>(arr: PossibleArray<T>, item: unknown, caller: AnyCaller = assertArrayItem): asserts item is T {
 	if (!isArrayItem(arr, item)) throw new RequiredError("Item must exist in array", { item, array: arr, caller });
@@ -193,7 +193,7 @@ export function assertArrayItem<T>(arr: PossibleArray<T>, item: unknown, caller:
  *
  * @example withArrayItems([1, 2], 2, 3); // [1, 2, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/withArrayItems
+ * @see https://shelving.cc/util/array/withArrayItems
  */
 export function withArrayItems<T>(list: PossibleArray<T>, ...add: T[]): ImmutableArray<T> {
 	const arr = Array.from(list);
@@ -213,7 +213,7 @@ function _doesNotInclude<T>(this: T[], value: T) {
  *
  * @example withArrayItem([1, 2], 3); // [1, 2, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/withArrayItem
+ * @see https://shelving.cc/util/array/withArrayItem
  */
 export const withArrayItem: <T>(items: PossibleArray<T>, add: T) => ImmutableArray<T> = withArrayItems;
 
@@ -226,7 +226,7 @@ export const withArrayItem: <T>(items: PossibleArray<T>, add: T) => ImmutableArr
  *
  * @example pickArrayItems([1, 2, 3], 1, 3); // [1, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/pickArrayItems
+ * @see https://shelving.cc/util/array/pickArrayItems
  */
 export function pickArrayItems<T>(items: PossibleArray<T>, ...pick: T[]): ImmutableArray<T> {
 	const arr = Array.from(pickItems(items, ...pick));
@@ -242,7 +242,7 @@ export function pickArrayItems<T>(items: PossibleArray<T>, ...pick: T[]): Immuta
  *
  * @example pickArrayItem([1, 2, 3], 2); // [2]
  *
- * @see https://dhoulb.github.io/shelving/util/array/pickArrayItem
+ * @see https://shelving.cc/util/array/pickArrayItem
  */
 export const pickArrayItem: <T>(items: PossibleArray<T>, pick: T) => ImmutableArray<T> = pickArrayItems;
 
@@ -255,7 +255,7 @@ export const pickArrayItem: <T>(items: PossibleArray<T>, pick: T) => ImmutableAr
  *
  * @example omitArrayItems([1, 2, 3], 2); // [1, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/omitArrayItems
+ * @see https://shelving.cc/util/array/omitArrayItems
  */
 export function omitArrayItems<T>(items: PossibleArray<T>, ...omit: T[]): ImmutableArray<T> {
 	const filtered = Array.from(omitItems(items, ...omit));
@@ -271,7 +271,7 @@ export function omitArrayItems<T>(items: PossibleArray<T>, ...omit: T[]): Immuta
  *
  * @example omitArrayItem([1, 2, 3], 2); // [1, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/omitArrayItem
+ * @see https://shelving.cc/util/array/omitArrayItem
  */
 export const omitArrayItem: <T>(items: PossibleArray<T>, omit: T) => ImmutableArray<T> = omitArrayItems;
 
@@ -284,7 +284,7 @@ export const omitArrayItem: <T>(items: PossibleArray<T>, omit: T) => ImmutableAr
  *
  * @example toggleArrayItems([1, 2], 2, 3); // [1, 3]
  *
- * @see https://dhoulb.github.io/shelving/util/array/toggleArrayItems
+ * @see https://shelving.cc/util/array/toggleArrayItems
  */
 export function toggleArrayItems<T>(items: PossibleArray<T>, ...toggle: T[]): ImmutableArray<T> {
 	const arr = Array.from(items);
@@ -302,7 +302,7 @@ export function toggleArrayItems<T>(items: PossibleArray<T>, ...toggle: T[]): Im
  *
  * @example toggleArrayItem([1, 2], 2); // [1]
  *
- * @see https://dhoulb.github.io/shelving/util/array/toggleArrayItem
+ * @see https://shelving.cc/util/array/toggleArrayItem
  */
 export const toggleArrayItem: <T>(items: PossibleArray<T>, toggle: T) => ImmutableArray<T> = toggleArrayItems;
 
@@ -314,7 +314,7 @@ export const toggleArrayItem: <T>(items: PossibleArray<T>, toggle: T) => Immutab
  *
  * @example shuffleArray([1, 2, 3]); // e.g. [2, 3, 1]
  *
- * @see https://dhoulb.github.io/shelving/util/array/shuffleArray
+ * @see https://shelving.cc/util/array/shuffleArray
  */
 export function shuffleArray<T>(items: PossibleArray<T>): ImmutableArray<T> {
 	const arr = Array.from(items);
@@ -335,7 +335,7 @@ export function shuffleArray<T>(items: PossibleArray<T>): ImmutableArray<T> {
  *
  * @example addArrayItem(arr, 3); // 3 (and `arr` now contains `3`)
  *
- * @see https://dhoulb.github.io/shelving/util/array/addArrayItem
+ * @see https://shelving.cc/util/array/addArrayItem
  */
 export function addArrayItem<T>(arr: MutableArray<T>, item: T): T {
 	if (arr.indexOf(item) < 0) arr.push(item);
@@ -349,7 +349,7 @@ export function addArrayItem<T>(arr: MutableArray<T>, item: T): T {
  * @param arr The array to add to (modified in place).
  * @param items The items to add.
  * @example addArrayItems(arr, 3, 4); // (`arr` now contains `3` and `4`)
- * @see https://dhoulb.github.io/shelving/util/array/addArrayItems
+ * @see https://shelving.cc/util/array/addArrayItems
  */
 export function addArrayItems<T>(arr: MutableArray<T>, ...items: T[]): void {
 	for (const item of items) if (arr.indexOf(item) < 0) arr.push(item);
@@ -361,7 +361,7 @@ export function addArrayItems<T>(arr: MutableArray<T>, ...items: T[]): void {
  * @param arr The array to remove from (modified in place).
  * @param items The items to remove.
  * @example deleteArrayItems(arr, 2, 3); // (`arr` no longer contains `2` or `3`)
- * @see https://dhoulb.github.io/shelving/util/array/deleteArrayItems
+ * @see https://shelving.cc/util/array/deleteArrayItems
  */
 export function deleteArrayItems<T>(arr: MutableArray<T>, ...items: T[]): void {
 	for (let i = arr.length - 1; i >= 0; i--) if (i in arr && items.includes(arr[i] as T)) arr.splice(i, 1);
@@ -373,7 +373,7 @@ export function deleteArrayItems<T>(arr: MutableArray<T>, ...items: T[]): void {
  * @param arr The array to remove from (modified in place).
  * @param item The item to remove.
  * @example deleteArrayItem(arr, 2); // (`arr` no longer contains `2`)
- * @see https://dhoulb.github.io/shelving/util/array/deleteArrayItem
+ * @see https://shelving.cc/util/array/deleteArrayItem
  */
 export const deleteArrayItem: <T>(arr: MutableArray<T>, item: T) => void = deleteArrayItems;
 
@@ -383,7 +383,7 @@ export const deleteArrayItem: <T>(arr: MutableArray<T>, item: T) => void = delet
  * @param list The array or iterable to deduplicate.
  * @returns A new array with duplicate items removed, or the same array if all items were already unique.
  * @example getUniqueArray([1, 2, 2, 3]) // [1, 2, 3]
- * @see https://dhoulb.github.io/shelving/util/array/getUniqueArray
+ * @see https://shelving.cc/util/array/getUniqueArray
  */
 export function getUniqueArray<T>(list: PossibleArray<T>): ImmutableArray<T> {
 	const output: MutableArray<T> = [];
@@ -399,7 +399,7 @@ export function getUniqueArray<T>(list: PossibleArray<T>): ImmutableArray<T> {
  * @returns An array of at most `limit` items, or the same array if it was already within the limit.
  * @throws {RequiredError} If `list` cannot be converted to an array.
  * @example limitArray([1, 2, 3, 4], 2) // [1, 2]
- * @see https://dhoulb.github.io/shelving/util/array/limitArray
+ * @see https://shelving.cc/util/array/limitArray
  */
 export function limitArray<T>(list: PossibleArray<T>, limit: number): ImmutableArray<T> {
 	const arr = requireArray(list, undefined, undefined, limitArray);
@@ -412,7 +412,7 @@ export function limitArray<T>(list: PossibleArray<T>, limit: number): ImmutableA
  * @param arr The array to count.
  * @returns The number of items in `arr`.
  * @example countArray([1, 2, 3]) // 3
- * @see https://dhoulb.github.io/shelving/util/array/countArray
+ * @see https://shelving.cc/util/array/countArray
  */
 export function countArray<T>(arr: ImmutableArray<T>): number {
 	return arr.length;
@@ -425,7 +425,7 @@ export function countArray<T>(arr: ImmutableArray<T>): number {
  * @param separator The value to insert between each pair of items.
  * @returns A new array with `separator` inserted between items, or the same array if it had fewer than two items.
  * @example interleaveArray([1, 2, 3], 0) // [1, 0, 2, 0, 3]
- * @see https://dhoulb.github.io/shelving/util/array/interleaveArray
+ * @see https://shelving.cc/util/array/interleaveArray
  */
 export function interleaveArray<T>(items: PossibleArray<T>, separator: T): ImmutableArray<T>;
 export function interleaveArray<A, B>(items: PossibleArray<A>, separator: B): ImmutableArray<A | B>;
@@ -442,7 +442,7 @@ export function interleaveArray<A, B>(items: PossibleArray<A>, separator: B): Im
  * @param value The new value to set at `index`.
  * @returns A new array with `value` at `index`, or the same array if the value was unchanged.
  * @example withArrayIndex([1, 2, 3], 1, 9) // [1, 9, 3]
- * @see https://dhoulb.github.io/shelving/util/array/withArrayIndex
+ * @see https://shelving.cc/util/array/withArrayIndex
  */
 export function withArrayIndex<T>(arr: ImmutableArray<T>, index: number, value: T): ImmutableArray<T> {
 	if (arr[index] === value) return arr;
@@ -456,7 +456,7 @@ export function withArrayIndex<T>(arr: ImmutableArray<T>, index: number, value: 
  * @param index The index to remove.
  * @returns A new array without `index`, or the same array if nothing changed.
  * @example omitArrayIndex([1, 2, 3], 1) // [1, 3]
- * @see https://dhoulb.github.io/shelving/util/array/omitArrayIndex
+ * @see https://shelving.cc/util/array/omitArrayIndex
  */
 export function omitArrayIndex<T>(arr: ImmutableArray<T>, index: number): ImmutableArray<T> {
 	const output = [...arr.slice(0, index), ...arr.slice(index + 1)];
@@ -469,7 +469,7 @@ export function omitArrayIndex<T>(arr: ImmutableArray<T>, index: number): Immuta
  * @param items The array or iterable to read from.
  * @returns The first item, or `undefined` if `items` is empty.
  * @example getFirst([1, 2, 3]) // 1
- * @see https://dhoulb.github.io/shelving/util/array/getFirst
+ * @see https://shelving.cc/util/array/getFirst
  */
 export function getFirst<T>(items: PossibleArray<T>): T | undefined {
 	if (isArray(items)) return items[0];
@@ -484,7 +484,7 @@ export function getFirst<T>(items: PossibleArray<T>): T | undefined {
  * @returns The first item.
  * @throws {RequiredError} If `items` is empty.
  * @example requireFirst([1, 2, 3]) // 1
- * @see https://dhoulb.github.io/shelving/util/array/requireFirst
+ * @see https://shelving.cc/util/array/requireFirst
  */
 export function requireFirst<T>(items: PossibleArray<T>, caller: AnyCaller = requireFirst): T {
 	const item = getFirst(items);
@@ -498,7 +498,7 @@ export function requireFirst<T>(items: PossibleArray<T>, caller: AnyCaller = req
  * @param items The array or iterable to read from.
  * @returns The last item, or `undefined` if `items` is empty.
  * @example getLast([1, 2, 3]) // 3
- * @see https://dhoulb.github.io/shelving/util/array/getLast
+ * @see https://shelving.cc/util/array/getLast
  */
 export function getLast<T>(items: PossibleArray<T>): T | undefined {
 	if (isArray(items)) return items[items.length - 1];
@@ -517,7 +517,7 @@ export function getLast<T>(items: PossibleArray<T>): T | undefined {
  * @returns The last item.
  * @throws {RequiredError} If `items` is empty.
  * @example requireLast([1, 2, 3]) // 3
- * @see https://dhoulb.github.io/shelving/util/array/requireLast
+ * @see https://shelving.cc/util/array/requireLast
  */
 export function requireLast<T>(items: PossibleArray<T>, caller: AnyCaller = requireLast): T {
 	const item = getLast(items);
@@ -532,7 +532,7 @@ export function requireLast<T>(items: PossibleArray<T>, caller: AnyCaller = requ
  * @param item The item to find the successor of.
  * @returns The item following `item`, or `undefined` if `item` is missing or last.
  * @example getNext([1, 2, 3], 2) // 3
- * @see https://dhoulb.github.io/shelving/util/array/getNext
+ * @see https://shelving.cc/util/array/getNext
  */
 export function getNext<T>(items: PossibleArray<T>, item: T): T | undefined {
 	let found = false;
@@ -551,7 +551,7 @@ export function getNext<T>(items: PossibleArray<T>, item: T): T | undefined {
  * @returns The item following `item`.
  * @throws {RequiredError} If `item` is missing or has no successor.
  * @example requireNext([1, 2, 3], 2) // 3
- * @see https://dhoulb.github.io/shelving/util/array/requireNext
+ * @see https://shelving.cc/util/array/requireNext
  */
 export function requireNext<T>(items: PossibleArray<T>, item: T, caller: AnyCaller = requireNext): T {
 	const next = getNext(items, item);
@@ -566,7 +566,7 @@ export function requireNext<T>(items: PossibleArray<T>, item: T, caller: AnyCall
  * @param value The item to find the predecessor of.
  * @returns The item preceding `value`, or `undefined` if `value` is missing or first.
  * @example getPrev([1, 2, 3], 2) // 1
- * @see https://dhoulb.github.io/shelving/util/array/getPrev
+ * @see https://shelving.cc/util/array/getPrev
  */
 export function getPrev<T>(items: PossibleArray<T>, value: T): T | undefined {
 	let last: T | undefined;
@@ -585,7 +585,7 @@ export function getPrev<T>(items: PossibleArray<T>, value: T): T | undefined {
  * @returns The item preceding `item`.
  * @throws {RequiredError} If `item` is missing or has no predecessor.
  * @example requirePrev([1, 2, 3], 2) // 1
- * @see https://dhoulb.github.io/shelving/util/array/requirePrev
+ * @see https://shelving.cc/util/array/requirePrev
  */
 export function requirePrev<T>(items: PossibleArray<T>, item: T, caller: AnyCaller = requirePrev): T {
 	const prev = getPrev(items, item);

--- a/modules/util/async.ts
+++ b/modules/util/async.ts
@@ -8,7 +8,7 @@ import { BLACKHOLE, type ErrorCallback, type ValueCallback } from "./function.js
  *
  * @param value The value to test.
  * @returns `true` if `value` is a `PromiseLike`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/async/isAsync
+ * @see https://shelving.cc/util/async/isAsync
  */
 export function isAsync<T>(value: PromiseLike<T> | T): value is PromiseLike<T> {
 	return typeof value === "object" && value !== null && typeof (value as Promise<T>).then === "function";
@@ -19,7 +19,7 @@ export function isAsync<T>(value: PromiseLike<T> | T): value is PromiseLike<T> {
  *
  * @param value The value to test.
  * @returns `true` if `value` is not a `PromiseLike`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/async/notAsync
+ * @see https://shelving.cc/util/async/notAsync
  */
 export function notAsync<T>(value: PromiseLike<T> | T): value is T {
 	return !isAsync(value);
@@ -32,7 +32,7 @@ export function notAsync<T>(value: PromiseLike<T> | T): value is T {
  * @returns Synchronous (not promised) value.
  * @throws Promise if value is an asynchronous (promised) value.
  * @example throwAsync(123) // 123
- * @see https://dhoulb.github.io/shelving/util/async/throwAsync
+ * @see https://shelving.cc/util/async/throwAsync
  */
 export function throwAsync<T>(value: PromiseLike<T> | T): T {
 	if (isAsync(value)) throw value;
@@ -45,7 +45,7 @@ export function throwAsync<T>(value: PromiseLike<T> | T): T {
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is a `PromiseLike`.
  * @example assertNotAsync(123); // passes
- * @see https://dhoulb.github.io/shelving/util/async/assertNotAsync
+ * @see https://shelving.cc/util/async/assertNotAsync
  */
 export function assertNotAsync<T>(value: PromiseLike<T> | T): asserts value is T {
 	if (isAsync(value)) throw new RequiredError("Must be synchronous", { received: value, caller: assertNotAsync });
@@ -57,7 +57,7 @@ export function assertNotAsync<T>(value: PromiseLike<T> | T): asserts value is T
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not a `PromiseLike`.
  * @example assertAsync(Promise.resolve(1)); // passes
- * @see https://dhoulb.github.io/shelving/util/async/assertAsync
+ * @see https://shelving.cc/util/async/assertAsync
  */
 export function assertAsync<T>(value: PromiseLike<T> | T): asserts value is PromiseLike<T> {
 	if (!isAsync(value)) throw new RequiredError("Must be asynchronous", { received: value, caller: assertAsync });
@@ -69,7 +69,7 @@ export function assertAsync<T>(value: PromiseLike<T> | T): asserts value is Prom
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not a `Promise` instance.
  * @example assertPromise(Promise.resolve(1)); // passes
- * @see https://dhoulb.github.io/shelving/util/async/assertPromise
+ * @see https://shelving.cc/util/async/assertPromise
  */
 export function assertPromise<T>(value: Promise<T> | T): asserts value is Promise<T> {
 	if (!(value instanceof Promise)) throw new RequiredError("Must be promise", { received: value, caller: assertPromise });
@@ -80,7 +80,7 @@ export function assertPromise<T>(value: Promise<T> | T): asserts value is Promis
  *
  * @returns A promise that resolves after all currently-queued microtasks have run.
  * @example await runMicrotasks();
- * @see https://dhoulb.github.io/shelving/util/async/runMicrotasks
+ * @see https://shelving.cc/util/async/runMicrotasks
  */
 export function runMicrotasks(): Promise<void> {
 	// Timeouts are part of the main event queue, and events in the main queue are run _after_ all microtasks complete.
@@ -99,7 +99,7 @@ export function runMicrotasks(): Promise<void> {
  * @returns Array of values of all promises (in the same order/positions as input).
  * @throws {Errors} If one or more promises throws all rejection reasons after resolving all of the promises.
  * @example const [a, b] = await awaitValues(getA(), getB());
- * @see https://dhoulb.github.io/shelving/util/async/awaitValues
+ * @see https://shelving.cc/util/async/awaitValues
  */
 export async function awaitValues<T extends ImmutableArray<unknown>>(...promises: T): Promise<{ readonly [P in keyof T]: Awaited<T[P]> }>;
 export async function awaitValues(...promises: unknown[]): Promise<ImmutableArray<unknown>> {
@@ -119,7 +119,7 @@ export async function awaitValues(...promises: unknown[]): Promise<ImmutableArra
  * @param promises Values (usually async, but not necessarily) that we need to wait for.
  * @returns Array of rejection reasons of all promises (or empty array if no promises threw).
  * @example const errors = await awaitErrors(getA(), getB());
- * @see https://dhoulb.github.io/shelving/util/async/awaitErrors
+ * @see https://shelving.cc/util/async/awaitErrors
  */
 export async function awaitErrors(...promises: PromiseLike<unknown>[]): Promise<ImmutableArray<unknown>> {
 	const errors: unknown[] = [];
@@ -134,7 +134,7 @@ export async function awaitErrors(...promises: PromiseLike<unknown>[]): Promise<
  * class MyPromise extends BasePromise<number> {
  * 	done() { this._resolve(123); }
  * }
- * @see https://dhoulb.github.io/shelving/util/async/BasePromise
+ * @see https://shelving.cc/util/async/BasePromise
  */
 export abstract class BasePromise<T> extends Promise<T> {
 	// Make `this.then()` create a `Promise` not a `Deferred`
@@ -163,7 +163,7 @@ export abstract class BasePromise<T> extends Promise<T> {
 /**
  * Deferred allows you to access the internal resolve/reject callbacks of a `Promise`.
  *
- * @see https://dhoulb.github.io/shelving/util/async/Deferred
+ * @see https://shelving.cc/util/async/Deferred
  */
 export type Deferred<T = unknown> = {
 	promise: Promise<T>;
@@ -177,7 +177,7 @@ export type Deferred<T = unknown> = {
  *
  * @returns A `Deferred` exposing the promise and its `resolve()`/`reject()` functions.
  * @example const { promise, resolve } = createDeferred<number>();
- * @see https://dhoulb.github.io/shelving/util/async/createDeferred
+ * @see https://shelving.cc/util/async/createDeferred
  */
 export function createDeferred<T = void>(): Deferred<T> {
 	let resolve: ValueCallback<T>;
@@ -200,7 +200,7 @@ export function createDeferred<T = void>(): Deferred<T> {
  * @param ms The delay in milliseconds before the promise resolves.
  * @returns A promise that resolves with `undefined` after `ms` milliseconds.
  * @example await getDelay(300); // resolves after 300ms
- * @see https://dhoulb.github.io/shelving/util/async/getDelay
+ * @see https://shelving.cc/util/async/getDelay
  */
 export function getDelay(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
@@ -215,7 +215,7 @@ export function getDelay(ms: number): Promise<void> {
  * @returns A promise that never resolves and rejects with the signal's reason when it fires.
  * @throws The signal's `reason` when the signal aborts.
  * @example await awaitRace(getDelay(300), awaitAbort(signal));
- * @see https://dhoulb.github.io/shelving/util/async/awaitAbort
+ * @see https://shelving.cc/util/async/awaitAbort
  */
 export function awaitAbort(signal: AbortSignal): Promise<never> {
 	const promise = new Promise<never>((_, reject) => {
@@ -236,7 +236,7 @@ export function awaitAbort(signal: AbortSignal): Promise<never> {
  * @returns A promise that settles with the first input to settle.
  * @throws The rejection reason of the first input to settle, if it rejects.
  * @example await awaitRace(getDelay(300), awaitAbort(signal)); // delay or abort, no leaked ABORT rejection if delay wins
- * @see https://dhoulb.github.io/shelving/util/async/awaitRace
+ * @see https://shelving.cc/util/async/awaitRace
  */
 export function awaitRace<T>(...promises: Promise<T>[]): Promise<T> {
 	for (const promise of promises) promise.catch(BLACKHOLE);

--- a/modules/util/base64.ts
+++ b/modules/util/base64.ts
@@ -82,7 +82,7 @@ function _lookup(base64: string, index: number, caller: AnyCaller): number {
  * @returns The Base64-encoded string.
  * @throws {RequiredError} If `input` cannot be converted to a byte sequence.
  * @example encodeBase64("abc") // "YWJj"
- * @see https://dhoulb.github.io/shelving/util/base64/encodeBase64
+ * @see https://shelving.cc/util/base64/encodeBase64
  */
 export function encodeBase64(input: PossibleBytes, pad = true): string {
 	return _encode(requireBytes(input), BASE64_CHARS, pad ? "=" : "");
@@ -95,7 +95,7 @@ export function encodeBase64(input: PossibleBytes, pad = true): string {
  * @returns The decoded UTF-8 string.
  * @throws {ValueError} If `base64` contains an invalid character.
  * @example decodeBase64String("YWJj") // "abc"
- * @see https://dhoulb.github.io/shelving/util/base64/decodeBase64String
+ * @see https://shelving.cc/util/base64/decodeBase64String
  */
 export function decodeBase64String(base64: string): string {
 	return new TextDecoder("utf-8").decode(_decode(base64, decodeBase64String));
@@ -108,7 +108,7 @@ export function decodeBase64String(base64: string): string {
  * @returns The decoded byte sequence.
  * @throws {ValueError} If `base64` contains an invalid character.
  * @example decodeBase64Bytes("YWJj") // Uint8Array([97, 98, 99])
- * @see https://dhoulb.github.io/shelving/util/base64/decodeBase64Bytes
+ * @see https://shelving.cc/util/base64/decodeBase64Bytes
  */
 export function decodeBase64Bytes(base64: string): Bytes {
 	return _decode(base64, decodeBase64Bytes);
@@ -122,7 +122,7 @@ export function decodeBase64Bytes(base64: string): Bytes {
  * @returns The Base64URL-encoded string.
  * @throws {RequiredError} If `input` cannot be converted to a byte sequence.
  * @example encodeBase64URL("abc") // "YWJj"
- * @see https://dhoulb.github.io/shelving/util/base64/encodeBase64URL
+ * @see https://shelving.cc/util/base64/encodeBase64URL
  */
 export function encodeBase64URL(input: PossibleBytes, pad = false): string {
 	return _encode(requireBytes(input), BASE64URL_CHARS, pad ? "=" : "");
@@ -135,7 +135,7 @@ export function encodeBase64URL(input: PossibleBytes, pad = false): string {
  * @returns The decoded UTF-8 string.
  * @throws {ValueError} If `base64` contains an invalid character.
  * @example decodeBase64URLString("YWJj") // "abc"
- * @see https://dhoulb.github.io/shelving/util/base64/decodeBase64URLString
+ * @see https://shelving.cc/util/base64/decodeBase64URLString
  */
 export function decodeBase64URLString(base64: string): string {
 	return new TextDecoder("utf-8").decode(_decode(base64, decodeBase64URLString));
@@ -148,7 +148,7 @@ export function decodeBase64URLString(base64: string): string {
  * @returns The decoded byte sequence.
  * @throws {ValueError} If `base64` contains an invalid character.
  * @example decodeBase64URLBytes("YWJj") // Uint8Array([97, 98, 99])
- * @see https://dhoulb.github.io/shelving/util/base64/decodeBase64URLBytes
+ * @see https://shelving.cc/util/base64/decodeBase64URLBytes
  */
 export function decodeBase64URLBytes(base64: string): Bytes {
 	return _decode(base64, decodeBase64URLBytes);

--- a/modules/util/boolean.ts
+++ b/modules/util/boolean.ts
@@ -6,7 +6,7 @@ import type { AnyCaller } from "./function.js";
  *
  * @param value The value to test.
  * @returns `true` if `value` is a `boolean`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/boolean/isBoolean
+ * @see https://shelving.cc/util/boolean/isBoolean
  */
 export function isBoolean(value: unknown): value is boolean {
 	return typeof value === "boolean";
@@ -17,7 +17,7 @@ export function isBoolean(value: unknown): value is boolean {
  *
  * @param value The value to test.
  * @returns `true` if `value` is the literal `true`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/boolean/isTrue
+ * @see https://shelving.cc/util/boolean/isTrue
  */
 export function isTrue(value: unknown): value is true {
 	return value === true;
@@ -28,7 +28,7 @@ export function isTrue(value: unknown): value is true {
  *
  * @param value The value to test.
  * @returns `true` if `value` is the literal `false`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/boolean/isFalse
+ * @see https://shelving.cc/util/boolean/isFalse
  */
 export function isFalse(value: unknown): value is false {
 	return value === false;
@@ -39,7 +39,7 @@ export function isFalse(value: unknown): value is false {
  *
  * @param value The value to test.
  * @returns `true` if `value` coerces to `true`.
- * @see https://dhoulb.github.io/shelving/util/boolean/isTruthy
+ * @see https://shelving.cc/util/boolean/isTruthy
  */
 export function isTruthy(value: unknown): boolean {
 	return !!value;
@@ -50,7 +50,7 @@ export function isTruthy(value: unknown): boolean {
  *
  * @param value The value to test.
  * @returns `true` if `value` coerces to `false`.
- * @see https://dhoulb.github.io/shelving/util/boolean/isFalsey
+ * @see https://shelving.cc/util/boolean/isFalsey
  */
 export function isFalsey(value: unknown): boolean {
 	return !value;
@@ -62,7 +62,7 @@ export function isFalsey(value: unknown): boolean {
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertBoolean` itself).
  * @throws {RequiredError} If `value` is not a `boolean`.
- * @see https://dhoulb.github.io/shelving/util/boolean/assertBoolean
+ * @see https://shelving.cc/util/boolean/assertBoolean
  */
 export function assertBoolean(value: unknown, caller: AnyCaller = assertBoolean): asserts value is boolean {
 	if (typeof value !== "boolean") throw new RequiredError("Must be boolean", { received: value, caller });
@@ -74,7 +74,7 @@ export function assertBoolean(value: unknown, caller: AnyCaller = assertBoolean)
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertTrue` itself).
  * @throws {RequiredError} If `value` is not the literal `true`.
- * @see https://dhoulb.github.io/shelving/util/boolean/assertTrue
+ * @see https://shelving.cc/util/boolean/assertTrue
  */
 export function assertTrue(value: unknown, caller: AnyCaller = assertTrue): asserts value is true {
 	if (value !== true) throw new RequiredError("Must be true", { received: value, caller });
@@ -86,7 +86,7 @@ export function assertTrue(value: unknown, caller: AnyCaller = assertTrue): asse
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertFalse` itself).
  * @throws {RequiredError} If `value` is not the literal `false`.
- * @see https://dhoulb.github.io/shelving/util/boolean/assertFalse
+ * @see https://shelving.cc/util/boolean/assertFalse
  */
 export function assertFalse(value: unknown, caller: AnyCaller = assertFalse): asserts value is false {
 	if (value !== false) throw new RequiredError("Must be false", { received: value, caller });
@@ -98,7 +98,7 @@ export function assertFalse(value: unknown, caller: AnyCaller = assertFalse): as
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertTruthy` itself).
  * @throws {RequiredError} If `value` is falsey.
- * @see https://dhoulb.github.io/shelving/util/boolean/assertTruthy
+ * @see https://shelving.cc/util/boolean/assertTruthy
  */
 export function assertTruthy(value: unknown, caller: AnyCaller = assertTruthy): asserts value is true {
 	if (!value) throw new RequiredError("Must be truthy", { received: value, caller });
@@ -110,7 +110,7 @@ export function assertTruthy(value: unknown, caller: AnyCaller = assertTruthy): 
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertFalsy` itself).
  * @throws {RequiredError} If `value` is truthy.
- * @see https://dhoulb.github.io/shelving/util/boolean/assertFalsy
+ * @see https://shelving.cc/util/boolean/assertFalsy
  */
 export function assertFalsy(value: unknown, caller: AnyCaller = assertFalsy): asserts value is false {
 	if (value) throw new RequiredError("Must be falsy", { received: value, caller });

--- a/modules/util/buffer.ts
+++ b/modules/util/buffer.ts
@@ -1,7 +1,7 @@
 /**
  * Union of the numeric `TypedArray` views over an `ArrayBufferLike` (excludes `DataView`).
  *
- * @see https://dhoulb.github.io/shelving/util/buffer/TypedArray
+ * @see https://shelving.cc/util/buffer/TypedArray
  */
 export type TypedArray<T extends ArrayBufferLike = ArrayBufferLike> =
 	| Uint8Array<T>
@@ -18,7 +18,7 @@ export type TypedArray<T extends ArrayBufferLike = ArrayBufferLike> =
  *
  * @param value The value to test.
  * @returns `true` if `value` is an `ArrayBuffer`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/buffer/isBuffer
+ * @see https://shelving.cc/util/buffer/isBuffer
  */
 export function isBuffer(value: unknown): value is ArrayBuffer {
 	return value instanceof ArrayBuffer;
@@ -29,7 +29,7 @@ export function isBuffer(value: unknown): value is ArrayBuffer {
  *
  * @param value The value to test.
  * @returns `true` if `value` is an `ArrayBufferView`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/buffer/isBufferView
+ * @see https://shelving.cc/util/buffer/isBufferView
  */
 export function isBufferView(value: unknown): value is ArrayBufferView {
 	return ArrayBuffer.isView(value);
@@ -40,7 +40,7 @@ export function isBufferView(value: unknown): value is ArrayBufferView {
  *
  * @param value The value to test.
  * @returns `true` if `value` is a numeric `TypedArray`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/buffer/isTypedArray
+ * @see https://shelving.cc/util/buffer/isTypedArray
  */
 export function isTypedArray(value: unknown): value is TypedArray {
 	return value instanceof Object.getPrototypeOf(Uint8Array);

--- a/modules/util/bytes.ts
+++ b/modules/util/bytes.ts
@@ -4,14 +4,14 @@ import type { AnyCaller } from "./function.js";
 /**
  * A set of bytes stored as a `Uint8Array` byte sequence backed by an `ArrayBuffer`.
  *
- * @see https://dhoulb.github.io/shelving/util/bytes/Bytes
+ * @see https://shelving.cc/util/bytes/Bytes
  */
 export type Bytes = Uint8Array<ArrayBuffer>;
 
 /**
  * Types that can be converted to a `Uint8Array` byte sequence.
  *
- * @see https://dhoulb.github.io/shelving/util/bytes/PossibleBytes
+ * @see https://shelving.cc/util/bytes/PossibleBytes
  */
 export type PossibleBytes = Bytes | ArrayBuffer | string;
 
@@ -20,7 +20,7 @@ export type PossibleBytes = Bytes | ArrayBuffer | string;
  *
  * @param value The value to test.
  * @returns `true` if `value` is a `Uint8Array` backed by an `ArrayBuffer`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/bytes/isBytes
+ * @see https://shelving.cc/util/bytes/isBytes
  */
 export function isBytes(value: unknown): value is Bytes {
 	return value instanceof Uint8Array && value.buffer instanceof ArrayBuffer;
@@ -35,7 +35,7 @@ export function isBytes(value: unknown): value is Bytes {
  * @param caller Function to attribute a thrown error to (defaults to `assertBytes` itself).
  * @throws {RequiredError} If `value` is not a byte sequence within the allowed length range.
  * @example assertBytes(new Uint8Array([1, 2, 3]), 1, 8);
- * @see https://dhoulb.github.io/shelving/util/bytes/assertBytes
+ * @see https://shelving.cc/util/bytes/assertBytes
  */
 export function assertBytes(
 	value: unknown,
@@ -61,7 +61,7 @@ export function assertBytes(
  * @param value The value to convert.
  * @returns The byte sequence, or `undefined` if `value` cannot be converted.
  * @example getBytes("abc") // Uint8Array([97, 98, 99])
- * @see https://dhoulb.github.io/shelving/util/bytes/getBytes
+ * @see https://shelving.cc/util/bytes/getBytes
  */
 export function getBytes(value: unknown): Uint8Array<ArrayBuffer> | undefined {
 	if (isBytes(value)) return value;
@@ -80,7 +80,7 @@ export function getBytes(value: unknown): Uint8Array<ArrayBuffer> | undefined {
  * @returns The converted byte sequence.
  * @throws {RequiredError} If `value` cannot be converted or is outside the allowed length range.
  * @example requireBytes("abc") // Uint8Array([97, 98, 99])
- * @see https://dhoulb.github.io/shelving/util/bytes/requireBytes
+ * @see https://shelving.cc/util/bytes/requireBytes
  */
 export function requireBytes(
 	value: PossibleBytes,

--- a/modules/util/class.ts
+++ b/modules/util/class.ts
@@ -4,14 +4,14 @@ import type { Arguments } from "./function.js";
 /**
  * Class that has a public `constructor()` function.
  *
- * @see https://dhoulb.github.io/shelving/util/class/Constructor
+ * @see https://shelving.cc/util/class/Constructor
  */
 export type Constructor<T, A extends Arguments> = new (...args: A) => T;
 
 /**
  * Any class constructor (designed for use with `extends AnyConstructor` guards).
  *
- * @see https://dhoulb.github.io/shelving/util/class/AnyConstructor
+ * @see https://shelving.cc/util/class/AnyConstructor
  */
 // biome-ignore lint/suspicious/noExplicitAny: `unknown` causes edge case matching issues.
 export type AnyConstructor = new (...args: any) => any;
@@ -19,7 +19,7 @@ export type AnyConstructor = new (...args: any) => any;
 /**
  * Class prototype that can be used with `instanceof`.
  *
- * @see https://dhoulb.github.io/shelving/util/class/Class
+ * @see https://shelving.cc/util/class/Class
  */
 // biome-ignore lint/suspicious/noExplicitAny: `unknown` causes edge case matching issues.
 export type Class<T> = new (...args: any) => T;
@@ -30,7 +30,7 @@ export type Class<T> = new (...args: any) => T;
  * @param value The value to test.
  * @returns `true` if `value` is a class constructor, narrowing its type.
  * @example isConstructor(class {}) // true
- * @see https://dhoulb.github.io/shelving/util/class/isConstructor
+ * @see https://shelving.cc/util/class/isConstructor
  */
 export function isConstructor(value: unknown): value is AnyConstructor {
 	return typeof value === "function" && value.toString().startsWith("class");
@@ -43,7 +43,7 @@ export function isConstructor(value: unknown): value is AnyConstructor {
  * @param type The class to test `value` against.
  * @returns `true` if `value` is an instance of `type`, narrowing its type.
  * @example isInstance(new Date(), Date) // true
- * @see https://dhoulb.github.io/shelving/util/class/isInstance
+ * @see https://shelving.cc/util/class/isInstance
  */
 export function isInstance<T>(value: unknown, type: Class<T>): value is T {
 	return value instanceof type;
@@ -56,7 +56,7 @@ export function isInstance<T>(value: unknown, type: Class<T>): value is T {
  * @param type The class `value` must be an instance of.
  * @throws {RequiredError} If `value` is not an instance of `type`.
  * @example assertInstance(new Date(), Date); // passes
- * @see https://dhoulb.github.io/shelving/util/class/assertInstance
+ * @see https://shelving.cc/util/class/assertInstance
  */
 export function assertInstance<T>(value: unknown, type: Class<T>): asserts value is T {
 	if (!(value instanceof type))
@@ -70,7 +70,7 @@ export function assertInstance<T>(value: unknown, type: Class<T>): asserts value
  * @param prop The property name to look up.
  * @returns The getter function bound to `T`, or `undefined` if the property has no getter.
  * @example getGetter(obj, "size") // () => number | undefined
- * @see https://dhoulb.github.io/shelving/util/class/getGetter
+ * @see https://shelving.cc/util/class/getGetter
  */
 // biome-ignore lint/complexity/noBannedTypes: This is correct here.
 export function getGetter<T extends Object, K extends keyof T>(obj: T, prop: K): ((this: T) => T[K]) | undefined {
@@ -85,7 +85,7 @@ export function getGetter<T extends Object, K extends keyof T>(obj: T, prop: K):
  * @param prop The property name to look up.
  * @returns The setter function bound to `T`, or `undefined` if the property has no setter.
  * @example getSetter(obj, "size") // (value: number) => void | undefined
- * @see https://dhoulb.github.io/shelving/util/class/getSetter
+ * @see https://shelving.cc/util/class/getSetter
  */
 // biome-ignore lint/complexity/noBannedTypes: This is correct here.
 export function getSetter<T extends Object, K extends keyof T>(obj: T, prop: K): ((this: T, value: T[K]) => void) | undefined {

--- a/modules/util/color.ts
+++ b/modules/util/color.ts
@@ -10,21 +10,21 @@ const DARK = 140; // Anything with a luminance > 140 is considered light.
 /**
  * Regular expression matching a three-digit hex color (e.g. `#F00`), capturing each channel.
  *
- * @see https://dhoulb.github.io/shelving/util/color/HEX3_REGEXP
+ * @see https://shelving.cc/util/color/HEX3_REGEXP
  */
 export const HEX3_REGEXP = /^#?([0-F])([0-F])([0-F])$/i;
 
 /**
  * Regular expression matching a six or eight digit hex color (e.g. `#FF0000` or `#FF0000FF`), capturing each channel.
  *
- * @see https://dhoulb.github.io/shelving/util/color/HEX6_REGEXP
+ * @see https://shelving.cc/util/color/HEX6_REGEXP
  */
 export const HEX6_REGEXP = /^#?([0-F]{2})([0-F]{2})([0-F]{2})([0-F]{2})?$/i;
 
 /**
  * Things that can be converted to a `Color` instance.
  *
- * @see https://dhoulb.github.io/shelving/util/color/PossibleColor
+ * @see https://shelving.cc/util/color/PossibleColor
  */
 export type PossibleColor = Color | string;
 
@@ -32,7 +32,7 @@ export type PossibleColor = Color | string;
  * Represents an RGBA color with red, green, blue, and alpha channels (each `0`–`255`).
  *
  * @example new Color(255, 0, 0).hex // "#FF0000"
- * @see https://dhoulb.github.io/shelving/util/color/Color
+ * @see https://shelving.cc/util/color/Color
  */
 export class Color {
 	/**
@@ -41,7 +41,7 @@ export class Color {
 	 * @param possible The value to parse, typically a `Color` instance or a three/six/eight digit hex string.
 	 * @returns The parsed `Color`, or `undefined` if `possible` cannot be converted.
 	 * @example Color.from("#F00") // Color(255, 0, 0)
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/from
+	 * @see https://shelving.cc/util/color/Color/from
 	 */
 	static from(possible: unknown): Color | undefined {
 		if (isColor(possible)) return possible;
@@ -59,28 +59,28 @@ export class Color {
 	/**
 	 * Red channel, bounded to `0`–`255`.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/r
+	 * @see https://shelving.cc/util/color/Color/r
 	 */
 	readonly r: number;
 
 	/**
 	 * Green channel, bounded to `0`–`255`.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/g
+	 * @see https://shelving.cc/util/color/Color/g
 	 */
 	readonly g: number;
 
 	/**
 	 * Blue channel, bounded to `0`–`255`.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/b
+	 * @see https://shelving.cc/util/color/Color/b
 	 */
 	readonly b: number;
 
 	/**
 	 * Alpha channel, bounded to `0`–`255`.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/a
+	 * @see https://shelving.cc/util/color/Color/a
 	 */
 	readonly a: number;
 
@@ -92,7 +92,7 @@ export class Color {
 	 * @param b Blue channel, bounded to `0`–`255` (defaults to `255`).
 	 * @param a Alpha channel, bounded to `0`–`255` (defaults to `255`).
 	 * @example new Color(255, 0, 0) // opaque red
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/constructor
+	 * @see https://shelving.cc/util/color/Color/constructor
 	 */
 	constructor(r = 255, g = 255, b = 255, a = 255) {
 		this.r = boundNumber(r, 0, 255);
@@ -104,7 +104,7 @@ export class Color {
 	/**
 	 * This color as a six or eight digit hex string (eight digits when the alpha channel is less than `255`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/hex
+	 * @see https://shelving.cc/util/color/Color/hex
 	 */
 	get hex(): string {
 		return `#${_hex(this.r)}${_hex(this.g)}${_hex(this.b)}${this.a < 255 ? _hex(this.a) : ""}`;
@@ -113,7 +113,7 @@ export class Color {
 	/**
 	 * This color as a CSS `rgb()` string.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/rgb
+	 * @see https://shelving.cc/util/color/Color/rgb
 	 */
 	get rgb(): string {
 		return `rgb(${this.r}, ${this.g}, ${this.b})`;
@@ -122,7 +122,7 @@ export class Color {
 	/**
 	 * This color as a CSS `rgba()` string.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/rgba
+	 * @see https://shelving.cc/util/color/Color/rgba
 	 */
 	get rgba(): string {
 		return `rgba(${this.r}, ${this.g}, ${this.b}, ${roundNumber(this.a / 256, 4)})`;
@@ -131,7 +131,7 @@ export class Color {
 	/**
 	 * The sRGB luminance of this color (`0`–`255`).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/luminance
+	 * @see https://shelving.cc/util/color/Color/luminance
 	 */
 	get luminance(): number {
 		// Green is the largest component of the luminence, etc.
@@ -141,7 +141,7 @@ export class Color {
 	/**
 	 * Whether this color is light (its luminance is above the dark/light threshold).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/isLight
+	 * @see https://shelving.cc/util/color/Color/isLight
 	 */
 	get isLight(): boolean {
 		return this.luminance > DARK;
@@ -150,7 +150,7 @@ export class Color {
 	/**
 	 * Whether this color is dark (its luminance is at or below the dark/light threshold).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/isDark
+	 * @see https://shelving.cc/util/color/Color/isDark
 	 */
 	get isDark(): boolean {
 		return this.luminance <= DARK;
@@ -161,7 +161,7 @@ export class Color {
 	 *
 	 * @returns This color formatted as a CSS `rgba()` string.
 	 * @example String(new Color(255, 0, 0)) // "rgba(255, 0, 0, 1)"
-	 * @see https://dhoulb.github.io/shelving/util/color/Color/toString
+	 * @see https://shelving.cc/util/color/Color/toString
 	 */
 	toString() {
 		return this.rgba;
@@ -182,7 +182,7 @@ function _hex(channel: number) {
  * @param value The value to test.
  * @returns `true` if `value` is a `Color`, narrowing its type.
  * @example isColor(new Color()) // true
- * @see https://dhoulb.github.io/shelving/util/color/isColor
+ * @see https://shelving.cc/util/color/isColor
  */
 export function isColor(value: unknown): value is Color {
 	return value instanceof Color;
@@ -195,7 +195,7 @@ export function isColor(value: unknown): value is Color {
  * @param caller Function to attribute a thrown error to (defaults to `assertColor` itself).
  * @throws {RequiredError} If `value` is not a `Color` instance.
  * @example assertColor(new Color());
- * @see https://dhoulb.github.io/shelving/util/color/assertColor
+ * @see https://shelving.cc/util/color/assertColor
  */
 export function assertColor(value: unknown, caller: AnyCaller = assertColor): asserts value is Color {
 	if (!isColor(value)) throw new RequiredError("Must be color", { received: value, caller });
@@ -207,7 +207,7 @@ export function assertColor(value: unknown, caller: AnyCaller = assertColor): as
  * @param value The value to convert.
  * @returns The converted `Color`, or `undefined` if `value` cannot be converted.
  * @example getColor("#F00") // Color(255, 0, 0)
- * @see https://dhoulb.github.io/shelving/util/color/getColor
+ * @see https://shelving.cc/util/color/getColor
  */
 export function getColor(value: unknown): Color | undefined {
 	return Color.from(value);
@@ -220,7 +220,7 @@ export function getColor(value: unknown): Color | undefined {
  * @param caller Function to attribute a thrown error to (defaults to `requireColor` itself).
  * @throws {RequiredError} If `value` cannot be converted to a `Color`.
  * @example requireColor("#F00") // Color(255, 0, 0)
- * @see https://dhoulb.github.io/shelving/util/color/requireColor
+ * @see https://shelving.cc/util/color/requireColor
  */
 export function requireColor(value: PossibleColor, caller: AnyCaller = requireColor): Color {
 	const color = getColor(value);

--- a/modules/util/constants.ts
+++ b/modules/util/constants.ts
@@ -1,77 +1,77 @@
 /**
  * One thousand.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/THOUSAND
+ * @see https://shelving.cc/util/constants/THOUSAND
  */
 export const THOUSAND = 1000;
 
 /**
  * Ten thousand.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/TEN_THOUSAND
+ * @see https://shelving.cc/util/constants/TEN_THOUSAND
  */
 export const TEN_THOUSAND = 10 * THOUSAND;
 
 /**
  * Hundred thousand.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/HUNDRED_THOUSAND
+ * @see https://shelving.cc/util/constants/HUNDRED_THOUSAND
  */
 export const HUNDRED_THOUSAND = 100 * THOUSAND;
 
 /**
  * One million.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/MILLION
+ * @see https://shelving.cc/util/constants/MILLION
  */
 export const MILLION = 1000 * THOUSAND;
 
 /**
  * One billion.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/BILLION
+ * @see https://shelving.cc/util/constants/BILLION
  */
 export const BILLION = 1000 * MILLION;
 
 /**
  * One trillion.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/TRILLION
+ * @see https://shelving.cc/util/constants/TRILLION
  */
 export const TRILLION = 1000 * BILLION;
 
 /**
  * One second in milliseconds.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/SECOND
+ * @see https://shelving.cc/util/constants/SECOND
  */
 export const SECOND = 1000;
 
 /**
  * One minute in milliseconds.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/MINUTE
+ * @see https://shelving.cc/util/constants/MINUTE
  */
 export const MINUTE = 60 * SECOND;
 
 /**
  * One hour in milliseconds.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/HOUR
+ * @see https://shelving.cc/util/constants/HOUR
  */
 export const HOUR = 60 * MINUTE;
 
 /**
  * One day in milliseconds.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/DAY
+ * @see https://shelving.cc/util/constants/DAY
  */
 export const DAY = 24 * HOUR;
 
 /**
  * One week in milliseconds.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/WEEK
+ * @see https://shelving.cc/util/constants/WEEK
  */
 export const WEEK = 7 * DAY;
 
@@ -79,7 +79,7 @@ export const WEEK = 7 * DAY;
  * One month in milliseconds.
  * - Approximated as 30 days.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/MONTH
+ * @see https://shelving.cc/util/constants/MONTH
  */
 export const MONTH = 30 * DAY;
 
@@ -87,49 +87,49 @@ export const MONTH = 30 * DAY;
  * One year in milliseconds.
  * - Approximated as 365 days.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/YEAR
+ * @see https://shelving.cc/util/constants/YEAR
  */
 export const YEAR = 365 * DAY;
 
 /**
  * Non-breaking space (`U+00A0`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/NBSP
+ * @see https://shelving.cc/util/constants/NBSP
  */
 export const NBSP = "\xA0";
 
 /**
  * Thin space (`U+2009`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/THINSP
+ * @see https://shelving.cc/util/constants/THINSP
  */
 export const THINSP = "\u2009";
 
 /**
  * Non-breaking narrow space (`U+202F`, goes between numbers and their corresponding units).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/NNBSP
+ * @see https://shelving.cc/util/constants/NNBSP
  */
 export const NNBSP = "\u202F";
 
 /**
  * The `ABORT` symbol indicates something was manually aborted.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/ABORT
+ * @see https://shelving.cc/util/constants/ABORT
  */
 export const ABORT: unique symbol = Symbol("shelving/ABORT");
 
 /**
  * The `NONE` symbol indicates something is nothing.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/NONE
+ * @see https://shelving.cc/util/constants/NONE
  */
 export const NONE: unique symbol = Symbol("shelving/NONE");
 
 /**
  * The `SKIP` symbol indicates something should be silently skipped.
  *
- * @see https://dhoulb.github.io/shelving/util/constants/SKIP
+ * @see https://shelving.cc/util/constants/SKIP
  */
 export const SKIP: unique symbol = Symbol("shelving/SKIP");
 
@@ -138,48 +138,48 @@ export const SKIP: unique symbol = Symbol("shelving/SKIP");
 /**
  * Waiting/ellipsis icon character (`⋯`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/WAITING
+ * @see https://shelving.cc/util/constants/WAITING
  */
 export const WAITING = "⋯";
 
 /**
  * Success/check icon character (`✓`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/SUCCESS
+ * @see https://shelving.cc/util/constants/SUCCESS
  */
 export const SUCCESS = "✓";
 
 /**
  * Failure/cross icon character (`✗`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/FAILURE
+ * @see https://shelving.cc/util/constants/FAILURE
  */
 export const FAILURE = "✗";
 
 /**
  * Up arrow icon character (`↑`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/UP
+ * @see https://shelving.cc/util/constants/UP
  */
 export const UP = "↑";
 
 /**
  * Down arrow icon character (`↓`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/DOWN
+ * @see https://shelving.cc/util/constants/DOWN
  */
 export const DOWN = "↓";
 
 /**
  * Right arrow icon character (`→`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/RIGHT
+ * @see https://shelving.cc/util/constants/RIGHT
  */
 export const RIGHT = "→";
 
 /**
  * Left arrow icon character (`←`).
  *
- * @see https://dhoulb.github.io/shelving/util/constants/LEFT
+ * @see https://shelving.cc/util/constants/LEFT
  */
 export const LEFT = "←";

--- a/modules/util/crypto.ts
+++ b/modules/util/crypto.ts
@@ -20,7 +20,7 @@ function _getKey(password: string): Promise<CryptoKey> {
  * @param length The number of random bytes to generate.
  * @returns A `Bytes` (`Uint8Array`) of the requested length filled with random values.
  * @example getRandomBytes(16) // Uint8Array(16) [ ... ]
- * @see https://dhoulb.github.io/shelving/util/crypto/getRandomBytes
+ * @see https://shelving.cc/util/crypto/getRandomBytes
  */
 export function getRandomBytes(length: number): Bytes {
 	const bytes: Bytes = new Uint8Array(length);
@@ -40,7 +40,7 @@ export function getRandomBytes(length: number): Bytes {
  * @throws {ValueError} If the password is shorter than the minimum length, or `iterations` is less than 1.
  *
  * @example const hash = await hashPassword("correct-horse"); // "abc…$500000$def…"
- * @see https://dhoulb.github.io/shelving/util/crypto/hashPassword
+ * @see https://shelving.cc/util/crypto/hashPassword
  */
 export async function hashPassword(password: string, iterations = ITERATIONS): Promise<string> {
 	// Checks.
@@ -71,7 +71,7 @@ export async function hashPassword(password: string, iterations = ITERATIONS): P
  * - Returns `false` (never throws) for malformed hash strings or invalid iteration counts.
  *
  * @example await verifyPassword("correct-horse", storedHash) // true
- * @see https://dhoulb.github.io/shelving/util/crypto/verifyPassword
+ * @see https://shelving.cc/util/crypto/verifyPassword
  */
 export async function verifyPassword(password: string, hash: string): Promise<boolean> {
 	// Check salthash.

--- a/modules/util/currency.ts
+++ b/modules/util/currency.ts
@@ -5,14 +5,14 @@ import type { AnyCaller } from "./function.js";
 /**
  * ISO 4217 currency code, e.g. `GBP` or `USD`.
  *
- * @see https://dhoulb.github.io/shelving/util/currency/CurrencyCode
+ * @see https://shelving.cc/util/currency/CurrencyCode
  */
 export type CurrencyCode = string;
 
 /**
  * Array of all ISO 4217 currency codes supported by the current runtime's `Intl` implementation.
  *
- * @see https://dhoulb.github.io/shelving/util/currency/CURRENCY_CODES
+ * @see https://shelving.cc/util/currency/CURRENCY_CODES
  */
 export const CURRENCY_CODES: ImmutableArray<CurrencyCode> = Intl.supportedValuesOf("currency");
 
@@ -24,7 +24,7 @@ export const CURRENCY_CODES: ImmutableArray<CurrencyCode> = Intl.supportedValues
  * @returns The normalised `CurrencyCode`, or `undefined` if the value isn't a supported currency.
  * @example getCurrencyCode("gbp") // "GBP"
  * @example getCurrencyCode("nope") // undefined
- * @see https://dhoulb.github.io/shelving/util/currency/getCurrencyCode
+ * @see https://shelving.cc/util/currency/getCurrencyCode
  */
 export function getCurrencyCode(value: string): CurrencyCode | undefined {
 	const currency = value.toUpperCase().trim();
@@ -39,7 +39,7 @@ export function getCurrencyCode(value: string): CurrencyCode | undefined {
  * @returns The normalised `CurrencyCode`.
  * @throws {RequiredError} If the value isn't a supported ISO 4217 currency code.
  * @example requireCurrencyCode("gbp") // "GBP"
- * @see https://dhoulb.github.io/shelving/util/currency/requireCurrencyCode
+ * @see https://shelving.cc/util/currency/requireCurrencyCode
  */
 export function requireCurrencyCode(value: string, caller: AnyCaller = requireCurrencyCode): CurrencyCode {
 	const currency = getCurrencyCode(value);
@@ -66,7 +66,7 @@ const _isCurrencyNumberPart = ({ type }: Intl.NumberFormatPart) => type === "cur
  * @throws {RequiredError} If the currency code is malformed or unsupported.
  *
  * @example getCurrencySymbol("GBP"); // "£"
- * @see https://dhoulb.github.io/shelving/util/currency/getCurrencySymbol
+ * @see https://shelving.cc/util/currency/getCurrencySymbol
  */
 export function getCurrencySymbol(currency: CurrencyCode, caller: AnyCaller = getCurrencySymbol): string {
 	return _formatter(currency, caller).formatToParts(0).find(_isCurrencyNumberPart)?.value as string;
@@ -83,7 +83,7 @@ export function getCurrencySymbol(currency: CurrencyCode, caller: AnyCaller = ge
  *
  * @example getCurrencyStep("USD") // 0.01
  * @example getCurrencyStep("JPY") // 1
- * @see https://dhoulb.github.io/shelving/util/currency/getCurrencyStep
+ * @see https://shelving.cc/util/currency/getCurrencyStep
  */
 export function getCurrencyStep(currency: CurrencyCode, caller: AnyCaller = getCurrencyStep): number {
 	const { minimumFractionDigits = 0 } = _formatter(currency, caller).resolvedOptions();

--- a/modules/util/data.ts
+++ b/modules/util/data.ts
@@ -11,28 +11,28 @@ import type { Resolve } from "./types.js";
 /**
  * Data object — a plain object with `string` keys and `unknown` values.
  *
- * @see https://dhoulb.github.io/shelving/util/data/Data
+ * @see https://shelving.cc/util/data/Data
  */
 export type Data = { readonly [K in string]: unknown };
 
 /**
  * Partial data object (values can be explicitly `undefined`).
  *
- * @see https://dhoulb.github.io/shelving/util/data/PartialData
+ * @see https://shelving.cc/util/data/PartialData
  */
 export type PartialData<T extends Data> = { readonly [K in keyof T]?: T[K] | undefined };
 
 /**
  * Helper type to get the key for a data object prop.
  *
- * @see https://dhoulb.github.io/shelving/util/data/DataKey
+ * @see https://shelving.cc/util/data/DataKey
  */
 export type DataKey<T extends Data> = keyof T & string;
 
 /**
  * Helper type to get the value for a data object prop.
  *
- * @see https://dhoulb.github.io/shelving/util/data/DataValue
+ * @see https://shelving.cc/util/data/DataValue
  */
 export type DataValue<T extends Data> = T[DataKey<T>];
 
@@ -40,7 +40,7 @@ export type DataValue<T extends Data> = T[DataKey<T>];
  * Helper type to get a prop for a data object.
  * i.e. `DataProp<{ a: number }>` produces `readonly ["a", number"]`
  *
- * @see https://dhoulb.github.io/shelving/util/data/DataProp
+ * @see https://shelving.cc/util/data/DataProp
  */
 export type DataProp<T extends Data> = {
 	readonly [K in DataKey<T>]: readonly [K, T[K]];
@@ -50,28 +50,28 @@ export type DataProp<T extends Data> = {
  * Helper type to get a flattened data object with every branch node of the data, flattened into `a.c.b` format.
  * i.e. `BranchData<{ a: { a2: number } }>` produces `{ "a": object, "a.a2": number }`
  *
- * @see https://dhoulb.github.io/shelving/util/data/BranchData
+ * @see https://shelving.cc/util/data/BranchData
  */
 export type BranchData<T extends Data> = EntryObject<BranchDataProp<T>>;
 
 /**
  * Helper type to get the path for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/BranchDataPath
+ * @see https://shelving.cc/util/data/BranchDataPath
  */
 export type BranchDataPath<T extends Data> = BranchDataProp<T>[0];
 
 /**
  * Helper type to get the value for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/BranchDataValue
+ * @see https://shelving.cc/util/data/BranchDataValue
  */
 export type BranchDataValue<T extends Data> = BranchDataProp<T>[1];
 
 /**
  * Helper type to get the prop for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/BranchDataProp
+ * @see https://shelving.cc/util/data/BranchDataProp
  */
 export type BranchDataProp<T extends Data> = {
 	readonly [K in DataKey<T>]: (
@@ -89,7 +89,7 @@ export type BranchDataProp<T extends Data> = {
  * Typed path tuple for every branch node of a data object (including intermediate objects).
  * i.e. `BranchPath<{ a: number, b: { c: string } }>` produces `readonly ["a"] | readonly ["b"] | readonly ["b", "c"]`
  *
- * @see https://dhoulb.github.io/shelving/util/data/BranchDataSegments
+ * @see https://shelving.cc/util/data/BranchDataSegments
  */
 export type BranchDataSegments<T extends Data> = {
 	readonly [K in DataKey<T>]: T[K] extends Data ? readonly [K] | readonly [K, ...BranchDataSegments<T[K]>] : readonly [K];
@@ -99,28 +99,28 @@ export type BranchDataSegments<T extends Data> = {
  * Helper type to get a flattened data object with only leaf nodes of the data, flattened into `a.c.b` format.
  * i.e. `LeafData<{ a: { a2: number } }>` produces `{ "a.a2": number }`
  *
- * @see https://dhoulb.github.io/shelving/util/data/LeafData
+ * @see https://shelving.cc/util/data/LeafData
  */
 export type LeafData<T extends Data> = EntryObject<LeafDataProp<T>>;
 
 /**
  * Helper type to get the leaf paths for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/LeafDataPath
+ * @see https://shelving.cc/util/data/LeafDataPath
  */
 export type LeafDataPath<T extends Data> = LeafDataProp<T>[0];
 
 /**
  * Helper type to get the leaf values for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/LeafDataValue
+ * @see https://shelving.cc/util/data/LeafDataValue
  */
 export type LeafDataValue<T extends Data> = LeafDataProp<T>[1];
 
 /**
  * Helper type to get the leaf props for a flattened data object with deep paths flattened into `a.c.b` format.
  *
- * @see https://dhoulb.github.io/shelving/util/data/LeafDataProp
+ * @see https://shelving.cc/util/data/LeafDataProp
  */
 export type LeafDataProp<T extends Data> = {
 	readonly [K in DataKey<T>]: (
@@ -138,7 +138,7 @@ export type LeafDataProp<T extends Data> = {
  * Typed path tuple for only leaf nodes of a data object.
  * i.e. `LeafPath<{ a: number, b: { c: string } }>` produces `readonly ["a"] | readonly ["b", "c"]`
  *
- * @see https://dhoulb.github.io/shelving/util/data/LeafDataSegments
+ * @see https://shelving.cc/util/data/LeafDataSegments
  */
 export type LeafDataSegments<T extends Data> = {
 	readonly [K in DataKey<T>]: T[K] extends Data ? readonly [K, ...LeafDataSegments<T[K]>] : readonly [K];
@@ -148,7 +148,7 @@ export type LeafDataSegments<T extends Data> = {
  * Object with one level of data nested beneath each prop.
  * i.e. `{ A: { a: number }, B: { b: string } }`
  *
- * @see https://dhoulb.github.io/shelving/util/data/NestedData
+ * @see https://shelving.cc/util/data/NestedData
  */
 export type NestedData = { readonly [key: string]: Data };
 
@@ -156,7 +156,7 @@ export type NestedData = { readonly [key: string]: Data };
  * Helper type to flatten one level of nested data into a single flat `Data` type.
  * i.e. `FlattenData<{ A: { a: number }, B: { b: string } }>` produces `{ a: number, b: string }`
  *
- * @see https://dhoulb.github.io/shelving/util/data/FlatData
+ * @see https://shelving.cc/util/data/FlatData
  */
 export type FlatData<T extends NestedData> = Resolve<UnionToIntersection<T[keyof T]>>;
 
@@ -166,7 +166,7 @@ export type FlatData<T extends NestedData> = Resolve<UnionToIntersection<T[keyof
  * @param value The value to check.
  * @returns `true` if the value is a plain data object, narrowing it to `Data`.
  * @example isData({ a: 1 }) // true
- * @see https://dhoulb.github.io/shelving/util/data/isData
+ * @see https://shelving.cc/util/data/isData
  */
 export function isData(value: unknown): value is Data {
 	return isPlainObject(value);
@@ -179,7 +179,7 @@ export function isData(value: unknown): value is Data {
  * @param caller The function to attribute a thrown error to (defaults to `assertData`).
  * @throws {RequiredError} If the value is not a plain data object.
  * @example assertData(value); // throws unless `value` is a `Data` object
- * @see https://dhoulb.github.io/shelving/util/data/assertData
+ * @see https://shelving.cc/util/data/assertData
  */
 export function assertData(value: unknown, caller: AnyCaller = assertData): asserts value is Data {
 	if (!isPlainObject(value)) throw new RequiredError("Must be data object", { received: value, caller });
@@ -192,7 +192,7 @@ export function assertData(value: unknown, caller: AnyCaller = assertData): asse
  * @param key The value to check as a key.
  * @returns `true` if `key` is an own string key of `data`, narrowing it to `DataKey<T>`.
  * @example isDataProp({ a: 1 }, "a") // true
- * @see https://dhoulb.github.io/shelving/util/data/isDataProp
+ * @see https://shelving.cc/util/data/isDataProp
  */
 export function isDataProp<T extends Data>(data: T, key: unknown): key is DataKey<T> {
 	return typeof key === "string" && Object.hasOwn(data, key);
@@ -206,7 +206,7 @@ export function isDataProp<T extends Data>(data: T, key: unknown): key is DataKe
  * @param caller The function to attribute a thrown error to (defaults to `assertDataProp`).
  * @throws {RequiredError} If `key` is not an own key of `data`.
  * @example assertDataProp(data, key); // throws unless `key` exists in `data`
- * @see https://dhoulb.github.io/shelving/util/data/assertDataProp
+ * @see https://shelving.cc/util/data/assertDataProp
  */
 export function assertDataProp<T extends Data>(data: T, key: unknown, caller: AnyCaller = assertDataProp): asserts key is DataKey<T> {
 	if (!isDataProp(data, key)) throw new RequiredError("Key must exist in data object", { key, data, caller });
@@ -218,7 +218,7 @@ export function assertDataProp<T extends Data>(data: T, key: unknown, caller: An
  * @param data The data object to read.
  * @returns An immutable array of `[key, value]` prop tuples.
  * @example getDataProps({ a: 1, b: 2 }) // [["a", 1], ["b", 2]]
- * @see https://dhoulb.github.io/shelving/util/data/getDataProps
+ * @see https://shelving.cc/util/data/getDataProps
  */
 export function getDataProps<T extends Data>(data: T): ImmutableArray<DataProp<T>>;
 export function getDataProps<T extends Data>(data: T | Partial<T>): ImmutableArray<DataProp<T>>;
@@ -232,7 +232,7 @@ export function getDataProps(data: Data | Partial<Data>): ImmutableArray<DataPro
  * @param data The data object to read.
  * @returns An immutable array of the object's string keys.
  * @example getDataKeys({ a: 1, b: 2 }) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/data/getDataKeys
+ * @see https://shelving.cc/util/data/getDataKeys
  */
 export function getDataKeys<T extends Data>(data: T): ImmutableArray<DataKey<T>>;
 export function getDataKeys<T extends Data>(data: T | Partial<T>): ImmutableArray<DataKey<T>>;
@@ -247,7 +247,7 @@ export function getDataKeys(data: Data | Partial<Data>): ImmutableArray<DataKey<
  * @param path The dotted path string (e.g. `"a.b"`) or an array of segments.
  * @returns The path as an array of segments.
  * @example splitDataPath<{ a: { b: number } }>("a.b"); // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/data/splitDataPath
+ * @see https://shelving.cc/util/data/splitDataPath
  */
 export function splitDataPath<T extends Data>(path: BranchDataPath<T> | BranchDataSegments<T>): BranchDataSegments<T>;
 export function splitDataPath<T extends Data>(path: LeafDataPath<T> | LeafDataSegments<T>): LeafDataSegments<T>;
@@ -263,7 +263,7 @@ export function splitDataPath(path: string | Segments): ImmutableArray<string> {
  * @param path An array of path segments, or an already-joined dotted path string.
  * @returns The path as a dotted string (e.g. `"a.b"`).
  * @example joinDataPath<{ a: { b: number } }>(["a", "b"]); // "a.b"
- * @see https://dhoulb.github.io/shelving/util/data/joinDataPath
+ * @see https://shelving.cc/util/data/joinDataPath
  */
 export function joinDataPath<T extends Data>(path: BranchDataSegments<T> | BranchDataPath<T>): BranchDataPath<T>;
 export function joinDataPath<T extends Data>(path: LeafDataSegments<T> | LeafDataPath<T>): LeafDataPath<T>;
@@ -281,7 +281,7 @@ export function joinDataPath(path: Segments | string): string {
  * @example getDataProp<{ a: { b: number } }>({ a: { b: 123 } }, ["a", "b"]); // 123
  * @example getDataProp<{ a: { b: number } }>({ a: { b: 123 } }, "a.b"); // 123
  * @example getDataProp({ a: { b: 123 } } as Data, "x.y.z"); // undefined
- * @see https://dhoulb.github.io/shelving/util/data/getDataProp
+ * @see https://shelving.cc/util/data/getDataProp
  */
 export function getDataProp<T extends Data, K extends BranchDataPath<T>>(data: T, path: K): BranchData<T>[K];
 export function getDataProp<T extends Data, K extends BranchDataPath<T>>(data: DeepPartial<T>, path: K): BranchData<T>[K] | undefined;

--- a/modules/util/date.ts
+++ b/modules/util/date.ts
@@ -4,7 +4,7 @@ import type { AnyCaller } from "./function.js";
 /**
  * Values that can be converted to dates.
  *
- * @see https://dhoulb.github.io/shelving/util/date/PossibleDate
+ * @see https://shelving.cc/util/date/PossibleDate
  */
 export type PossibleDate = "now" | "today" | "tomorrow" | "yesterday" | Date | number | string;
 
@@ -14,7 +14,7 @@ export type PossibleDate = "now" | "today" | "tomorrow" | "yesterday" | Date | n
  *
  * @param value The value to check.
  * @returns `true` if the value is a `Date` instance representing a valid date, narrowing it to `Date`.
- * @see https://dhoulb.github.io/shelving/util/date/isDate
+ * @see https://shelving.cc/util/date/isDate
  */
 export function isDate(value: unknown): value is Date {
 	return value instanceof Date && Number.isFinite(value.getTime());
@@ -27,7 +27,7 @@ export function isDate(value: unknown): value is Date {
  * @param caller The function to attribute a thrown error to (defaults to `assertDate`).
  * @throws {RequiredError} If the value is not a valid `Date` instance.
  * @example assertDate(value); // throws unless `value` is a valid `Date`
- * @see https://dhoulb.github.io/shelving/util/date/assertDate
+ * @see https://shelving.cc/util/date/assertDate
  */
 export function assertDate(value: unknown, caller: AnyCaller = assertDate): asserts value is Date {
 	if (!isDate(value)) throw new RequiredError("Must be valid date", { received: value, caller });
@@ -52,7 +52,7 @@ export function assertDate(value: unknown, caller: AnyCaller = assertDate): asse
  * @returns `Date` instance if the value could be converted to a valid date, or `undefined` if not.
  * @example getDate("2003-09-12") // Date instance for 2003-09-12
  * @example getDate("nope") // undefined
- * @see https://dhoulb.github.io/shelving/util/date/getDate
+ * @see https://shelving.cc/util/date/getDate
  */
 export function getDate(value: unknown): Date | undefined {
 	if (value === "now") return getNow();
@@ -73,7 +73,7 @@ export function getDate(value: unknown): Date | undefined {
  *
  * @returns A new `Date` instance for the current moment.
  * @example getNow() // Date instance for right now
- * @see https://dhoulb.github.io/shelving/util/date/getNow
+ * @see https://shelving.cc/util/date/getNow
  */
 export function getNow(): Date {
 	return new Date();
@@ -84,7 +84,7 @@ export function getNow(): Date {
  *
  * @returns A new `Date` instance at midnight yesterday.
  * @example getYesterday() // Date instance for yesterday at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getYesterday
+ * @see https://shelving.cc/util/date/getYesterday
  */
 export function getYesterday(): Date {
 	const date = new Date();
@@ -98,7 +98,7 @@ export function getYesterday(): Date {
  *
  * @returns A new `Date` instance at midnight today.
  * @example getToday() // Date instance for today at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getToday
+ * @see https://shelving.cc/util/date/getToday
  */
 export function getToday(): Date {
 	const date = new Date();
@@ -111,7 +111,7 @@ export function getToday(): Date {
  *
  * @returns A new `Date` instance at midnight tomorrow.
  * @example getTomorrow() // Date instance for tomorrow at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getTomorrow
+ * @see https://shelving.cc/util/date/getTomorrow
  */
 export function getTomorrow(): Date {
 	const date = new Date();
@@ -128,7 +128,7 @@ export function getTomorrow(): Date {
  * @returns A new `Date` instance at midnight of the target date.
  * @throws {RequiredError} If `target` couldn't be converted to a valid date.
  * @example getMidnight("2003-09-12") // Date instance for 2003-09-12 at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getMidnight
+ * @see https://shelving.cc/util/date/getMidnight
  */
 export function getMidnight(target?: PossibleDate, caller: AnyCaller = getMidnight): Date {
 	const date = new Date(requireDate(target, caller));
@@ -144,7 +144,7 @@ export function getMidnight(target?: PossibleDate, caller: AnyCaller = getMidnig
  * @returns A new `Date` instance at midnight on Monday of the target week.
  * @throws {RequiredError} If `target` couldn't be converted to a valid date.
  * @example getMonday("2003-09-12") // Date instance for the Monday of that week at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getMonday
+ * @see https://shelving.cc/util/date/getMonday
  */
 export function getMonday(target?: PossibleDate, caller: AnyCaller = getMonday): Date {
 	const date = getMidnight(target, caller);
@@ -162,7 +162,7 @@ export function getMonday(target?: PossibleDate, caller: AnyCaller = getMonday):
  * @returns A new `Date` instance at midnight on the 1st of the target month.
  * @throws {RequiredError} If `target` couldn't be converted to a valid date.
  * @example getMonthStart("2003-09-12") // Date instance for 2003-09-01 at 00:00
- * @see https://dhoulb.github.io/shelving/util/date/getMonthStart
+ * @see https://shelving.cc/util/date/getMonthStart
  */
 export function getMonthStart(target?: PossibleDate, caller: AnyCaller = getMonthStart): Date {
 	const date = getMidnight(target, caller);
@@ -178,7 +178,7 @@ export function getMonthStart(target?: PossibleDate, caller: AnyCaller = getMont
  * @returns A valid `Date` instance.
  * @throws {RequiredError} If `value` couldn't be converted to a valid date.
  * @example requireDate("2003-09-12") // Date instance for 2003-09-12
- * @see https://dhoulb.github.io/shelving/util/date/requireDate
+ * @see https://shelving.cc/util/date/requireDate
  */
 export function requireDate(value: PossibleDate = "now", caller: AnyCaller = requireDate): Date {
 	const date = getDate(value);
@@ -192,7 +192,7 @@ export function requireDate(value: PossibleDate = "now", caller: AnyCaller = req
  * @param value Any value that we want to parse as a valid date.
  * @returns The timestamp in milliseconds, or `undefined` if the value couldn't be converted.
  * @example getTimestamp("1970-01-01T00:00:00Z") // 0
- * @see https://dhoulb.github.io/shelving/util/date/getTimestamp
+ * @see https://shelving.cc/util/date/getTimestamp
  */
 export function getTimestamp(value?: unknown): number | undefined {
 	return getDate(value)?.getTime();
@@ -205,7 +205,7 @@ export function getTimestamp(value?: unknown): number | undefined {
  * @returns The timestamp in milliseconds.
  * @throws {RequiredError} If `value` couldn't be converted to a valid date.
  * @example requireTimestamp("1970-01-01T00:00:00Z") // 0
- * @see https://dhoulb.github.io/shelving/util/date/requireTimestamp
+ * @see https://shelving.cc/util/date/requireTimestamp
  */
 export function requireTimestamp(value?: PossibleDate): number {
 	return requireDate(value, requireTimestamp).getTime();
@@ -231,7 +231,7 @@ function _datetime(date: Date): string {
  * @param value Any value that we want to parse as a valid date.
  * @returns The local datetime string, or `undefined` if `value` couldn't be converted.
  * @example getDateTimeString("2015-09-12T18:30:00") // "2015-09-12T18:30:00"
- * @see https://dhoulb.github.io/shelving/util/date/getDateTimeString
+ * @see https://shelving.cc/util/date/getDateTimeString
  */
 export function getDateTimeString(value?: unknown): string | undefined {
 	const date = getDate(value);
@@ -246,7 +246,7 @@ export function getDateTimeString(value?: unknown): string | undefined {
  * @returns The local datetime string.
  * @throws {RequiredError} If `value` couldn't be converted to a valid date.
  * @example requireDateTimeString("2015-09-12T18:30:00") // "2015-09-12T18:30:00"
- * @see https://dhoulb.github.io/shelving/util/date/requireDateTimeString
+ * @see https://shelving.cc/util/date/requireDateTimeString
  */
 export function requireDateTimeString(value?: PossibleDate, caller: AnyCaller = requireDateTimeString): string {
 	return _datetime(requireDate(value, caller));
@@ -258,7 +258,7 @@ export function requireDateTimeString(value?: PossibleDate, caller: AnyCaller = 
  * @param value Any value that we want to parse as a valid date.
  * @returns The local date string, or `undefined` if `value` couldn't be converted.
  * @example getDateString("2015-09-12T18:30:00") // "2015-09-12"
- * @see https://dhoulb.github.io/shelving/util/date/getDateString
+ * @see https://shelving.cc/util/date/getDateString
  */
 export function getDateString(value?: unknown): string | undefined {
 	const date = getDate(value);
@@ -353,7 +353,7 @@ export function addMinutes(change: number, target?: PossibleDate, caller: AnyCal
  * @returns A new `Date` instance offset by `change` seconds.
  * @throws {RequiredError} If `target` couldn't be converted to a valid date.
  * @example addSeconds(30, "2003-09-12T00:00:00") // Date instance for 2003-09-12T00:00:30
- * @see https://dhoulb.github.io/shelving/util/date/addSeconds
+ * @see https://shelving.cc/util/date/addSeconds
  */
 export function addSeconds(change: number, target?: PossibleDate, caller: AnyCaller = addSeconds): Date {
 	const date = new Date(requireDate(target, caller));
@@ -370,7 +370,7 @@ export function addSeconds(change: number, target?: PossibleDate, caller: AnyCal
  * @returns A new `Date` instance offset by `change` milliseconds.
  * @throws {RequiredError} If `target` couldn't be converted to a valid date.
  * @example addMilliseconds(500, "2003-09-12T00:00:00") // Date instance for 2003-09-12T00:00:00.500
- * @see https://dhoulb.github.io/shelving/util/date/addMilliseconds
+ * @see https://shelving.cc/util/date/addMilliseconds
  */
 export function addMilliseconds(change: number, target?: PossibleDate, caller: AnyCaller = addMilliseconds): Date {
 	const date = new Date(requireDate(target, caller));

--- a/modules/util/debug.ts
+++ b/modules/util/debug.ts
@@ -12,7 +12,7 @@ import type { ImmutableSet } from "./set.js";
  * @param depth How many levels of nested containers to expand (defaults to `1`).
  * @returns A human-readable string representation of `value`.
  * @example debug({ a: 1, b: "two" }) // `{\n\t"a": 1,\n\t"b": "two"\n}`
- * @see https://dhoulb.github.io/shelving/util/debug/debug
+ * @see https://shelving.cc/util/debug/debug
  */
 export function debug(value: unknown, depth = 1): string {
 	if (value === null) return "null";
@@ -44,7 +44,7 @@ export function debug(value: unknown, depth = 1): string {
  * @param value The string to debug.
  * @returns The quoted and escaped string.
  * @example debugString("a\tb") // `"a\\tb"`
- * @see https://dhoulb.github.io/shelving/util/debug/debugString
+ * @see https://shelving.cc/util/debug/debugString
  */
 export function debugString(value: string): string {
 	return `"${value.replace(ESCAPE_REGEXP, _escapeChar)}"`;
@@ -70,7 +70,7 @@ const _escapeChar = (char: string): string => ESCAPE_LIST[char] || `\\x${char.ch
  * @param headers The `Headers` object to debug.
  * @returns A newline-separated string of `key: value` pairs.
  * @example debugHeaders(new Headers({ "Content-Type": "text/plain" })) // "content-type: text/plain"
- * @see https://dhoulb.github.io/shelving/util/debug/debugHeaders
+ * @see https://shelving.cc/util/debug/debugHeaders
  */
 export function debugHeaders(headers: Headers): string {
 	return Array.from(headers, ([key, value]) => `${key}: ${value}`).join("\n");
@@ -84,7 +84,7 @@ export function debugHeaders(headers: Headers): string {
  * @param request The `Request` to debug.
  * @returns A promise resolving to the request line, headers, and body as a string.
  * @example await debugFullRequest(new Request("https://x.com")) // "GET https://x.com/"
- * @see https://dhoulb.github.io/shelving/util/debug/debugFullRequest
+ * @see https://shelving.cc/util/debug/debugFullRequest
  */
 export async function debugFullRequest(request: Request): Promise<string> {
 	return _debugFullMessage(debugRequest(request), request);
@@ -99,7 +99,7 @@ export async function debugFullRequest(request: Request): Promise<string> {
  * @param response The `Response` to debug.
  * @returns A promise resolving to the status line, headers, and body as a string.
  * @example await debugFullResponse(new Response("hi", { status: 200 })) // "200 \n\nhi"
- * @see https://dhoulb.github.io/shelving/util/debug/debugFullResponse
+ * @see https://shelving.cc/util/debug/debugFullResponse
  */
 export async function debugFullResponse(response: Response): Promise<string> {
 	return _debugFullMessage(debugResponse(response), response);
@@ -147,7 +147,7 @@ async function _debugMessageBody(message: Request | Response): Promise<string> {
  * @param request The `Request` to debug.
  * @returns A string in `METHOD url` format.
  * @example debugRequest(new Request("https://x.com")) // "GET https://x.com/"
- * @see https://dhoulb.github.io/shelving/util/debug/debugRequest
+ * @see https://shelving.cc/util/debug/debugRequest
  */
 export function debugRequest(request: Request): string {
 	return `${request.method} ${request.url}`;
@@ -160,7 +160,7 @@ export function debugRequest(request: Request): string {
  * @param response The `Response` to debug.
  * @returns A string in `status statusText` format.
  * @example debugResponse(new Response("hi", { status: 404 })) // "404 Not Found"
- * @see https://dhoulb.github.io/shelving/util/debug/debugResponse
+ * @see https://shelving.cc/util/debug/debugResponse
  */
 export function debugResponse(response: Response): string {
 	return `${response.status} ${response.statusText}`;
@@ -175,7 +175,7 @@ export function debugResponse(response: Response): string {
  * @param depth How many levels of nested containers to expand (defaults to `1`).
  * @returns A human-readable string representation of the array.
  * @example debugArray([1, 2]) // `[\n\t1,\n\t2\n]`
- * @see https://dhoulb.github.io/shelving/util/debug/debugArray
+ * @see https://shelving.cc/util/debug/debugArray
  */
 export function debugArray(value: ImmutableArray, depth = 1): string {
 	const prototype = Object.getPrototypeOf(value) as typeof value;
@@ -193,7 +193,7 @@ export function debugArray(value: ImmutableArray, depth = 1): string {
  * @param depth How many levels of nested containers to expand (defaults to `1`).
  * @returns A human-readable string representation of the set.
  * @example debugSet(new Set([1, 2])) // `(value.size) {\n\t1,\n\t2\n}`
- * @see https://dhoulb.github.io/shelving/util/debug/debugSet
+ * @see https://shelving.cc/util/debug/debugSet
  */
 export function debugSet(value: ImmutableSet, depth = 1): string {
 	const prototype = Object.getPrototypeOf(value) as typeof value;
@@ -216,7 +216,7 @@ export function debugSet(value: ImmutableSet, depth = 1): string {
  * @param depth How many levels of nested containers to expand (defaults to `1`).
  * @returns A human-readable string representation of the map.
  * @example debugMap(new Map([["a", 1]])) // `(value.size) {\n\t"a": 1\n}`
- * @see https://dhoulb.github.io/shelving/util/debug/debugMap
+ * @see https://shelving.cc/util/debug/debugMap
  */
 export function debugMap(value: ImmutableMap, depth = 1): string {
 	const prototype = Object.getPrototypeOf(value) as typeof value;
@@ -239,7 +239,7 @@ export function debugMap(value: ImmutableMap, depth = 1): string {
  * @param depth How many levels of nested containers to expand (defaults to `1`).
  * @returns A human-readable string representation of the object.
  * @example debugObject({ a: 1 }) // `{\n\t"a": 1\n}`
- * @see https://dhoulb.github.io/shelving/util/debug/debugObject
+ * @see https://shelving.cc/util/debug/debugObject
  */
 export function debugObject(value: object, depth = 1): string {
 	const prototype = Object.getPrototypeOf(value) as typeof value;
@@ -261,7 +261,7 @@ export function debugObject(value: object, depth = 1): string {
  * @param str The string to indent.
  * @returns The indented string.
  * @example indent("a\nb") // `\na\n\tb`
- * @see https://dhoulb.github.io/shelving/util/debug/indent
+ * @see https://shelving.cc/util/debug/indent
  */
 export function indent(str: string): string {
 	const lines = str.split("\n");

--- a/modules/util/dictionary.ts
+++ b/modules/util/dictionary.ts
@@ -8,7 +8,7 @@ import { deleteProps, isPlainObject, omitProps, pickProps, setProp, setProps, wi
  * Readonly dictionary object.
  * - A dictionary is a plain object whose keys are arbitrary strings, all sharing the same value type.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/ImmutableDictionary
+ * @see https://shelving.cc/util/dictionary/ImmutableDictionary
  */
 export type ImmutableDictionary<T = unknown> = { readonly [K in string]: T };
 
@@ -16,7 +16,7 @@ export type ImmutableDictionary<T = unknown> = { readonly [K in string]: T };
  * Writable dictionary object.
  * - A dictionary is a plain object whose keys are arbitrary strings, all sharing the same value type.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/MutableDictionary
+ * @see https://shelving.cc/util/dictionary/MutableDictionary
  */
 export type MutableDictionary<T = unknown> = { [K in string]: T };
 
@@ -24,14 +24,14 @@ export type MutableDictionary<T = unknown> = { [K in string]: T };
  * Single item for a dictionary object in entry format.
  * - A readonly key/value entry tuple.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/DictionaryItem
+ * @see https://shelving.cc/util/dictionary/DictionaryItem
  */
 export type DictionaryItem<T> = readonly [string, T];
 
 /**
  * Get the type of the _values_ of the items of a dictionary object.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/DictionaryValue
+ * @see https://shelving.cc/util/dictionary/DictionaryValue
  */
 export type DictionaryValue<T extends ImmutableDictionary> = T[string];
 
@@ -39,7 +39,7 @@ export type DictionaryValue<T extends ImmutableDictionary> = T[string];
  * Value that can be converted to a dictionary object.
  * - Either the dictionary itself, or an iterable set of key/value entry tuples.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/PossibleDictionary
+ * @see https://shelving.cc/util/dictionary/PossibleDictionary
  */
 export type PossibleDictionary<T> = ImmutableDictionary<T> | Iterable<DictionaryItem<T>>;
 
@@ -48,7 +48,7 @@ export type PossibleDictionary<T> = ImmutableDictionary<T> | Iterable<Dictionary
  *
  * @param value The value to test.
  * @returns `true` if `value` is a dictionary (plain) object, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/dictionary/isDictionary
+ * @see https://shelving.cc/util/dictionary/isDictionary
  */
 export function isDictionary(value: unknown): value is ImmutableDictionary {
 	return isPlainObject(value);
@@ -60,7 +60,7 @@ export function isDictionary(value: unknown): value is ImmutableDictionary {
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertDictionary` itself).
  * @throws {ValueError} If `value` is not a dictionary object.
- * @see https://dhoulb.github.io/shelving/util/dictionary/assertDictionary
+ * @see https://shelving.cc/util/dictionary/assertDictionary
  */
 export function assertDictionary(value: unknown, caller: AnyCaller = assertDictionary): asserts value is ImmutableDictionary {
 	if (!isDictionary(value)) throw new ValueError("Must be dictionary object", { received: value, caller });
@@ -74,7 +74,7 @@ export function assertDictionary(value: unknown, caller: AnyCaller = assertDicti
  * @returns The corresponding dictionary object.
  * @example
  * requireDictionary([["a", 1], ["b", 2]]); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/requireDictionary
+ * @see https://shelving.cc/util/dictionary/requireDictionary
  */
 export function requireDictionary<T>(dict: PossibleDictionary<T>): ImmutableDictionary<T> {
 	return isDictionary(dict) ? dict : Object.fromEntries(dict as Iterable<DictionaryItem<T>>);
@@ -87,7 +87,7 @@ export function requireDictionary<T>(dict: PossibleDictionary<T>): ImmutableDict
  * @returns Iterable set of key/value entry tuples for the dictionary.
  * @example
  * getDictionaryItems({ a: 1, b: 2 }); // [["a", 1], ["b", 2]]
- * @see https://dhoulb.github.io/shelving/util/dictionary/getDictionaryItems
+ * @see https://shelving.cc/util/dictionary/getDictionaryItems
  */
 export function getDictionaryItems<T>(input: ImmutableDictionary<T>): readonly DictionaryItem<T>[];
 export function getDictionaryItems<T>(input: PossibleDictionary<T>): Iterable<DictionaryItem<T>>;
@@ -101,7 +101,7 @@ export function getDictionaryItems<T>(input: PossibleDictionary<T>): Iterable<Di
  * @param dict The dictionary to test against.
  * @param key The key to test for.
  * @returns `true` if `key` is a string and an own prop of `dict`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/dictionary/isDictionaryItem
+ * @see https://shelving.cc/util/dictionary/isDictionaryItem
  */
 export function isDictionaryItem<T>(dict: ImmutableDictionary<T>, key: unknown): key is string {
 	return typeof key === "string" && Object.hasOwn(dict, key);
@@ -114,7 +114,7 @@ export function isDictionaryItem<T>(dict: ImmutableDictionary<T>, key: unknown):
  * @param key The key to assert is an own prop.
  * @param caller Function to attribute a thrown error to (defaults to `assertDictionaryItem` itself).
  * @throws {RequiredError} If `key` is not an own prop of `dict`.
- * @see https://dhoulb.github.io/shelving/util/dictionary/assertDictionaryItem
+ * @see https://shelving.cc/util/dictionary/assertDictionaryItem
  */
 export function assertDictionaryItem<T>(
 	dict: ImmutableDictionary<T>,
@@ -134,7 +134,7 @@ export function assertDictionaryItem<T>(
  * @throws {RequiredError} If `key` is not an own prop of `dict`.
  * @example
  * requireDictionaryItem({ a: 1 }, "a"); // 1
- * @see https://dhoulb.github.io/shelving/util/dictionary/requireDictionaryItem
+ * @see https://shelving.cc/util/dictionary/requireDictionaryItem
  */
 export function requireDictionaryItem<T>(dict: ImmutableDictionary<T>, key: string, caller: AnyCaller = requireDictionaryItem): T {
 	assertDictionaryItem(dict, key, caller);
@@ -149,7 +149,7 @@ export function requireDictionaryItem<T>(dict: ImmutableDictionary<T>, key: stri
  * @returns The value of the item, or `undefined` if `key` is not an own prop of `dict`.
  * @example
  * getDictionaryItem({ a: 1 }, "a"); // 1
- * @see https://dhoulb.github.io/shelving/util/dictionary/getDictionaryItem
+ * @see https://shelving.cc/util/dictionary/getDictionaryItem
  */
 export function getDictionaryItem<T>(dict: ImmutableDictionary<T>, key: string): T | undefined {
 	return dict[key];
@@ -165,7 +165,7 @@ export function getDictionaryItem<T>(dict: ImmutableDictionary<T>, key: string):
  * @returns A new dictionary including the set item, or the original dictionary if the value was unchanged.
  * @example
  * withDictionaryItem({ a: 1 }, "b", 2); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/withDictionaryItem
+ * @see https://shelving.cc/util/dictionary/withDictionaryItem
  */
 export const withDictionaryItem: <T>(dict: ImmutableDictionary<T>, key: string, value: T) => ImmutableDictionary<T> = withProp;
 
@@ -178,7 +178,7 @@ export const withDictionaryItem: <T>(dict: ImmutableDictionary<T>, key: string, 
  * @returns A new dictionary including the set items, or the original dictionary if all values were unchanged.
  * @example
  * withDictionaryItems({ a: 1 }, { b: 2, c: 3 }); // { a: 1, b: 2, c: 3 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/withDictionaryItems
+ * @see https://shelving.cc/util/dictionary/withDictionaryItems
  */
 export const withDictionaryItems: <T>(dict: ImmutableDictionary<T>, props: PossibleDictionary<T>) => ImmutableDictionary<T> = withProps;
 
@@ -191,7 +191,7 @@ export const withDictionaryItems: <T>(dict: ImmutableDictionary<T>, props: Possi
  * @returns A new dictionary without the removed items, or the original dictionary if no keys were present.
  * @example
  * omitDictionaryItems({ a: 1, b: 2, c: 3 }, "b", "c"); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/omitDictionaryItems
+ * @see https://shelving.cc/util/dictionary/omitDictionaryItems
  */
 export const omitDictionaryItems: <T>(dict: ImmutableDictionary<T>, ...keys: string[]) => ImmutableDictionary<T> = omitProps;
 
@@ -204,7 +204,7 @@ export const omitDictionaryItems: <T>(dict: ImmutableDictionary<T>, ...keys: str
  * @returns A new dictionary without the removed item, or the original dictionary if the key was not present.
  * @example
  * omitDictionaryItem({ a: 1, b: 2 }, "b"); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/omitDictionaryItem
+ * @see https://shelving.cc/util/dictionary/omitDictionaryItem
  */
 export const omitDictionaryItem: <T>(dict: ImmutableDictionary<T>, key: string) => ImmutableDictionary<T> = omitProps;
 
@@ -216,7 +216,7 @@ export const omitDictionaryItem: <T>(dict: ImmutableDictionary<T>, key: string) 
  * @returns A new dictionary containing only the picked items.
  * @example
  * pickDictionaryItems({ a: 1, b: 2, c: 3 }, "a", "b"); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/dictionary/pickDictionaryItems
+ * @see https://shelving.cc/util/dictionary/pickDictionaryItems
  */
 export const pickDictionaryItems: <T>(dict: ImmutableDictionary<T>, ...keys: string[]) => ImmutableDictionary<T> = pickProps;
 
@@ -229,7 +229,7 @@ export const pickDictionaryItems: <T>(dict: ImmutableDictionary<T>, ...keys: str
  * @returns The value that was set.
  * @example
  * setDictionaryItem(dict, "a", 1); // 1
- * @see https://dhoulb.github.io/shelving/util/dictionary/setDictionaryItem
+ * @see https://shelving.cc/util/dictionary/setDictionaryItem
  */
 export const setDictionaryItem: <T>(dict: MutableDictionary<T>, key: string, value: T) => T = setProp;
 
@@ -240,7 +240,7 @@ export const setDictionaryItem: <T>(dict: MutableDictionary<T>, key: string, val
  * @param entries The items to set, as a dictionary or iterable set of key/value entry tuples.
  * @example
  * setDictionaryItems(dict, { a: 1, b: 2 });
- * @see https://dhoulb.github.io/shelving/util/dictionary/setDictionaryItems
+ * @see https://shelving.cc/util/dictionary/setDictionaryItems
  */
 export const setDictionaryItems: <T>(dict: MutableDictionary<T>, entries: PossibleDictionary<T>) => void = setProps;
 
@@ -251,7 +251,7 @@ export const setDictionaryItems: <T>(dict: MutableDictionary<T>, entries: Possib
  * @param keys The keys of the items to remove.
  * @example
  * deleteDictionaryItems(dict, "a", "b");
- * @see https://dhoulb.github.io/shelving/util/dictionary/deleteDictionaryItems
+ * @see https://shelving.cc/util/dictionary/deleteDictionaryItems
  */
 export const deleteDictionaryItems: <T extends MutableDictionary>(dict: T, ...keys: string[]) => void = deleteProps;
 
@@ -262,20 +262,20 @@ export const deleteDictionaryItems: <T extends MutableDictionary>(dict: T, ...ke
  * @param key The key of the item to remove.
  * @example
  * deleteDictionaryItem(dict, "a");
- * @see https://dhoulb.github.io/shelving/util/dictionary/deleteDictionaryItem
+ * @see https://shelving.cc/util/dictionary/deleteDictionaryItem
  */
 export const deleteDictionaryItem: <T extends MutableDictionary>(dict: T, key: string) => void = deleteProps;
 
 /**
  * Type that represents an empty dictionary object.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/EmptyDictionary
+ * @see https://shelving.cc/util/dictionary/EmptyDictionary
  */
 export type EmptyDictionary = { readonly [K in never]: never };
 
 /**
  * An empty dictionary object.
  *
- * @see https://dhoulb.github.io/shelving/util/dictionary/EMPTY_DICTIONARY
+ * @see https://shelving.cc/util/dictionary/EMPTY_DICTIONARY
  */
 export const EMPTY_DICTIONARY: EmptyDictionary = { __proto__: null };

--- a/modules/util/diff.ts
+++ b/modules/util/diff.ts
@@ -8,7 +8,7 @@ import { isObject } from "./object.js";
  * The `SAME` symbol indicates sameness.
  * - Returned by the diff functions when two values are deeply equal and no transformation is needed.
  *
- * @see https://dhoulb.github.io/shelving/util/diff/SAME
+ * @see https://shelving.cc/util/diff/SAME
  */
 export const SAME: unique symbol = Symbol("shelving/SAME");
 
@@ -26,7 +26,7 @@ export const SAME: unique symbol = Symbol("shelving/SAME");
  *
  * @example deepDiff({ a: 1 }, { a: 1 }) // SAME
  * @example deepDiff({ a: 1 }, { a: 2 }) // { a: 2 }
- * @see https://dhoulb.github.io/shelving/util/diff/deepDiff
+ * @see https://shelving.cc/util/diff/deepDiff
  */
 export function deepDiff<R extends ImmutableObject>(left: unknown, right: R): R | DeepPartial<R> | typeof SAME;
 export function deepDiff<R>(left: unknown, right: R): R | typeof SAME;
@@ -47,7 +47,7 @@ export function deepDiff(left: unknown, right: unknown): unknown {
  * - If the two values are deeply equal the `SAME` constant is returned.
  * @example deepDiffArray([1, 2], [1, 2]) // SAME
  * @example deepDiffArray([1, 2], [1, 3]) // [1, 3]
- * @see https://dhoulb.github.io/shelving/util/diff/deepDiffArray
+ * @see https://shelving.cc/util/diff/deepDiffArray
  */
 export function deepDiffArray<R extends ImmutableArray>(left: ImmutableArray, right: R): R | typeof SAME {
 	if (left === right) return SAME;
@@ -68,7 +68,7 @@ export function deepDiffArray<R extends ImmutableArray>(left: ImmutableArray, ri
  * - If `left` isn't an object then the result can't be diffed so entire `right` is returned.
  * @example deepDiffObject({ a: 1 }, { a: 1 }) // SAME
  * @example deepDiffObject({ a: 1, b: 2 }, { a: 1 }) // { b: undefined }
- * @see https://dhoulb.github.io/shelving/util/diff/deepDiffObject
+ * @see https://shelving.cc/util/diff/deepDiffObject
  */
 export function deepDiffObject<R extends ImmutableObject>(left: ImmutableObject, right: R): R | DeepPartial<R> | typeof SAME;
 export function deepDiffObject(left: ImmutableObject, right: ImmutableObject): ImmutableObject | typeof SAME {

--- a/modules/util/dispose.ts
+++ b/modules/util/dispose.ts
@@ -21,7 +21,7 @@ import { isObject } from "./object.js";
  *
  * @throws {Errors} Error that aggregates all the disposal errors.
  * @example dispose(resource, () => clearTimeout(id)) // disposes both, even if one throws
- * @see https://dhoulb.github.io/shelving/util/dispose/dispose
+ * @see https://shelving.cc/util/dispose/dispose
  */
 export function dispose(...values: Nullish<Disposable | Callback>[]): void {
 	const errors: unknown[] = [];
@@ -48,7 +48,7 @@ export function dispose(...values: Nullish<Disposable | Callback>[]): void {
  * @throws {Errors} Error that aggregates all the disposal errors.
  *
  * @example await awaitDispose(asyncResource, promise, () => cleanup()) // disposes all in parallel
- * @see https://dhoulb.github.io/shelving/util/dispose/awaitDispose
+ * @see https://shelving.cc/util/dispose/awaitDispose
  *
  * @todo Potentially rewrite this to use `AsyncDisposableStack` internally.
  */
@@ -68,7 +68,7 @@ async function _disposeAsync(value: AsyncDisposable | Disposable | Callback | Pr
  *
  * @param v The value to test.
  * @returns `true` if `v` has a `[Symbol.dispose]` method, narrowing its type to `Disposable`.
- * @see https://dhoulb.github.io/shelving/util/dispose/isDisposable
+ * @see https://shelving.cc/util/dispose/isDisposable
  */
 export function isDisposable(v: unknown): v is Disposable {
 	return isObject(v) && typeof v[Symbol.dispose] === "function";
@@ -79,7 +79,7 @@ export function isDisposable(v: unknown): v is Disposable {
  *
  * @param v The value to test.
  * @returns `true` if `v` has a `[Symbol.asyncDispose]` method, narrowing its type to `AsyncDisposable`.
- * @see https://dhoulb.github.io/shelving/util/dispose/isAsyncDisposable
+ * @see https://shelving.cc/util/dispose/isAsyncDisposable
  */
 export function isAsyncDisposable(v: unknown): v is AsyncDisposable {
 	return isObject(v) && typeof v[Symbol.asyncDispose] === "function";
@@ -92,7 +92,7 @@ export function isAsyncDisposable(v: unknown): v is AsyncDisposable {
  * - Values are disposed when all items are cleared.
  * - All items are cleared and their values are disposed when this map itself is disposed.
  *
- * @see https://dhoulb.github.io/shelving/util/dispose/DisposableMap
+ * @see https://shelving.cc/util/dispose/DisposableMap
  */
 export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements Disposable {
 	/**
@@ -102,7 +102,7 @@ export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements
 	 * @param value The disposable value to store.
 	 * @returns This map, for chaining.
 	 * @example map.set("a", resource) // disposes the old "a" value if it differs
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableMap/set
+	 * @see https://shelving.cc/util/dispose/DisposableMap/set
 	 */
 	override set(key: K, value: T): this {
 		const previous = this.get(key);
@@ -115,7 +115,7 @@ export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements
 	 * @param key The key to delete.
 	 * @returns `true` if a value existed and was deleted, otherwise `false`.
 	 * @example map.delete("a") // disposes the "a" value
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableMap/delete
+	 * @see https://shelving.cc/util/dispose/DisposableMap/delete
 	 */
 	override delete(key: K): boolean {
 		const value = this.get(key);
@@ -127,7 +127,7 @@ export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements
 	 *
 	 * @returns Nothing.
 	 * @example map.clear() // disposes every value
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableMap/clear
+	 * @see https://shelving.cc/util/dispose/DisposableMap/clear
 	 */
 	override clear(): void {
 		dispose(...this.values());
@@ -137,7 +137,7 @@ export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements
 	 * Dispose this map by clearing all items and disposing their values.
 	 *
 	 * @returns Nothing.
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableMap/dispose
+	 * @see https://shelving.cc/util/dispose/DisposableMap/dispose
 	 */
 	[Symbol.dispose]() {
 		this.clear();
@@ -150,7 +150,7 @@ export class DisposableMap<K, T extends Disposable> extends Map<K, T> implements
  * - Values are disposed when all items are cleared.
  * - All items are cleared (and disposed) when this map itself is disposed.
  *
- * @see https://dhoulb.github.io/shelving/util/dispose/DisposableSet
+ * @see https://shelving.cc/util/dispose/DisposableSet
  */
 export class DisposableSet<T extends Disposable> extends Set<T> implements Disposable {
 	/**
@@ -159,7 +159,7 @@ export class DisposableSet<T extends Disposable> extends Set<T> implements Dispo
 	 * @param item The item to delete.
 	 * @returns `true` if the item existed and was deleted, otherwise `false`.
 	 * @example set.delete(resource) // disposes the item
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableSet/delete
+	 * @see https://shelving.cc/util/dispose/DisposableSet/delete
 	 */
 	override delete(item: T): boolean {
 		if (this.has(item)) dispose(item);
@@ -170,7 +170,7 @@ export class DisposableSet<T extends Disposable> extends Set<T> implements Dispo
 	 *
 	 * @returns Nothing.
 	 * @example set.clear() // disposes every item
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableSet/clear
+	 * @see https://shelving.cc/util/dispose/DisposableSet/clear
 	 */
 	override clear(): void {
 		dispose(...this);
@@ -180,7 +180,7 @@ export class DisposableSet<T extends Disposable> extends Set<T> implements Dispo
 	 * Dispose this set by clearing all items and disposing each one.
 	 *
 	 * @returns Nothing.
-	 * @see https://dhoulb.github.io/shelving/util/dispose/DisposableSet/dispose
+	 * @see https://shelving.cc/util/dispose/DisposableSet/dispose
 	 */
 	[Symbol.dispose]() {
 		this.clear();

--- a/modules/util/duration.ts
+++ b/modules/util/duration.ts
@@ -8,7 +8,7 @@ import { type Unit, UnitList } from "./units.js";
 /**
  * Duration data object keyed by `Intl.DurationFormatUnit`.
  *
- * @see https://dhoulb.github.io/shelving/util/duration/DurationData
+ * @see https://shelving.cc/util/duration/DurationData
  */
 export type DurationData = { [K in Intl.DurationFormatUnit]?: number };
 
@@ -21,7 +21,7 @@ export type DurationData = { [K in Intl.DurationFormatUnit]?: number };
  * @returns Number of milliseconds from `from` to `to` (negative if `to` is before `from`).
  * @throws {RequiredError} If `from` or `to` cannot be converted to a valid date.
  * @example getMilliseconds("2025-01-01", "2025-01-02") // 86400000
- * @see https://dhoulb.github.io/shelving/util/duration/getMilliseconds
+ * @see https://shelving.cc/util/duration/getMilliseconds
  */
 export function getMilliseconds(from?: PossibleDate, to?: PossibleDate, caller: AnyCaller = getMilliseconds): number {
 	return requireDate(to, caller).getTime() - requireDate(from, caller).getTime();
@@ -36,7 +36,7 @@ export function getMilliseconds(from?: PossibleDate, to?: PossibleDate, caller: 
  * @returns `DurationData` object breaking the span down into years, months, weeks, days, hours, minutes, seconds, and milliseconds.
  * @throws {RequiredError} If `from` or `to` cannot be converted to a valid date.
  * @example getDuration("2025-01-01", "2025-01-02") // { years: 0, months: 0, weeks: 0, days: 1, ... }
- * @see https://dhoulb.github.io/shelving/util/duration/getDuration
+ * @see https://shelving.cc/util/duration/getDuration
  */
 export function getDuration(from?: PossibleDate, to?: PossibleDate, caller: AnyCaller = getDuration): DurationData {
 	const ms = getMilliseconds(from, to, caller);
@@ -61,7 +61,7 @@ export function getDuration(from?: PossibleDate, to?: PossibleDate, caller: AnyC
  * @returns `DurationData` object for the span from `current` to `target`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getUntil("2099-01-01") // { years: 73, ... }
- * @see https://dhoulb.github.io/shelving/util/duration/getUntil
+ * @see https://shelving.cc/util/duration/getUntil
  */
 export function getUntil(target: PossibleDate, current: PossibleDate = "now", caller: AnyCaller = getUntil): DurationData {
 	return getDuration(current, target, caller);
@@ -76,7 +76,7 @@ export function getUntil(target: PossibleDate, current: PossibleDate = "now", ca
  * @returns `DurationData` object for the span from `target` to `current`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getAgo("2000-01-01") // { years: 26, ... }
- * @see https://dhoulb.github.io/shelving/util/duration/getAgo
+ * @see https://shelving.cc/util/duration/getAgo
  */
 export function getAgo(target: PossibleDate, current: PossibleDate = "now", caller: AnyCaller = getAgo): DurationData {
 	return getDuration(target, current, caller);
@@ -91,7 +91,7 @@ export function getAgo(target: PossibleDate, current: PossibleDate = "now", call
  * @returns Number of milliseconds from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMillisecondsUntil("2099-01-01") // 2303683200000
- * @see https://dhoulb.github.io/shelving/util/duration/getMillisecondsUntil
+ * @see https://shelving.cc/util/duration/getMillisecondsUntil
  */
 export function getMillisecondsUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMillisecondsUntil): number {
 	return getMilliseconds(current, target, caller);
@@ -106,7 +106,7 @@ export function getMillisecondsUntil(target: PossibleDate, current?: PossibleDat
  * @returns Number of milliseconds from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMillisecondsAgo("2000-01-01") // 833587200000
- * @see https://dhoulb.github.io/shelving/util/duration/getMillisecondsAgo
+ * @see https://shelving.cc/util/duration/getMillisecondsAgo
  */
 export function getMillisecondsAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMillisecondsAgo): number {
 	return 0 - getMillisecondsUntil(target, current, caller);
@@ -122,7 +122,7 @@ export function getMillisecondsAgo(target: PossibleDate, current?: PossibleDate,
  * @returns Number of whole seconds from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getSecondsUntil(target) // 90
- * @see https://dhoulb.github.io/shelving/util/duration/getSecondsUntil
+ * @see https://shelving.cc/util/duration/getSecondsUntil
  */
 export function getSecondsUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getSecondsUntil): number {
 	return Math.round(getMilliseconds(current, target, caller) / SECOND);
@@ -138,7 +138,7 @@ export function getSecondsUntil(target: PossibleDate, current?: PossibleDate, ca
  * @returns Number of whole seconds from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getSecondsAgo(target) // 90
- * @see https://dhoulb.github.io/shelving/util/duration/getSecondsAgo
+ * @see https://shelving.cc/util/duration/getSecondsAgo
  */
 export function getSecondsAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getSecondsAgo): number {
 	return 0 - getSecondsUntil(target, current, caller);
@@ -154,7 +154,7 @@ export function getSecondsAgo(target: PossibleDate, current?: PossibleDate, call
  * @returns Number of whole minutes from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMinutesUntil(target) // 5
- * @see https://dhoulb.github.io/shelving/util/duration/getMinutesUntil
+ * @see https://shelving.cc/util/duration/getMinutesUntil
  */
 export function getMinutesUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMinutesUntil): number {
 	return Math.round(getMilliseconds(current, target, caller) / MINUTE);
@@ -170,7 +170,7 @@ export function getMinutesUntil(target: PossibleDate, current?: PossibleDate, ca
  * @returns Number of whole minutes from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMinutesAgo(target) // 5
- * @see https://dhoulb.github.io/shelving/util/duration/getMinutesAgo
+ * @see https://shelving.cc/util/duration/getMinutesAgo
  */
 export function getMinutesAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMinutesAgo): number {
 	return 0 - getMinutesUntil(target, current, caller);
@@ -186,7 +186,7 @@ export function getMinutesAgo(target: PossibleDate, current?: PossibleDate, call
  * @returns Number of whole hours from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getHoursUntil(target) // 3
- * @see https://dhoulb.github.io/shelving/util/duration/getHoursUntil
+ * @see https://shelving.cc/util/duration/getHoursUntil
  */
 export function getHoursUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getHoursUntil): number {
 	return Math.round(getMilliseconds(current, target, caller) / HOUR);
@@ -202,7 +202,7 @@ export function getHoursUntil(target: PossibleDate, current?: PossibleDate, call
  * @returns Number of whole hours from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getHoursAgo(target) // 3
- * @see https://dhoulb.github.io/shelving/util/duration/getHoursAgo
+ * @see https://shelving.cc/util/duration/getHoursAgo
  */
 export function getHoursAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getHoursAgo): number {
 	return 0 - getHoursUntil(target, current, caller);
@@ -218,7 +218,7 @@ export function getHoursAgo(target: PossibleDate, current?: PossibleDate, caller
  * @returns Number of calendar days from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getDaysUntil(target) // 13
- * @see https://dhoulb.github.io/shelving/util/duration/getDaysUntil
+ * @see https://shelving.cc/util/duration/getDaysUntil
  */
 export function getDaysUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getDaysUntil): number {
 	return Math.round((getMidnight(target, caller).getTime() - getMidnight(current, caller).getTime()) / DAY);
@@ -234,7 +234,7 @@ export function getDaysUntil(target: PossibleDate, current?: PossibleDate, calle
  * @returns Number of calendar days from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getDaysAgo(target) // 13
- * @see https://dhoulb.github.io/shelving/util/duration/getDaysAgo
+ * @see https://shelving.cc/util/duration/getDaysAgo
  */
 export function getDaysAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getDaysAgo): number {
 	return 0 - getDaysUntil(target, current, caller);
@@ -250,7 +250,7 @@ export function getDaysAgo(target: PossibleDate, current?: PossibleDate, caller:
  * @returns Number of whole weeks from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getWeeksUntil(target) // 9
- * @see https://dhoulb.github.io/shelving/util/duration/getWeeksUntil
+ * @see https://shelving.cc/util/duration/getWeeksUntil
  */
 export function getWeeksUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getWeeksUntil): number {
 	return Math.trunc(getDaysUntil(target, current, caller) / 7);
@@ -266,7 +266,7 @@ export function getWeeksUntil(target: PossibleDate, current?: PossibleDate, call
  * @returns Number of whole weeks from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getWeeksAgo(target) // 9
- * @see https://dhoulb.github.io/shelving/util/duration/getWeeksAgo
+ * @see https://shelving.cc/util/duration/getWeeksAgo
  */
 export function getWeeksAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getWeeksAgo): number {
 	return 0 - getWeeksUntil(target, current, caller);
@@ -282,7 +282,7 @@ export function getWeeksAgo(target: PossibleDate, current?: PossibleDate, caller
  * @returns Number of calendar months from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMonthsUntil(target) // 14
- * @see https://dhoulb.github.io/shelving/util/duration/getMonthsUntil
+ * @see https://shelving.cc/util/duration/getMonthsUntil
  */
 export function getMonthsUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMonthsUntil): number {
 	const t = requireDate(target, caller);
@@ -302,7 +302,7 @@ export function getMonthsUntil(target: PossibleDate, current?: PossibleDate, cal
  * @returns Number of calendar months from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getMonthsAgo(target) // 14
- * @see https://dhoulb.github.io/shelving/util/duration/getMonthsAgo
+ * @see https://shelving.cc/util/duration/getMonthsAgo
  */
 export function getMonthsAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getMonthsAgo): number {
 	return 0 - getMonthsUntil(target, current, caller);
@@ -318,7 +318,7 @@ export function getMonthsAgo(target: PossibleDate, current?: PossibleDate, calle
  * @returns Number of calendar years from `current` to `target` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getYearsUntil(target) // 2
- * @see https://dhoulb.github.io/shelving/util/duration/getYearsUntil
+ * @see https://shelving.cc/util/duration/getYearsUntil
  */
 export function getYearsUntil(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getYearsUntil): number {
 	return requireDate(target, caller).getFullYear() - requireDate(current, caller).getFullYear();
@@ -335,7 +335,7 @@ export function getYearsUntil(target: PossibleDate, current?: PossibleDate, call
  * @returns Number of calendar years from `target` to `current` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example getYearsAgo(target) // 2
- * @see https://dhoulb.github.io/shelving/util/duration/getYearsAgo
+ * @see https://shelving.cc/util/duration/getYearsAgo
  */
 export function getYearsAgo(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = getYearsAgo): number {
 	return 0 - getYearsUntil(target, current, caller);
@@ -350,7 +350,7 @@ export function getYearsAgo(target: PossibleDate, current?: PossibleDate, caller
  * @returns `true` if `target` is before `current`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example isPast("2000-01-01") // true
- * @see https://dhoulb.github.io/shelving/util/duration/isPast
+ * @see https://shelving.cc/util/duration/isPast
  */
 export function isPast(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = isPast): boolean {
 	return getMilliseconds(current, target, caller) < 0;
@@ -365,7 +365,7 @@ export function isPast(target: PossibleDate, current?: PossibleDate, caller: Any
  * @returns `true` if `target` is after `current`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example isFuture("2099-01-01") // true
- * @see https://dhoulb.github.io/shelving/util/duration/isFuture
+ * @see https://shelving.cc/util/duration/isFuture
  */
 export function isFuture(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = isFuture): boolean {
 	return getMilliseconds(current, target, caller) > 0;
@@ -380,7 +380,7 @@ export function isFuture(target: PossibleDate, current?: PossibleDate, caller: A
  * @returns `true` if `target` falls on the same calendar day as `current`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example isToday(new Date()) // true
- * @see https://dhoulb.github.io/shelving/util/duration/isToday
+ * @see https://shelving.cc/util/duration/isToday
  */
 export function isToday(target: PossibleDate, current?: PossibleDate, caller: AnyCaller = isToday): boolean {
 	return getDaysUntil(target, current, caller) === 0;
@@ -389,7 +389,7 @@ export function isToday(target: PossibleDate, current?: PossibleDate, caller: An
 /**
  * List of duration units (`millisecond` through `year`) keyed by unit reference.
  *
- * @see https://dhoulb.github.io/shelving/util/duration/DURATION_UNITS
+ * @see https://shelving.cc/util/duration/DURATION_UNITS
  */
 export const DURATION_UNITS = new UnitList({
 	millisecond: { roundingMode: "trunc", maximumFractionDigits: 0, abbr: "ms" },
@@ -404,7 +404,7 @@ export const DURATION_UNITS = new UnitList({
 /**
  * Key for one of the duration units in `DURATION_UNITS`.
  *
- * @see https://dhoulb.github.io/shelving/util/duration/DurationUnitKey
+ * @see https://shelving.cc/util/duration/DurationUnitKey
  */
 export type DurationUnitKey = MapKey<typeof DURATION_UNITS>;
 
@@ -422,7 +422,7 @@ export type DurationUnitKey = MapKey<typeof DURATION_UNITS>;
  * @param ms Amount of time in milliseconds (the sign is ignored, only the magnitude matters).
  * @returns The best-fit `Unit` from `DURATION_UNITS` for the given magnitude.
  * @example getBestDurationUnit(90000).key // "minute"
- * @see https://dhoulb.github.io/shelving/util/duration/getBestDurationUnit
+ * @see https://shelving.cc/util/duration/getBestDurationUnit
  */
 export function getBestDurationUnit(ms: number): Unit<DurationUnitKey> {
 	const abs = Math.abs(ms);
@@ -448,7 +448,7 @@ export function getBestDurationUnit(ms: number): Unit<DurationUnitKey> {
  * @returns Compact string like `in 10d`, `2h ago`, or `just now`.
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example formatWhen("2099-01-01") // "in 73 years"
- * @see https://dhoulb.github.io/shelving/util/duration/formatWhen
+ * @see https://shelving.cc/util/duration/formatWhen
  */
 export function formatWhen(
 	target: PossibleDate,
@@ -474,7 +474,7 @@ export function formatWhen(
  * @returns Compact string like `10d` or `2h` (negative if `target` is in the past).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example formatUntil("2099-01-01") // "73y"
- * @see https://dhoulb.github.io/shelving/util/duration/formatUntil
+ * @see https://shelving.cc/util/duration/formatUntil
  */
 export function formatUntil(
 	target: PossibleDate,
@@ -498,7 +498,7 @@ export function formatUntil(
  * @returns Compact string like `10d` or `2h` (negative if `target` is in the future).
  * @throws {RequiredError} If `target` or `current` cannot be converted to a valid date.
  * @example formatAgo("2000-01-01") // "26y"
- * @see https://dhoulb.github.io/shelving/util/duration/formatAgo
+ * @see https://shelving.cc/util/duration/formatAgo
  */
 export function formatAgo(
 	target: PossibleDate,
@@ -521,7 +521,7 @@ interface DurationFormatOptions extends FormatOptions, Intl.DurationFormatOption
  * @param options Formatting options passed through to `Intl.DurationFormat`.
  * @returns Human-readable string describing the duration.
  * @example formatDuration({ years: 1, months: 2, days: 3 }) // "1 yr, 2 mths, 3 days"
- * @see https://dhoulb.github.io/shelving/util/duration/formatDuration
+ * @see https://shelving.cc/util/duration/formatDuration
  */
 export function formatDuration(duration: DurationData, options?: DurationFormatOptions): string {
 	return new Intl.DurationFormat(options?.locale, options).format(duration);

--- a/modules/util/element.ts
+++ b/modules/util/element.ts
@@ -6,7 +6,7 @@ import { queryItems } from "./query.js";
 /**
  * Set of valid props for an element.
  *
- * @see https://dhoulb.github.io/shelving/util/element/ElementProps
+ * @see https://shelving.cc/util/element/ElementProps
  */
 export type ElementProps = {
 	readonly children?: Elements;
@@ -16,7 +16,7 @@ export type ElementProps = {
  * Element with a type, props, and optional key (compatible with `React.ReactElement`).
  * - Declared as a `type`, not an `interface`, so its implicit index signature lets it satisfy `Data` — `queryElements()` runs elements through `queryItems()`.
  *
- * @see https://dhoulb.github.io/shelving/util/element/Element
+ * @see https://shelving.cc/util/element/Element
  */
 export type Element<P extends ElementProps = ElementProps> = {
 	readonly type: string | ((props: P) => Elements | null);
@@ -28,7 +28,7 @@ export type Element<P extends ElementProps = ElementProps> = {
 /**
  * Collection of elements (compatible with `React.ReactNode`).
  *
- * @see https://dhoulb.github.io/shelving/util/element/Elements
+ * @see https://shelving.cc/util/element/Elements
  */
 export type Elements<T extends Element = Element> = undefined | null | string | T | Iterable<Elements<T>>;
 
@@ -38,7 +38,7 @@ export type Elements<T extends Element = Element> = undefined | null | string | 
  * @param value The value to test.
  * @returns `true` if `value` is an `Element`, narrowing its type.
  * @example isElement({ type: "div", props: {}, key: null }) // true
- * @see https://dhoulb.github.io/shelving/util/element/isElement
+ * @see https://shelving.cc/util/element/isElement
  */
 export function isElement(value: unknown): value is Element {
 	return typeof value === "object" && value !== null && "type" in value;
@@ -50,7 +50,7 @@ export function isElement(value: unknown): value is Element {
  * @param value The value to test.
  * @returns `true` if `value` is an `Elements` value, narrowing its type.
  * @example isElements("hello") // true
- * @see https://dhoulb.github.io/shelving/util/element/isElements
+ * @see https://shelving.cc/util/element/isElements
  */
 export function isElements(value: unknown): value is Elements {
 	return value === null || typeof value === "string" || isElement(value) || isArray(value);
@@ -64,7 +64,7 @@ export function isElements(value: unknown): value is Elements {
  * @returns The combined string made from the elements.
  *
  * @example `- Item with *strong*\n- Item with _em_` becomes `Item with strong Item with em`
- * @see https://dhoulb.github.io/shelving/util/element/getElementText
+ * @see https://shelving.cc/util/element/getElementText
  */
 export function getElementText(elements: Elements): string {
 	if (typeof elements === "string") return elements;
@@ -92,7 +92,7 @@ export function getElementText(elements: Elements): string {
  * @param elements An element, a (possibly nested) iterable of elements, `null`, `undefined`, or a string (strings are skipped).
  * @returns A flat iterable of `Element` objects.
  * @example [...walkElements([a, [b, c]])] // [a, b, c]
- * @see https://dhoulb.github.io/shelving/util/element/walkElements
+ * @see https://shelving.cc/util/element/walkElements
  */
 export function walkElements<T extends Element>(elements: Elements<T>): Iterable<T>;
 export function walkElements(elements: Elements): Iterable<Element>;
@@ -109,7 +109,7 @@ export function* walkElements(elements: Elements): Iterable<Element> {
  * @param query The `Query<Element>` object describing the filter, sort, and limit to apply.
  * @returns An iterable of the matching `Element` objects.
  * @example [...queryElements(elements, { type: "br" })] // all `<br>` elements
- * @see https://dhoulb.github.io/shelving/util/element/queryElements
+ * @see https://shelving.cc/util/element/queryElements
  */
 export function queryElements(elements: Elements, query: Query<Element>): Iterable<Element> {
 	return queryItems(walkElements(elements), query) as Iterable<Element>;
@@ -122,7 +122,7 @@ export function queryElements(elements: Elements, query: Query<Element>): Iterab
  * @param match Function called with each element; return `true` to keep the element.
  * @returns An iterable of the matching `Element` objects.
  * @example [...filterElements(elements, el => el.type === "br")] // all `<br>` elements
- * @see https://dhoulb.github.io/shelving/util/element/filterElements
+ * @see https://shelving.cc/util/element/filterElements
  */
 export function* filterElements(elements: Elements, match: (element: Element) => boolean): Iterable<Element> {
 	for (const element of walkElements(elements)) if (match(element)) yield element;
@@ -136,7 +136,7 @@ export function* filterElements(elements: Elements, match: (element: Element) =>
  * @param b The second elements.
  * @returns The combined `Elements`, or whichever side is set if the other is falsy.
  * @example mergeElements("a", "b") // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/element/mergeElements
+ * @see https://shelving.cc/util/element/mergeElements
  */
 export function mergeElements<T extends Element>(a: Elements<T>, b: Elements<T>): Elements<T>;
 export function mergeElements(a: Elements, b: Elements): Elements;

--- a/modules/util/entity.ts
+++ b/modules/util/entity.ts
@@ -5,28 +5,28 @@ import type { Nullish } from "./null.js";
 /**
  * Entity string combining a type and ID, e.g. `challenge:a1b2c3`
  *
- * @see https://dhoulb.github.io/shelving/util/entity/Entity
+ * @see https://shelving.cc/util/entity/Entity
  */
 export type Entity<T extends string = string> = `${T}:${string}`;
 
 /**
  * Extract the type portion from an `Entity` string.
  *
- * @see https://dhoulb.github.io/shelving/util/entity/EntityType
+ * @see https://shelving.cc/util/entity/EntityType
  */
 export type EntityType<E extends Entity> = E extends Entity<infer T> ? T : never;
 
 /**
  * Tuple representing an empty (invalid) entity, with `undefined` type and ID.
  *
- * @see https://dhoulb.github.io/shelving/util/entity/EmptyEntity
+ * @see https://shelving.cc/util/entity/EmptyEntity
  */
 export type EmptyEntity = [type: undefined, id: undefined];
 
 /**
  * Shared `EmptyEntity` constant returned when an entity string is invalid.
  *
- * @see https://dhoulb.github.io/shelving/util/entity/EMPTY_ENTITY
+ * @see https://shelving.cc/util/entity/EMPTY_ENTITY
  */
 export const EMPTY_ENTITY: EmptyEntity = [undefined, undefined];
 
@@ -37,7 +37,7 @@ export const EMPTY_ENTITY: EmptyEntity = [undefined, undefined];
  * @returns A `[type, id]` tuple, or `EMPTY_ENTITY` if the entity was missing or invalid.
  * @example getEntity("challenge:a1b2c3") // ["challenge", "a1b2c3"]
  * @example getEntity(undefined) // [undefined, undefined]
- * @see https://dhoulb.github.io/shelving/util/entity/getEntity
+ * @see https://shelving.cc/util/entity/getEntity
  */
 export function getEntity<T extends string>(entity: Entity<T>): [type: T, id: string];
 export function getEntity<T extends string>(entity: Nullish<Entity<T>>): [type: T, id: string] | EmptyEntity;
@@ -58,7 +58,7 @@ export function getEntity(entity: Nullish<string>): [type: string, id: string] |
  * @returns A `[type, id]` tuple.
  * @throws {RequiredError} If the entity string is missing or invalid.
  * @example requireEntity("challenge:a1b2c3") // ["challenge", "a1b2c3"]
- * @see https://dhoulb.github.io/shelving/util/entity/requireEntity
+ * @see https://shelving.cc/util/entity/requireEntity
  */
 export function requireEntity<T extends string>(entity: Entity<T>, caller?: AnyCaller): [type: T, id: string];
 export function requireEntity(entity: string, caller?: AnyCaller): [type: string, id: string];

--- a/modules/util/entry.ts
+++ b/modules/util/entry.ts
@@ -11,21 +11,21 @@ import { isSet } from "./set.js";
  * - Consistency with `UnknownObject`
  * - Always readonly.
  *
- * @see https://dhoulb.github.io/shelving/util/entry/Entry
+ * @see https://shelving.cc/util/entry/Entry
  */
 export type Entry<K = unknown, T = unknown> = readonly [K, T];
 
 /**
  * Extract the key type from an `Entry`.
  *
- * @see https://dhoulb.github.io/shelving/util/entry/EntryKey
+ * @see https://shelving.cc/util/entry/EntryKey
  */
 export type EntryKey<X> = X extends Entry<infer Y, unknown> ? Y : never;
 
 /**
  * Extract the value type from an `Entry`.
  *
- * @see https://dhoulb.github.io/shelving/util/entry/EntryValue
+ * @see https://shelving.cc/util/entry/EntryValue
  */
 export type EntryValue<X> = X extends Entry<unknown, infer Y> ? Y : never;
 
@@ -33,7 +33,7 @@ export type EntryValue<X> = X extends Entry<unknown, infer Y> ? Y : never;
  * Turn an `Entry` type back into an object with a single property.
  * i.e. `EntryObject<Entry<"a", string>>` produces `{ a: string }`
  *
- * @see https://dhoulb.github.io/shelving/util/entry/EntryObject
+ * @see https://shelving.cc/util/entry/EntryObject
  */
 export type EntryObject<T extends Entry<PropertyKey, unknown>> = { readonly [E in T as E[0]]: E[1] };
 
@@ -43,7 +43,7 @@ export type EntryObject<T extends Entry<PropertyKey, unknown>> = { readonly [E i
  * @param entry The `[key, value]` entry to read from.
  * @returns The key (first element) of the entry.
  * @example getEntryKey(["a", 1]) // "a"
- * @see https://dhoulb.github.io/shelving/util/entry/getEntryKey
+ * @see https://shelving.cc/util/entry/getEntryKey
  */
 export function getEntryKey<K, T>([k]: Entry<K, T>): K {
 	return k;
@@ -55,7 +55,7 @@ export function getEntryKey<K, T>([k]: Entry<K, T>): K {
  * @param entry The `[key, value]` entry to read from.
  * @returns The value (second element) of the entry.
  * @example getEntryValue(["a", 1]) // 1
- * @see https://dhoulb.github.io/shelving/util/entry/getEntryValue
+ * @see https://shelving.cc/util/entry/getEntryValue
  */
 export function getEntryValue<K, T>([, v]: Entry<K, T>): T {
 	return v;
@@ -67,7 +67,7 @@ export function getEntryValue<K, T>([, v]: Entry<K, T>): T {
  * @param input Iterable of `[key, value]` entries.
  * @returns Iterable yielding each entry's key.
  * @example Array.from(getEntryKeys([["a", 1], ["b", 2]])) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/entry/getEntryKeys
+ * @see https://shelving.cc/util/entry/getEntryKeys
  */
 export function* getEntryKeys<K, T>(input: Iterable<Entry<K, T>>): Iterable<K> {
 	for (const [k] of input) yield k;
@@ -79,7 +79,7 @@ export function* getEntryKeys<K, T>(input: Iterable<Entry<K, T>>): Iterable<K> {
  * @param input Iterable of `[key, value]` entries.
  * @returns Iterable yielding each entry's value.
  * @example Array.from(getEntryValues([["a", 1], ["b", 2]])) // [1, 2]
- * @see https://dhoulb.github.io/shelving/util/entry/getEntryValues
+ * @see https://shelving.cc/util/entry/getEntryValues
  */
 export function* getEntryValues<K, T>(input: Iterable<Entry<K, T>>): Iterable<T> {
 	for (const [, v] of input) yield v;
@@ -91,7 +91,7 @@ export function* getEntryValues<K, T>(input: Iterable<Entry<K, T>>): Iterable<T>
  * @param input One or more sources that can yield `[key, value]` entries.
  * @returns Iterable yielding the combined entries from every input.
  * @example Array.from(getEntries({ a: 1, b: 2 })) // [["a", 1], ["b", 2]]
- * @see https://dhoulb.github.io/shelving/util/entry/getEntries
+ * @see https://shelving.cc/util/entry/getEntries
  */
 export function getEntries<K extends string, T = K>(
 	...input: (ImmutableSet<K & T> | Partial<ImmutableObject<K, T>> | Iterable<Entry<K, T>>)[]

--- a/modules/util/env.ts
+++ b/modules/util/env.ts
@@ -7,7 +7,7 @@ import type { AnyCaller } from "./function.js";
  * @param name Name of the environment variable to read.
  * @returns The variable's string value, or `undefined` if missing or unsupported.
  * @example getEnv("NODE_ENV") // "production"
- * @see https://dhoulb.github.io/shelving/util/env/getEnv
+ * @see https://shelving.cc/util/env/getEnv
  */
 export function getEnv(name: string): string | undefined {
 	if (typeof process === "object" && typeof process.env === "object") return process.env[name];
@@ -21,7 +21,7 @@ export function getEnv(name: string): string | undefined {
  * @returns The variable's string value.
  * @throws `RequiredError` if the variable is missing or `process.env` is unsupported.
  * @example requireEnv("DATABASE_URL") // "postgres://..."
- * @see https://dhoulb.github.io/shelving/util/env/requireEnv
+ * @see https://shelving.cc/util/env/requireEnv
  */
 export function requireEnv(name: string, caller: AnyCaller = requireEnv): string {
 	const env = getEnv(name);
@@ -37,7 +37,7 @@ export function requireEnv(name: string, caller: AnyCaller = requireEnv): string
  * @param name Name of the environment variable to read.
  * @returns `true` or `false` if the value is recognised, otherwise `undefined`.
  * @example getEnvBoolean("FEATURE_FLAG") // true
- * @see https://dhoulb.github.io/shelving/util/env/getEnvBoolean
+ * @see https://shelving.cc/util/env/getEnvBoolean
  */
 export function getEnvBoolean(name: string): boolean | undefined {
 	const env = getEnv(name)?.toLowerCase();
@@ -55,7 +55,7 @@ const _FALSES = [`0`, `off`, `no`, `false`];
  * @returns `false` if the environment variable is `0`, `off`, `no`, `false`; `true` if it is `1`, `on`, `yes`, `true`.
  * @throws `RequiredError` if the env variable is any other value.
  * @example requireEnvBoolean("FEATURE_FLAG") // true
- * @see https://dhoulb.github.io/shelving/util/env/requireEnvBoolean
+ * @see https://shelving.cc/util/env/requireEnvBoolean
  */
 export function requireEnvBoolean(name: string, caller: AnyCaller = requireEnvBoolean): boolean {
 	const env = getEnv(name);

--- a/modules/util/equal.ts
+++ b/modules/util/equal.ts
@@ -17,7 +17,7 @@ import { compareAscending } from "./sort.js";
  * @param caller Function to attribute a thrown error to (defaults to `assertEqual`).
  * @throws {RequiredError} If the values are not equal.
  * @example assertEqual(1, 1); // passes
- * @see https://dhoulb.github.io/shelving/util/equal/assertEqual
+ * @see https://shelving.cc/util/equal/assertEqual
  */
 export function assertEqual<T>(left: unknown, right: T, caller: AnyCaller = assertEqual): asserts left is T {
 	if (left !== right) new RequiredError("Must be equal", { left, right, caller });
@@ -31,7 +31,7 @@ export function assertEqual<T>(left: unknown, right: T, caller: AnyCaller = asse
  * @param caller Function to attribute a thrown error to (defaults to `assertNot`).
  * @throws {RequiredError} If the values are equal.
  * @example assertNot(1, 2); // passes
- * @see https://dhoulb.github.io/shelving/util/equal/assertNot
+ * @see https://shelving.cc/util/equal/assertNot
  */
 export function assertNot<T, N>(left: T | N, right: N, caller: AnyCaller = assertNot): asserts left is T {
 	if (left === right) new RequiredError("Must not be equal", { left, right, caller });
@@ -44,7 +44,7 @@ export function assertNot<T, N>(left: T | N, right: N, caller: AnyCaller = asser
  * @param right The value to compare against.
  * @returns `true` if the values are strictly equal.
  * @example isEqual(1, 1) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isEqual
+ * @see https://shelving.cc/util/equal/isEqual
  */
 export function isEqual<T>(left: unknown, right: T): left is T {
 	return left === right;
@@ -57,7 +57,7 @@ export function isEqual<T>(left: unknown, right: T): left is T {
  * @param right The value to compare against.
  * @returns `true` if the values are not strictly equal.
  * @example notEqual(1, 2) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notEqual
+ * @see https://shelving.cc/util/equal/notEqual
  */
 export function notEqual<T, N>(left: T | N, right: N): left is T {
 	return left !== right;
@@ -70,7 +70,7 @@ export function notEqual<T, N>(left: T | N, right: N): left is T {
  * @param right The value to compare against.
  * @returns `true` if `left` sorts before `right`.
  * @example isLess(1, 2) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isLess
+ * @see https://shelving.cc/util/equal/isLess
  */
 export function isLess(left: unknown, right: unknown) {
 	return compareAscending(left, right) < 0;
@@ -83,7 +83,7 @@ export function isLess(left: unknown, right: unknown) {
  * @param right The value to compare against.
  * @returns `true` if `left` sorts before or equal to `right`.
  * @example isEqualLess(2, 2) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isEqualLess
+ * @see https://shelving.cc/util/equal/isEqualLess
  */
 export function isEqualLess(left: unknown, right: unknown) {
 	return compareAscending(left, right) <= 0;
@@ -96,7 +96,7 @@ export function isEqualLess(left: unknown, right: unknown) {
  * @param right The value to compare against.
  * @returns `true` if `left` sorts after `right`.
  * @example isGreater(2, 1) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isGreater
+ * @see https://shelving.cc/util/equal/isGreater
  */
 export function isGreater(left: unknown, right: unknown) {
 	return compareAscending(left, right) > 0;
@@ -109,7 +109,7 @@ export function isGreater(left: unknown, right: unknown) {
  * @param right The value to compare against.
  * @returns `true` if `left` sorts after or equal to `right`.
  * @example isEqualGreater(2, 2) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isEqualGreater
+ * @see https://shelving.cc/util/equal/isEqualGreater
  */
 export function isEqualGreater(left: unknown, right: unknown) {
 	return compareAscending(left, right) >= 0;
@@ -134,7 +134,7 @@ function _isEqualRecursively(left: unknown, right: unknown, recursor: Match): bo
  * @param right The value to compare against.
  * @returns `true` if the values are shallowly equal.
  * @example isShallowEqual({ a: 1 }, { a: 1 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isShallowEqual
+ * @see https://shelving.cc/util/equal/isShallowEqual
  */
 export function isShallowEqual<T>(left: unknown, right: T): left is T {
 	return _isEqualRecursively(left, right, isEqual);
@@ -147,7 +147,7 @@ export function isShallowEqual<T>(left: unknown, right: T): left is T {
  * @param right The value to compare against.
  * @returns `true` if the values are not shallowly equal.
  * @example notShallowEqual({ a: 1 }, { a: 2 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notShallowEqual
+ * @see https://shelving.cc/util/equal/notShallowEqual
  */
 export function notShallowEqual<T>(left: unknown, right: T): left is T {
 	return !isShallowEqual(left, right);
@@ -161,7 +161,7 @@ export function notShallowEqual<T>(left: unknown, right: T): left is T {
  * @param right The value to compare against.
  * @returns `true` if the values are deeply equal.
  * @example isDeepEqual({ a: { b: 1 } }, { a: { b: 1 } }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isDeepEqual
+ * @see https://shelving.cc/util/equal/isDeepEqual
  */
 export function isDeepEqual<T>(left: unknown, right: T): left is T {
 	return _isEqualRecursively(left, right, isDeepEqual);
@@ -174,7 +174,7 @@ export function isDeepEqual<T>(left: unknown, right: T): left is T {
  * @param right The value to compare against.
  * @returns `true` if the values are not deeply equal.
  * @example notDeepEqual({ a: { b: 1 } }, { a: { b: 2 } }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notDeepEqual
+ * @see https://shelving.cc/util/equal/notDeepEqual
  */
 export function notDeepEqual<T>(left: unknown, right: T): left is T {
 	return !isShallowEqual(left, right);
@@ -188,7 +188,7 @@ export function notDeepEqual<T>(left: unknown, right: T): left is T {
  * @param recursor Function that checks each value of the map (defaults to `isEqual()` for strict equality; pass `isDeepEqual()` for deep equality).
  * @returns `true` if both maps have the same keys and matching values.
  * @example isMapEqual(new Map([["a", 1]]), new Map([["a", 1]])) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isMapEqual
+ * @see https://shelving.cc/util/equal/isMapEqual
  */
 export function isMapEqual<T extends ImmutableMap>(left: ImmutableMap, right: T, recursor: Match = isEqual): left is T {
 	if (left === right) return true; // Referentially equal.
@@ -212,7 +212,7 @@ export function isMapEqual<T extends ImmutableMap>(left: ImmutableMap, right: T,
  * - Use `isDeepEqual()` as the recursor to check to check deep equality of the items.
  * @returns `true` if both arrays have the same length and matching items.
  * @example isArrayEqual([1, 2], [1, 2]) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isArrayEqual
+ * @see https://shelving.cc/util/equal/isArrayEqual
  */
 export function isArrayEqual<T extends ImmutableArray>(left: ImmutableArray, right: T, recursor: Match = isEqual): left is T {
 	if (left === right) return true; // Referentially equal.
@@ -228,7 +228,7 @@ export function isArrayEqual<T extends ImmutableArray>(left: ImmutableArray, rig
  * @param right The array to search within.
  * @returns `true` if `left` is an item of `right`.
  * @example isInArray(2, [1, 2, 3]) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isInArray
+ * @see https://shelving.cc/util/equal/isInArray
  */
 export function isInArray<R>(left: unknown, right: ImmutableArray<R>): left is R {
 	return right.includes(left as R);
@@ -241,7 +241,7 @@ export function isInArray<R>(left: unknown, right: ImmutableArray<R>): left is R
  * @param right The array to search within.
  * @returns `true` if `left` is not an item of `right`.
  * @example notInArray(9, [1, 2, 3]) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notInArray
+ * @see https://shelving.cc/util/equal/notInArray
  */
 export function notInArray(left: unknown, right: ImmutableArray): boolean {
 	return !isInArray(left, right);
@@ -254,7 +254,7 @@ export function notInArray(left: unknown, right: ImmutableArray): boolean {
  * @param right The item the array must include.
  * @returns `true` if `left` is an array containing `right`.
  * @example isArrayWith([1, 2, 3], 2) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isArrayWith
+ * @see https://shelving.cc/util/equal/isArrayWith
  */
 export function isArrayWith<T>(left: unknown, right: T): left is ImmutableArray<T> {
 	return isArray(left) && left.includes(right);
@@ -267,7 +267,7 @@ export function isArrayWith<T>(left: unknown, right: T): left is ImmutableArray<
  * @param right The item the array must include.
  * @returns `true` if `left` is not an array or does not include `right`.
  * @example notArrayWith([1, 2, 3], 9) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notArrayWith
+ * @see https://shelving.cc/util/equal/notArrayWith
  */
 export function notArrayWith(left: unknown, right: unknown): boolean {
 	return !isArrayWith(left, right);
@@ -285,7 +285,7 @@ export function notArrayWith(left: unknown, right: unknown): boolean {
  * - Use `isDeepEqual()` as the recursor to check to check deep equality of the properties.
  * @returns `true` if both objects have exactly the same own props and matching values.
  * @example isObjectEqual({ a: 1 }, { a: 1 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isObjectEqual
+ * @see https://shelving.cc/util/equal/isObjectEqual
  */
 export function isObjectEqual<T extends ImmutableObject>(left: ImmutableObject, right: T, recursor: Match = isEqual): left is T {
 	if (left === right) return true; // Referentially equal.
@@ -308,7 +308,7 @@ export function isObjectEqual<T extends ImmutableObject>(left: ImmutableObject, 
  * - Use `isDeepEqual()` as the recursor to check to check deep equality of the properties.
  * @returns `true` if `left` contains every prop of `right` with matching values.
  * @example isObjectMatch({ a: 1, b: 2 }, { a: 1 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isObjectMatch
+ * @see https://shelving.cc/util/equal/isObjectMatch
  */
 export function isObjectMatch<L extends ImmutableObject, R extends ImmutableObject>(
 	left: L | R,
@@ -328,7 +328,7 @@ export function isObjectMatch<L extends ImmutableObject, R extends ImmutableObje
  * @param right The object whose props `left` must contain.
  * @returns `true` if `left` is an object containing every prop of `right`.
  * @example isObjectWith({ a: 1, b: 2 }, { a: 1 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/isObjectWith
+ * @see https://shelving.cc/util/equal/isObjectWith
  */
 export function isObjectWith(left: unknown, right: ImmutableObject): boolean {
 	return isObject(left) && isObjectMatch(left, right);
@@ -341,7 +341,7 @@ export function isObjectWith(left: unknown, right: ImmutableObject): boolean {
  * @param right The object whose props `left` must contain.
  * @returns `true` if `left` is not an object or is missing one or more props of `right`.
  * @example notObjectWith({ a: 1 }, { b: 2 }) // true
- * @see https://dhoulb.github.io/shelving/util/equal/notObjectWith
+ * @see https://shelving.cc/util/equal/notObjectWith
  */
 export function notObjectWith(left: unknown, right: ImmutableObject): boolean {
 	return !isObjectWith(left, right);

--- a/modules/util/error.ts
+++ b/modules/util/error.ts
@@ -9,7 +9,7 @@ import { isObject } from "./object.js";
  * @param reason The error (or any thrown value) to log.
  * @returns Nothing.
  * @example logError(new Error("Boom")) // logs to console.error
- * @see https://dhoulb.github.io/shelving/util/error/logError
+ * @see https://shelving.cc/util/error/logError
  */
 export function logError(reason: unknown): void {
 	console.error(reason);
@@ -21,7 +21,7 @@ export function logError(reason: unknown): void {
  *
  * @param v The value to check and narrow.
  * @returns `true` if `v` is an `Error` (narrowing it, with an optional `code` string).
- * @see https://dhoulb.github.io/shelving/util/error/isError
+ * @see https://shelving.cc/util/error/isError
  */
 export function isError(v: unknown): v is Error & { readonly code?: string | undefined } {
 	return typeof Error.isError === "function" ? Error.isError(v) : v instanceof Error;
@@ -30,7 +30,7 @@ export function isError(v: unknown): v is Error & { readonly code?: string | und
 /**
  * Things that can be a message: a string, or an object with a `message` string property.
  *
- * @see https://dhoulb.github.io/shelving/util/error/PossibleMessage
+ * @see https://shelving.cc/util/error/PossibleMessage
  */
 export type PossibleMessage = { message: string } | string;
 
@@ -41,7 +41,7 @@ export type PossibleMessage = { message: string } | string;
  * @returns The message string, or `undefined` if none could be found.
  * @example getMessage(new Error("Boom")) // "Boom"
  * @example getMessage(123) // undefined
- * @see https://dhoulb.github.io/shelving/util/error/getMessage
+ * @see https://shelving.cc/util/error/getMessage
  */
 export function getMessage(input: unknown): string | undefined {
 	return typeof input === "string" ? input : isObject(input) && typeof input.message === "string" ? input.message : undefined;
@@ -55,7 +55,7 @@ export function getMessage(input: unknown): string | undefined {
  * @returns The message string.
  * @throws `RequiredError` if no message could be found.
  * @example requireMessage(new Error("Boom")) // "Boom"
- * @see https://dhoulb.github.io/shelving/util/error/requireMessage
+ * @see https://shelving.cc/util/error/requireMessage
  */
 export function requireMessage(input: PossibleMessage, caller: AnyCaller = requireMessage): string {
 	const message = getMessage(input);
@@ -73,7 +73,7 @@ export function requireMessage(input: PossibleMessage, caller: AnyCaller = requi
  * @returns Dictionary mapping each name (or `""` for unnamed lines) to its combined message.
  * @throws `RequiredError` if no message could be found.
  * @example splitMessage("name: Bad\nUh oh") // { name: "Bad", "": "Uh oh" }
- * @see https://dhoulb.github.io/shelving/util/error/splitMessage
+ * @see https://shelving.cc/util/error/splitMessage
  */
 export function splitMessage(input: PossibleMessage): ImmutableDictionary<string> {
 	const messages = requireMessage(input, splitMessage).split("\n");
@@ -105,7 +105,7 @@ export function splitMessage(input: PossibleMessage): ImmutableDictionary<string
  * @param input Dictionary mapping each name (or `""` for unnamed lines) to its message.
  * @returns The combined message string, with one line per message line.
  * @example joinMessage({ name: "Bad", "": "Uh oh" }) // "name: Bad\nUh oh"
- * @see https://dhoulb.github.io/shelving/util/error/joinMessage
+ * @see https://shelving.cc/util/error/joinMessage
  */
 export function joinMessage(input: ImmutableDictionary<string>): string {
 	const output: string[] = [];
@@ -127,7 +127,7 @@ export function joinMessage(input: ImmutableDictionary<string>): string {
  * @param message The message to prefix (may contain multiple `\n`-separated lines).
  * @returns The message with `name: ` prefixed to every line.
  * @example getNamedMessage("email", "Required\nInvalid") // "email: Required\nemail: Invalid"
- * @see https://dhoulb.github.io/shelving/util/error/getNamedMessage
+ * @see https://shelving.cc/util/error/getNamedMessage
  */
 export function getNamedMessage(name: string | number, message: string): string {
 	return `${name}: ${message.split("\n").join(`\n${name}: `)}`;

--- a/modules/util/file.ts
+++ b/modules/util/file.ts
@@ -5,7 +5,7 @@ import type { Nullish } from "./null.js";
 /**
  * List of file types in `extension: mime` format.
  *
- * @see https://dhoulb.github.io/shelving/util/file/FileTypes
+ * @see https://shelving.cc/util/file/FileTypes
  */
 export type FileTypes = { [extension: string]: string };
 
@@ -20,7 +20,7 @@ export type FileTypes = { [extension: string]: string };
  * @example splitFileExtension("no-ext") // ["no-ext", undefined]
  * @example splitFileExtension(".gitignore") // [undefined, "gitignore"]
  * @example splitFileExtension(undefined) // [undefined, undefined]
- * @see https://dhoulb.github.io/shelving/util/file/splitFileExtension
+ * @see https://shelving.cc/util/file/splitFileExtension
  */
 export function splitFileExtension(file: Nullish<string> = ""): [base: string | undefined, extension: string | undefined] {
 	if (!file) return [undefined, undefined];
@@ -35,7 +35,7 @@ export function splitFileExtension(file: Nullish<string> = ""): [base: string | 
  * @param file The filename to read the extension from, or a nullish value.
  * @returns The extension (no leading dot), or `undefined` if the input has no extension.
  * @example getFileExtension("readme.md") // "md"
- * @see https://dhoulb.github.io/shelving/util/file/getFileExtension
+ * @see https://shelving.cc/util/file/getFileExtension
  */
 export function getFileExtension(file: Nullish<string>): string | undefined {
 	return splitFileExtension(file)[1];
@@ -49,7 +49,7 @@ export function getFileExtension(file: Nullish<string>): string | undefined {
  * @returns The extension (no leading dot).
  * @throws `RequiredError` if the input has no extension.
  * @example requireFileExtension("component.tsx") // "tsx"
- * @see https://dhoulb.github.io/shelving/util/file/requireFileExtension
+ * @see https://shelving.cc/util/file/requireFileExtension
  */
 export function requireFileExtension(file: string, caller: AnyCaller = requireFileExtension): string {
 	const extension = getFileExtension(file);

--- a/modules/util/filter.ts
+++ b/modules/util/filter.ts
@@ -4,7 +4,7 @@ import type { Arguments } from "./function.js";
 /**
  * Function that can match an item against a target.
  *
- * @see https://dhoulb.github.io/shelving/util/filter/Match
+ * @see https://shelving.cc/util/filter/Match
  */
 export type Match<A extends Arguments = unknown[]> = (...args: A) => boolean;
 
@@ -16,7 +16,7 @@ export type Match<A extends Arguments = unknown[]> = (...args: A) => boolean;
  * @param args Extra arguments passed to `match` after each item.
  * @returns Iterable yielding only the items the matcher returned `true` for.
  * @example Array.from(filterItems([1, 2, 3], n => n > 1)) // [2, 3]
- * @see https://dhoulb.github.io/shelving/util/filter/filterItems
+ * @see https://shelving.cc/util/filter/filterItems
  */
 export function* filterItems<T, A extends Arguments = []>(items: Iterable<T>, match: Match<[T, ...A]>, ...args: A): Iterable<T> {
 	for (const item of items) if (match(item, ...args)) yield item;
@@ -31,7 +31,7 @@ export function* filterItems<T, A extends Arguments = []>(items: Iterable<T>, ma
  * @param args Extra arguments passed to `match` after each item.
  * @returns A filtered array, or the same `input` instance if nothing was removed.
  * @example filterArray([1, 2, 3], n => n > 1) // [2, 3]
- * @see https://dhoulb.github.io/shelving/util/filter/filterArray
+ * @see https://shelving.cc/util/filter/filterArray
  */
 export function filterArray<T, A extends Arguments = []>(input: ImmutableArray<T>, match: Match<[T, ...A]>, ...args: A): ImmutableArray<T> {
 	if (!input.length) return input;
@@ -47,7 +47,7 @@ export function filterArray<T, A extends Arguments = []>(input: ImmutableArray<T
  * @param args Extra arguments passed to `match` after each item.
  * @returns Async iterable yielding only the items the matcher returned `true` for.
  * @example for await (const n of filterSequence(stream, n => n > 1)) { ... }
- * @see https://dhoulb.github.io/shelving/util/filter/filterSequence
+ * @see https://shelving.cc/util/filter/filterSequence
  */
 export async function* filterSequence<T, A extends Arguments = []>(sequence: AsyncIterable<T>, match: Match, ...args: A): AsyncIterable<T> {
 	for await (const item of sequence) if (match(item, ...args)) yield item;

--- a/modules/util/focus.ts
+++ b/modules/util/focus.ts
@@ -8,7 +8,7 @@ const FOCUSABLE = `a:link, button:enabled, input:enabled, select:enabled, textar
  * @param el The HTML element to search (it is tested first, then its descendants).
  * @returns The first focusable `HTMLElement`, or `null` if none is found.
  * @example getFirstFocusable(form) // the first enabled input inside the form
- * @see https://dhoulb.github.io/shelving/util/focus/getFirstFocusable
+ * @see https://shelving.cc/util/focus/getFirstFocusable
  */
 export function getFirstFocusable(el: HTMLElement): HTMLElement | null {
 	return el.matches(FOCUSABLE) ? el : el.querySelector(FOCUSABLE);

--- a/modules/util/format.ts
+++ b/modules/util/format.ts
@@ -10,13 +10,13 @@ import { type PossibleURL, requireURL } from "./url.js";
 /**
  * Options that are shared across all formatters.
  *
- * @see https://dhoulb.github.io/shelving/util/format/FormatOptions
+ * @see https://shelving.cc/util/format/FormatOptions
  */
 export interface FormatOptions {
 	/**
 	 * Override the locale for formatting (defaults to detected locale).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/format/FormatOptions/locale
+	 * @see https://shelving.cc/util/format/FormatOptions/locale
 	 */
 	readonly locale?: Intl.Locale | undefined;
 }
@@ -27,7 +27,7 @@ export interface FormatOptions {
  * @param value Boolean value to format.
  * @returns `"Yes"` if `value` is `true`, otherwise `"No"`.
  * @example formatBoolean(true) // "Yes"
- * @see https://dhoulb.github.io/shelving/util/format/formatBoolean
+ * @see https://shelving.cc/util/format/formatBoolean
  */
 export function formatBoolean(value: boolean): string {
 	return value ? "Yes" : "No";
@@ -36,7 +36,7 @@ export function formatBoolean(value: boolean): string {
 /**
  * Options we use for number formatting.
  *
- * @see https://dhoulb.github.io/shelving/util/format/NumberFormatOptions
+ * @see https://shelving.cc/util/format/NumberFormatOptions
  */
 export interface NumberFormatOptions
 	extends FormatOptions,
@@ -49,7 +49,7 @@ export interface NumberFormatOptions
  * @param options Formatting options passed through to `Intl.NumberFormat`.
  * @returns Locale-formatted number string.
  * @example formatNumber(1234.5) // "1,234.5"
- * @see https://dhoulb.github.io/shelving/util/format/formatNumber
+ * @see https://shelving.cc/util/format/formatNumber
  */
 export function formatNumber(num: number, options?: NumberFormatOptions): string {
 	return Intl.NumberFormat(options?.locale, options).format(num);
@@ -63,7 +63,7 @@ export function formatNumber(num: number, options?: NumberFormatOptions): string
  * @param options Formatting options passed through to `Intl.NumberFormat`.
  * @returns Locale-formatted number range string.
  * @example formatRange(1, 10) // "1–10"
- * @see https://dhoulb.github.io/shelving/util/format/formatRange
+ * @see https://shelving.cc/util/format/formatRange
  */
 export function formatRange(from: number, to: number, options?: NumberFormatOptions): string {
 	return Intl.NumberFormat(options?.locale, options).formatRange(from, to);
@@ -72,7 +72,7 @@ export function formatRange(from: number, to: number, options?: NumberFormatOpti
 /**
  * Options for quantity formatting.
  *
- * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions
+ * @see https://shelving.cc/util/format/UnitFormatOptions
  */
 export interface UnitFormatOptions
 	extends FormatOptions,
@@ -82,7 +82,7 @@ export interface UnitFormatOptions
 	 * - Used for `unitDisplay: "long"` formatting.
 	 * - Defaults to unit reference, e.g. "minute"
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/one
+	 * @see https://shelving.cc/util/format/UnitFormatOptions/one
 	 */
 	readonly one?: string | undefined;
 	/**
@@ -90,7 +90,7 @@ export interface UnitFormatOptions
 	 * - Used for `unitDisplay: "long"` formatting.
 	 * - Defaults to `one + "s"`
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/many
+	 * @see https://shelving.cc/util/format/UnitFormatOptions/many
 	 */
 	readonly many?: string | undefined;
 	/**
@@ -98,7 +98,7 @@ export interface UnitFormatOptions
 	 * - Used for `unitDisplay: "narrow"` formatting.
 	 * - Defaults to unit reference, e.g. "minute"
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/format/UnitFormatOptions/abbr
+	 * @see https://shelving.cc/util/format/UnitFormatOptions/abbr
 	 */
 	readonly abbr?: string | undefined;
 }
@@ -116,7 +116,7 @@ export interface UnitFormatOptions
  * @param options Formatting options including custom `one`/`many`/`abbr` strings for unsupported units.
  * @returns Formatted quantity string, e.g. `"5 minutes"` or `"5 products"`.
  * @example formatUnit(5, "minute", { unitDisplay: "long" }) // "5 minutes"
- * @see https://dhoulb.github.io/shelving/util/format/formatUnit
+ * @see https://shelving.cc/util/format/formatUnit
  */
 export function formatUnit(num: number, unit: string, options?: UnitFormatOptions): string {
 	// Check if the unit is supported by the browser.
@@ -133,7 +133,7 @@ export function formatUnit(num: number, unit: string, options?: UnitFormatOption
 /**
  * Options we use for currency formatting.
  *
- * @see https://dhoulb.github.io/shelving/util/format/CurrencyFormatOptions
+ * @see https://shelving.cc/util/format/CurrencyFormatOptions
  */
 export interface CurrencyFormatOptions
 	extends FormatOptions,
@@ -149,7 +149,7 @@ export interface CurrencyFormatOptions
  * @returns Locale-formatted currency string.
  * @throws {RequiredError} If `currency` is not a valid currency code.
  * @example formatCurrency(1234.5, "USD") // "$1,234.50"
- * @see https://dhoulb.github.io/shelving/util/format/formatCurrency
+ * @see https://shelving.cc/util/format/formatCurrency
  */
 export function formatCurrency(
 	amount: number,
@@ -167,7 +167,7 @@ export function formatCurrency(
 /**
  * Options we use for percent formatting.
  *
- * @see https://dhoulb.github.io/shelving/util/format/PercentFormatOptions
+ * @see https://shelving.cc/util/format/PercentFormatOptions
  */
 export interface PercentFormatOptions
 	extends FormatOptions,
@@ -184,7 +184,7 @@ export interface PercentFormatOptions
  * @param options Formatting options passed through to `Intl.NumberFormat`.
  * @returns Locale-formatted percentage string.
  * @example formatPercent(50) // "50%"
- * @see https://dhoulb.github.io/shelving/util/format/formatPercent
+ * @see https://shelving.cc/util/format/formatPercent
  */
 export function formatPercent(numerator: number, denumerator?: number, options?: PercentFormatOptions): string {
 	return Intl.NumberFormat(options?.locale, {
@@ -204,7 +204,7 @@ export function formatPercent(numerator: number, denumerator?: number, options?:
  * @param obj Object to format.
  * @returns Best-available string representation of `obj`, or `"Object"` as a fallback.
  * @example formatObject({ name: "Dave" }) // "Dave"
- * @see https://dhoulb.github.io/shelving/util/format/formatObject
+ * @see https://shelving.cc/util/format/formatObject
  */
 export function formatObject(obj: ImmutableObject): string {
 	if (typeof obj.toString === "function" && obj.toString !== Object.prototype.toString) return obj.toString();
@@ -220,7 +220,7 @@ export function formatObject(obj: ImmutableObject): string {
 /**
  * Options for formatting an array as a string with `formatArray()`.
  *
- * @see https://dhoulb.github.io/shelving/util/format/ArrayFormatOptions
+ * @see https://shelving.cc/util/format/ArrayFormatOptions
  */
 export interface ArrayFormatOptions extends FormatOptions, Intl.ListFormatOptions {}
 
@@ -232,7 +232,7 @@ export interface ArrayFormatOptions extends FormatOptions, Intl.ListFormatOption
  * @param caller Function to attribute a thrown error to (defaults to `formatArray` itself).
  * @returns Locale-formatted list string with each item converted via `formatValue()`.
  * @example formatArray(["a", "b", "c"]) // "a, b, and c"
- * @see https://dhoulb.github.io/shelving/util/format/formatArray
+ * @see https://shelving.cc/util/format/formatArray
  */
 export function formatArray(arr: ImmutableArray<unknown>, options?: ArrayFormatOptions, caller: AnyCaller = formatArray): string {
 	return new Intl.ListFormat(undefined, { style: "long", type: "unit", ...options }).format(formatValues(arr, options, caller));
@@ -241,13 +241,13 @@ export function formatArray(arr: ImmutableArray<unknown>, options?: ArrayFormatO
 /**
  * Options we use for date, time, and datetime formatting.
  *
- * @see https://dhoulb.github.io/shelving/util/format/DateFormatOptions
+ * @see https://shelving.cc/util/format/DateFormatOptions
  */
 export interface DateFormatOptions extends Intl.DateTimeFormatOptions {
 	/**
 	 * Override the locale for formatting (defaults to detected locale).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/format/DateFormatOptions/locale
+	 * @see https://shelving.cc/util/format/DateFormatOptions/locale
 	 */
 	readonly locale?: Intl.Locale | undefined;
 }
@@ -261,7 +261,7 @@ export interface DateFormatOptions extends Intl.DateTimeFormatOptions {
  * @returns Locale-formatted date string.
  * @throws {RequiredError} If `date` cannot be converted to a valid date.
  * @example formatDate("2025-01-01") // "1/1/2025"
- * @see https://dhoulb.github.io/shelving/util/format/formatDate
+ * @see https://shelving.cc/util/format/formatDate
  */
 export function formatDate(date: PossibleDate, options?: DateFormatOptions, caller: AnyCaller = formatDate): string {
 	return requireDate(date, caller).toLocaleDateString(options?.locale, options);
@@ -276,7 +276,7 @@ export function formatDate(date: PossibleDate, options?: DateFormatOptions, call
  * @returns Locale-formatted time string.
  * @throws {RequiredError} If `time` cannot be converted to a valid date.
  * @example formatTime("2025-01-01T13:30") // "01:30 PM"
- * @see https://dhoulb.github.io/shelving/util/format/formatTime
+ * @see https://shelving.cc/util/format/formatTime
  */
 export function formatTime(time?: PossibleDate, options?: DateFormatOptions, caller: AnyCaller = formatTime): string {
 	return requireDate(time, caller).toLocaleTimeString(options?.locale, {
@@ -296,7 +296,7 @@ export function formatTime(time?: PossibleDate, options?: DateFormatOptions, cal
  * @returns Locale-formatted datetime string.
  * @throws {RequiredError} If `date` cannot be converted to a valid date.
  * @example formatDateTime("2025-01-01T13:30") // "1/1/2025, 01:30 PM"
- * @see https://dhoulb.github.io/shelving/util/format/formatDateTime
+ * @see https://shelving.cc/util/format/formatDateTime
  */
 export function formatDateTime(date: PossibleDate, options?: DateFormatOptions, caller: AnyCaller = formatDateTime): string {
 	return requireDate(date, caller).toLocaleString(options?.locale, {
@@ -320,7 +320,7 @@ export function formatDateTime(date: PossibleDate, options?: DateFormatOptions, 
  * @returns Friendly string showing the host and path with any trailing slash removed.
  * @throws {RequiredError} If `url` cannot be converted to a valid URI.
  * @example formatURI("http://shax.com/test?uid=129483") // "shax.com/test"
- * @see https://dhoulb.github.io/shelving/util/format/formatURI
+ * @see https://shelving.cc/util/format/formatURI
  */
 export function formatURI(url: PossibleURI, caller: AnyCaller = formatURI): string {
 	return _formatURI(requireURI(url, caller));
@@ -339,7 +339,7 @@ function _formatURI({ host, pathname }: URL): string {
  * @returns Friendly string showing the host and path with any trailing slash removed.
  * @throws {RequiredError} If `url` cannot be converted to a valid URL.
  * @example formatURL("http://shax.com/test?uid=129483") // "shax.com/test"
- * @see https://dhoulb.github.io/shelving/util/format/formatURL
+ * @see https://shelving.cc/util/format/formatURL
  */
 export function formatURL(url: PossibleURL, base?: PossibleURL, caller: AnyCaller = formatURL): string {
 	return _formatURI(requireURL(url, base, caller));
@@ -363,7 +363,7 @@ export function formatURL(url: PossibleURL, base?: PossibleURL, caller: AnyCalle
  * @param caller Function to attribute a thrown error to (defaults to `formatValue` itself).
  * @returns User-facing string representation of `value`.
  * @example formatValue(1234) // "1,234"
- * @see https://dhoulb.github.io/shelving/util/format/formatValue
+ * @see https://shelving.cc/util/format/formatValue
  */
 export function formatValue(value: unknown, options?: FormatOptions, caller: AnyCaller = formatValue): string {
 	if (value === null || value === undefined) return "None";
@@ -387,7 +387,7 @@ export function formatValue(value: unknown, options?: FormatOptions, caller: Any
  * @param caller Function to attribute a thrown error to (defaults to `formatValues` itself).
  * @returns Iterable yielding the user-facing string for each value.
  * @example [...formatValues([1234, true])] // ["1,234", "Yes"]
- * @see https://dhoulb.github.io/shelving/util/format/formatValues
+ * @see https://shelving.cc/util/format/formatValues
  */
 export function* formatValues(values: Iterable<unknown>, options?: FormatOptions, caller: AnyCaller = formatValues): Iterable<string> {
 	for (const v of values) yield formatValue(v, options, caller);

--- a/modules/util/function.ts
+++ b/modules/util/function.ts
@@ -4,21 +4,21 @@ import type { AnyConstructor } from "./class.js";
 /**
  * Readonly unknown array that is being used as a set of arguments to a function.
  *
- * @see https://dhoulb.github.io/shelving/util/function/Arguments
+ * @see https://shelving.cc/util/function/Arguments
  */
 export type Arguments = readonly unknown[];
 
 /**
  * Unknown function.
  *
- * @see https://dhoulb.github.io/shelving/util/function/UnknownFunction
+ * @see https://shelving.cc/util/function/UnknownFunction
  */
 export type UnknownFunction = (...args: unknown[]) => unknown;
 
 /**
  * Any function (purposefully as wide as possible for use with `extends X` or `is X` statements).
  *
- * @see https://dhoulb.github.io/shelving/util/function/AnyFunction
+ * @see https://shelving.cc/util/function/AnyFunction
  */
 // biome-ignore lint/suspicious/noExplicitAny: `unknown` causes edge case matching issues.
 export type AnyFunction = (...args: any) => any;
@@ -26,28 +26,28 @@ export type AnyFunction = (...args: any) => any;
 /**
  * Any calling function or constructor, usually referring to something that can call in the current scope that can appear in a stack trace.
  *
- * @see https://dhoulb.github.io/shelving/util/function/AnyCaller
+ * @see https://shelving.cc/util/function/AnyCaller
  */
 export type AnyCaller = AnyFunction | AnyConstructor;
 
 /**
  * A callback is a function that is called when something happens, optionally with multiple values.
  *
- * @see https://dhoulb.github.io/shelving/util/function/Callback
+ * @see https://shelving.cc/util/function/Callback
  */
 export type Callback<A extends Arguments = []> = (...args: A) => void;
 
 /**
  * A callback is a function that is called when something happens with a value.
  *
- * @see https://dhoulb.github.io/shelving/util/function/ValueCallback
+ * @see https://shelving.cc/util/function/ValueCallback
  */
 export type ValueCallback<T> = (value: T) => void;
 
 /**
  * Function that is called when something errors.
  *
- * @see https://dhoulb.github.io/shelving/util/function/ErrorCallback
+ * @see https://shelving.cc/util/function/ErrorCallback
  */
 export type ErrorCallback = (reason: unknown) => void;
 
@@ -57,7 +57,7 @@ export type ErrorCallback = (reason: unknown) => void;
  * @param value The value to test.
  * @returns `true` if `value` is a function, narrowing its type to `AnyFunction`.
  * @example isFunction(() => {}) // true
- * @see https://dhoulb.github.io/shelving/util/function/isFunction
+ * @see https://shelving.cc/util/function/isFunction
  */
 export function isFunction(value: unknown): value is AnyFunction {
 	return typeof value === "function";
@@ -68,7 +68,7 @@ export function isFunction(value: unknown): value is AnyFunction {
  *
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not a function.
- * @see https://dhoulb.github.io/shelving/util/function/assertFunction
+ * @see https://shelving.cc/util/function/assertFunction
  */
 export function assertFunction(value: unknown): asserts value is AnyFunction {
 	if (typeof value !== "function") throw new RequiredError("Must be function", { received: value, caller: assertFunction });
@@ -80,7 +80,7 @@ export function assertFunction(value: unknown): asserts value is AnyFunction {
  * @param value The value to return.
  * @returns The exact `value` it was given, unchanged.
  * @example PASSTHROUGH(123) // 123
- * @see https://dhoulb.github.io/shelving/util/function/PASSTHROUGH
+ * @see https://shelving.cc/util/function/PASSTHROUGH
  */
 export function PASSTHROUGH<T>(value: T): T {
 	return value;
@@ -92,7 +92,7 @@ export function PASSTHROUGH<T>(value: T): T {
  * @param _unused Zero or more arguments, all ignored.
  * @returns Always `undefined`.
  * @example BLACKHOLE(1, 2, 3) // undefined
- * @see https://dhoulb.github.io/shelving/util/function/BLACKHOLE
+ * @see https://shelving.cc/util/function/BLACKHOLE
  */
 export function BLACKHOLE(..._unused: Arguments): void | undefined {
 	return undefined;

--- a/modules/util/geo.ts
+++ b/modules/util/geo.ts
@@ -6,7 +6,7 @@ import { isProp } from "./object.js";
  * List of countries by two-letter ISO 3166-1 alpha-2 code.
  * - Keys are uppercase two-letter codes; values are the full English country name.
  *
- * @see https://dhoulb.github.io/shelving/util/geo/COUNTRIES
+ * @see https://shelving.cc/util/geo/COUNTRIES
  */
 export const COUNTRIES = {
 	AF: "Afghanistan",
@@ -260,14 +260,14 @@ export const COUNTRIES = {
 /**
  * Two-letter ISO 3166-1 alpha-2 country code string (a key of `COUNTRIES`).
  *
- * @see https://dhoulb.github.io/shelving/util/geo/Country
+ * @see https://shelving.cc/util/geo/Country
  */
 export type Country = keyof typeof COUNTRIES;
 
 /**
  * A value that can possibly be resolved to a `Country` — either a country code or the literal `"detect"`.
  *
- * @see https://dhoulb.github.io/shelving/util/geo/PossibleCountry
+ * @see https://shelving.cc/util/geo/PossibleCountry
  */
 export type PossibleCountry = Country | "detect";
 
@@ -279,7 +279,7 @@ export type PossibleCountry = Country | "detect";
  * @param value The country code to parse, or `"detect"` to read it from the browser. Defaults to `"detect"`.
  * @returns The matching `Country` code, or `undefined` if it could not be resolved.
  * @example getCountry("gb") // "GB"
- * @see https://dhoulb.github.io/shelving/util/geo/getCountry
+ * @see https://shelving.cc/util/geo/getCountry
  */
 export function getCountry(value: unknown = "detect"): Country | undefined {
 	if (value === "detect") {
@@ -301,7 +301,7 @@ export function getCountry(value: unknown = "detect"): Country | undefined {
  * @returns The matching `Country` code.
  * @throws RequiredError If a country could not be resolved.
  * @example requireCountry("gb") // "GB"
- * @see https://dhoulb.github.io/shelving/util/geo/requireCountry
+ * @see https://shelving.cc/util/geo/requireCountry
  */
 export function requireCountry(value?: unknown, caller: AnyCaller = requireCountry): Country {
 	const country = getCountry(value);
@@ -316,7 +316,7 @@ export function requireCountry(value?: unknown, caller: AnyCaller = requireCount
  * @param country The country code to format.
  * @returns The full English country name, or the input unchanged if it is not a known code.
  * @example formatCountry("GB") // "United Kingdom"
- * @see https://dhoulb.github.io/shelving/util/geo/formatCountry
+ * @see https://shelving.cc/util/geo/formatCountry
  */
 export function formatCountry(country: string): string {
 	const code = country.toUpperCase();
@@ -326,7 +326,7 @@ export function formatCountry(country: string): string {
 /**
  * Valid shape for physical address data.
  *
- * @see https://dhoulb.github.io/shelving/util/geo/AddressData
+ * @see https://shelving.cc/util/geo/AddressData
  */
 export type AddressData = {
 	readonly address1: string;
@@ -345,7 +345,7 @@ export type AddressData = {
  * @param address The address data to format.
  * @returns A newline-separated address string.
  * @example formatAddress({ address1: "1 High St", address2: "", city: "London", state: "", postcode: "SW1", country: "GB" })
- * @see https://dhoulb.github.io/shelving/util/geo/formatAddress
+ * @see https://shelving.cc/util/geo/formatAddress
  */
 export function formatAddress({ address1, address2, city, state, postcode, country }: AddressData): string {
 	return `${address1}\n${address2 ? `${address2}\n` : ""}${city}\n${state}\n${postcode}\n${formatCountry(country)}`;

--- a/modules/util/hash.ts
+++ b/modules/util/hash.ts
@@ -8,7 +8,7 @@ import { wrapNumber } from "./number.js";
  * @param str The string to hash.
  * @returns A non-negative number derived from the string's characters.
  * @example hashString("abc") // 294
- * @see https://dhoulb.github.io/shelving/util/hash/hashString
+ * @see https://shelving.cc/util/hash/hashString
  */
 export function hashString(str: string): number {
 	let hash = 0;
@@ -25,7 +25,7 @@ export function hashString(str: string): number {
  * @param max The exclusive upper bound of the output range. Defaults to `256`.
  * @returns A number in the range `min` to `max` derived from the string.
  * @example hashStringBetween("abc", 0, 10) // 4
- * @see https://dhoulb.github.io/shelving/util/hash/hashStringBetween
+ * @see https://shelving.cc/util/hash/hashStringBetween
  */
 export function hashStringBetween(str: string, min = 0, max = 256): number {
 	return wrapNumber(hashString(str), min, max);

--- a/modules/util/http.ts
+++ b/modules/util/http.ts
@@ -13,21 +13,21 @@ import { getXML } from "./xml.js";
 /**
  * A handler function takes a `Request` and optional extra arguments and returns a `Response` (possibly asynchronously).
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestHandler
+ * @see https://shelving.cc/util/http/RequestHandler
  */
 export type RequestHandler<A extends Arguments = []> = (request: Request, ...args: A) => Response | Promise<Response>;
 
 /**
  * An optional request handler that may return `undefined` to indicate no match.
  *
- * @see https://dhoulb.github.io/shelving/util/http/OptionalRequestHandler
+ * @see https://shelving.cc/util/http/OptionalRequestHandler
  */
 export type OptionalRequestHandler<A extends Arguments = []> = (request: Request, ...args: A) => Response | Promise<Response> | undefined;
 
 /**
  * A list of optional request handlers.
  *
- * @see https://dhoulb.github.io/shelving/util/http/OptionalRequestHandlers
+ * @see https://shelving.cc/util/http/OptionalRequestHandlers
  */
 export type OptionalRequestHandlers<A extends Arguments = []> = Iterable<OptionalRequestHandler<A>>;
 
@@ -84,7 +84,7 @@ function _parseMessageBody(
  *
  * @throws {RequestError} If the content is not `text/plain`, or `application/json` with valid JSON.
  * @example const body = await parseRequestBody(request);
- * @see https://dhoulb.github.io/shelving/util/http/parseRequestBody
+ * @see https://shelving.cc/util/http/parseRequestBody
  */
 export function parseRequestBody(request: Request, caller: AnyCaller = parseRequestBody): Promise<unknown> {
 	return _parseMessageBody(request, RequestError, caller);
@@ -98,7 +98,7 @@ export function parseRequestBody(request: Request, caller: AnyCaller = parseRequ
  * @returns The parsed JSON value, or `undefined` if the body is empty.
  * @throws {RequestError} If the request body is not valid JSON.
  * @example const data = await parseRequestJSON(request);
- * @see https://dhoulb.github.io/shelving/util/http/parseRequestJSON
+ * @see https://shelving.cc/util/http/parseRequestJSON
  */
 export function parseRequestJSON(request: Request, caller: AnyCaller = parseRequestJSON): Promise<unknown> {
 	return _parseMessageJSON(request, RequestError, caller);
@@ -112,7 +112,7 @@ export function parseRequestJSON(request: Request, caller: AnyCaller = parseRequ
  * @returns The parsed `FormData`.
  * @throws {RequestError} If the request body is not valid multipart form-data.
  * @example const form = await parseRequestFormData(request);
- * @see https://dhoulb.github.io/shelving/util/http/parseRequestFormData
+ * @see https://shelving.cc/util/http/parseRequestFormData
  */
 export function parseRequestFormData(request: Request, caller: AnyCaller = parseRequestFormData): Promise<FormData | undefined> {
 	return _parseMessageFormData(request, RequestError, caller);
@@ -129,7 +129,7 @@ export function parseRequestFormData(request: Request, caller: AnyCaller = parse
  *
  * @throws {ResponseError} If the content is not `text/plain` or `application/json` with valid JSON.
  * @example const body = await parseResponseBody(response);
- * @see https://dhoulb.github.io/shelving/util/http/parseResponseBody
+ * @see https://shelving.cc/util/http/parseResponseBody
  */
 export function parseResponseBody(response: Response, caller: AnyCaller = parseResponseBody): Promise<unknown> {
 	return _parseMessageBody(response, ResponseError, caller);
@@ -143,7 +143,7 @@ export function parseResponseBody(response: Response, caller: AnyCaller = parseR
  * @returns The parsed JSON value, or `undefined` if the body is empty.
  * @throws {ResponseError} If the response body is not valid JSON.
  * @example const data = await parseResponseJSON(response);
- * @see https://dhoulb.github.io/shelving/util/http/parseResponseJSON
+ * @see https://shelving.cc/util/http/parseResponseJSON
  */
 export function parseResponseJSON(response: Response, caller: AnyCaller = parseResponseJSON): Promise<unknown> {
 	return _parseMessageJSON(response, ResponseError, caller);
@@ -157,7 +157,7 @@ export function parseResponseJSON(response: Response, caller: AnyCaller = parseR
  * @returns The parsed `FormData`.
  * @throws {ResponseError} If the response body is not valid multipart form-data.
  * @example const form = await parseResponseFormData(response);
- * @see https://dhoulb.github.io/shelving/util/http/parseResponseFormData
+ * @see https://shelving.cc/util/http/parseResponseFormData
  */
 export function parseResponseFormData(response: Response, caller: AnyCaller = parseResponseFormData): Promise<FormData> {
 	return _parseMessageFormData(response, ResponseError, caller);
@@ -172,7 +172,7 @@ export function parseResponseFormData(response: Response, caller: AnyCaller = pa
  * @param value The value to convert to a `Response`.
  * @returns A `Response` with a 2xx status, and response body as JSON (if it was set), or no body if `value` is `undefined`
  * @example getResponse({ name: "abc" }) // 200 JSON Response
- * @see https://dhoulb.github.io/shelving/util/http/getResponse
+ * @see https://shelving.cc/util/http/getResponse
  */
 export function getResponse(value: unknown): Response {
 	// If it's already a `Response`, return it directly.
@@ -199,7 +199,7 @@ export function getResponse(value: unknown): Response {
  * @param debug If `true` include the error message in the response (for debugging), or `false` to return generic error codes (for security). Defaults to `false`.
  * @returns A `Response` with a status code and (optionally) body derived from the error.
  * @example getErrorResponse("Invalid input") // 422 Response
- * @see https://dhoulb.github.io/shelving/util/http/getErrorResponse
+ * @see https://shelving.cc/util/http/getErrorResponse
  */
 export function getErrorResponse(reason: unknown, debug = false): Response {
 	// If it's already a `Response`, return it directly.
@@ -225,21 +225,21 @@ export function getErrorResponse(reason: unknown, debug = false): Response {
 /**
  * HTTP request methods that have no body.
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestHeadMethod
+ * @see https://shelving.cc/util/http/RequestHeadMethod
  */
 export type RequestHeadMethod = "HEAD" | "GET";
 
 /**
  * HTTP request methods that have a body.
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestBodyMethod
+ * @see https://shelving.cc/util/http/RequestBodyMethod
  */
 export type RequestBodyMethod = "POST" | "PUT" | "PATCH" | "DELETE";
 
 /**
  * HTTP request methods.
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestMethod
+ * @see https://shelving.cc/util/http/RequestMethod
  */
 export type RequestMethod = RequestHeadMethod | RequestBodyMethod;
 
@@ -254,7 +254,7 @@ const _REQUEST_METHODS = [..._REQUEST_HEAD_METHODS, ..._REQUEST_BODY_METHODS];
  * @param method The method string to test.
  * @returns `true` if `method` is a supported `RequestMethod`, narrowing its type.
  * @example isRequestMethod("GET") // true
- * @see https://dhoulb.github.io/shelving/util/http/isRequestMethod
+ * @see https://shelving.cc/util/http/isRequestMethod
  */
 export function isRequestMethod(method: string): method is RequestMethod {
 	return _REQUEST_METHODS.includes(method);
@@ -266,7 +266,7 @@ export function isRequestMethod(method: string): method is RequestMethod {
  * @param method The method string to test.
  * @returns `true` if `method` is a supported `RequestHeadMethod`, narrowing its type.
  * @example isRequestHeadMethod("GET") // true
- * @see https://dhoulb.github.io/shelving/util/http/isRequestHeadMethod
+ * @see https://shelving.cc/util/http/isRequestHeadMethod
  */
 export function isRequestHeadMethod(method: string): method is RequestHeadMethod {
 	return _REQUEST_HEAD_METHODS.includes(method);
@@ -275,14 +275,14 @@ export function isRequestHeadMethod(method: string): method is RequestHeadMethod
 /**
  * Params in requests are a dictionary of strings.
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestParams
+ * @see https://shelving.cc/util/http/RequestParams
  */
 export type RequestParams = ImmutableDictionary<string>;
 
 /**
  * Configurable options for endpoint requests.
  *
- * @see https://dhoulb.github.io/shelving/util/http/RequestOptions
+ * @see https://shelving.cc/util/http/RequestOptions
  */
 export type RequestOptions = Pick<
 	RequestInit,
@@ -299,7 +299,7 @@ export type RequestOptions = Pick<
  * @param b The call-level request options whose values override `a`.
  * @returns A merged `RequestOptions` with combined headers and abort signals.
  * @example mergeRequestOptions({ cache: "no-store" }, { mode: "cors" }) // { cache: "no-store", mode: "cors", ... }
- * @see https://dhoulb.github.io/shelving/util/http/mergeRequestOptions
+ * @see https://shelving.cc/util/http/mergeRequestOptions
  */
 export function mergeRequestOptions(
 	{ headers: aHeaders, signal: aSignal, ...a }: RequestOptions = {},
@@ -322,7 +322,7 @@ export function mergeRequestOptions(
  * @returns A `Request` with no body content.
  *
  * @example createHeadRequest("POST", "https://api.example.com/items", { name: "abc" })
- * @see https://dhoulb.github.io/shelving/util/http/createHeadRequest
+ * @see https://shelving.cc/util/http/createHeadRequest
  */
 export function createHeadRequest(
 	method: RequestHeadMethod,
@@ -347,7 +347,7 @@ export function createHeadRequest(
  * @returns A `Request` with `text/plain` content type.
  *
  * @example createTextRequest("POST", "https://api.example.com/items", "hello")
- * @see https://dhoulb.github.io/shelving/util/http/createTextRequest
+ * @see https://shelving.cc/util/http/createTextRequest
  */
 export function createTextRequest(
 	method: RequestMethod,
@@ -373,7 +373,7 @@ const _REQUEST_TEXT_OPTIONS = { headers: { "Content-Type": "text/plain" } };
  * @returns A `Request` with `application/json` content type.
  *
  * @example createJSONRequest("POST", "https://api.example.com/items", { name: "abc" })
- * @see https://dhoulb.github.io/shelving/util/http/createJSONRequest
+ * @see https://shelving.cc/util/http/createJSONRequest
  */
 export function createJSONRequest(
 	method: RequestBodyMethod,
@@ -402,7 +402,7 @@ const _REQUEST_JSON_OPTIONS = { headers: { "Content-Type": "application/json" } 
  * @returns A `Request` with a multipart body.
  *
  * @example createFormDataRequest("POST", "https://api.example.com/upload", new FormData())
- * @see https://dhoulb.github.io/shelving/util/http/createFormDataRequest
+ * @see https://shelving.cc/util/http/createFormDataRequest
  */
 export function createFormDataRequest(
 	method: RequestBodyMethod,
@@ -429,7 +429,7 @@ export function createFormDataRequest(
  * @throws {RequiredError} If the XML data contains invalid element names or values.
  *
  * @example createXMLRequest("POST", "https://api.example.com/items", { item: { name: "abc" } })
- * @see https://dhoulb.github.io/shelving/util/http/createXMLRequest
+ * @see https://shelving.cc/util/http/createXMLRequest
  */
 export function createXMLRequest(
 	method: RequestBodyMethod,
@@ -465,7 +465,7 @@ const _REQUEST_XML_OPTIONS = { headers: { "Content-Type": "application/xml; char
  * @throws {RequiredError} if this is a `HEAD` or `GET` request but `body` is not a data object.
  *
  * @example createRequest("POST", "https://api.example.com/items", { name: "abc" }) // JSON Request
- * @see https://dhoulb.github.io/shelving/util/http/createRequest
+ * @see https://shelving.cc/util/http/createRequest
  */
 export function createRequest(
 	method: RequestMethod,
@@ -503,7 +503,7 @@ export function createRequest(
  * @param caller Function to attribute a thrown error to (defaults to `assertRequestHeadPayload`).
  * @throws {RequiredError} If `payload` is not a data object, `null`, or `undefined`.
  * @example assertRequestHeadPayload({ q: "abc" }, "GET"); // passes
- * @see https://dhoulb.github.io/shelving/util/http/assertRequestHeadPayload
+ * @see https://shelving.cc/util/http/assertRequestHeadPayload
  */
 export function assertRequestHeadPayload(
 	payload: unknown,

--- a/modules/util/hydrate.ts
+++ b/modules/util/hydrate.ts
@@ -15,14 +15,14 @@ import { mapArray, mapProps } from "./transform.js";
  * A set of hydrations describes a set of string keys and the class constructor to be dehydrated and rehydrated.
  * - We can't use `class.name` because we don't know that the name of the class will survive minification.
  *
- * @see https://dhoulb.github.io/shelving/util/hydrate/Hydrations
+ * @see https://shelving.cc/util/hydrate/Hydrations
  */
 export type Hydrations = ImmutableDictionary<Class<unknown>>;
 
 /**
  * A dehydrated object with a `$type` key.
  *
- * @see https://dhoulb.github.io/shelving/util/hydrate/DehydratedObject
+ * @see https://shelving.cc/util/hydrate/DehydratedObject
  */
 export type DehydratedObject = { readonly $type: string; readonly $value: unknown };
 
@@ -43,7 +43,7 @@ function _isDehydrated(value: DehydratedObject | ImmutableObject): value is Dehy
  * @returns The hydrated value, with matched objects rebuilt as their class instances.
  * @throws `ValueError` If a dehydrated object's `$type` is not matched by any constructor in `hydrations`.
  * @example hydrate({ $type: "Date", $value: 0 }, {}) // Date instance
- * @see https://dhoulb.github.io/shelving/util/hydrate/hydrate
+ * @see https://shelving.cc/util/hydrate/hydrate
  */
 export function hydrate(value: unknown, hydrations: Hydrations): unknown {
 	if (isArray(value)) return mapArray(value, hydrate, hydrations);
@@ -77,7 +77,7 @@ function _hydrateProp([, v]: Entry, hydrations: Hydrations): unknown {
  * @returns The dehydrated version of the specified value.
  * @throws `ValueError` If the value is a class instance that cannot be dehydrated (i.e. is not matched by any constructor in `hydrations`).
  * @example dehydrate(new Date(0), {}) // { $type: "Date", $value: 0 }
- * @see https://dhoulb.github.io/shelving/util/hydrate/dehydrate
+ * @see https://shelving.cc/util/hydrate/dehydrate
  */
 export function dehydrate(value: unknown, hydrations: Hydrations): unknown {
 	if (isObject(value)) {

--- a/modules/util/item.ts
+++ b/modules/util/item.ts
@@ -4,49 +4,49 @@ import type { Data } from "./data.js";
 /**
  * Allowed types for the "id" property (identifier) for an item.
  *
- * @see https://dhoulb.github.io/shelving/util/item/Identifier
+ * @see https://shelving.cc/util/item/Identifier
  */
 export type Identifier = string | number;
 
 /**
  * An item object is a data object that includes an "id" identifier property that is either a string or number.
  *
- * @see https://dhoulb.github.io/shelving/util/item/Item
+ * @see https://shelving.cc/util/item/Item
  */
 export type Item<I extends Identifier = Identifier, T extends Data = Data> = { id: I } & T;
 
 /**
  * Item object, or `undefined` to indicate the item doesn't exist.
  *
- * @see https://dhoulb.github.io/shelving/util/item/OptionalItem
+ * @see https://shelving.cc/util/item/OptionalItem
  */
 export type OptionalItem<I extends Identifier = Identifier, T extends Data = Data> = Item<I, T> | undefined;
 
 /**
  * An async sequence of item objects.
  *
- * @see https://dhoulb.github.io/shelving/util/item/ItemSequence
+ * @see https://shelving.cc/util/item/ItemSequence
  */
 export type ItemSequence<I extends Identifier = Identifier, T extends Data = Data> = AsyncIterable<Item<I, T>, void, void>;
 
 /**
  * An async sequence of optional item objects.
  *
- * @see https://dhoulb.github.io/shelving/util/item/OptionalItemSequence
+ * @see https://shelving.cc/util/item/OptionalItemSequence
  */
 export type OptionalItemSequence<I extends Identifier = Identifier, T extends Data = Data> = AsyncIterable<OptionalItem<I, T>, void, void>;
 
 /**
  * An array of item objects.
  *
- * @see https://dhoulb.github.io/shelving/util/item/Items
+ * @see https://shelving.cc/util/item/Items
  */
 export type Items<I extends Identifier = Identifier, T extends Data = Data> = ImmutableArray<Item<I, T>>;
 
 /**
  * An async sequence of arrays of item objects.
  *
- * @see https://dhoulb.github.io/shelving/util/item/ItemsSequence
+ * @see https://shelving.cc/util/item/ItemsSequence
  */
 export type ItemsSequence<I extends Identifier = Identifier, T extends Data = Data> = AsyncIterable<Items<I, T>, void, void>;
 
@@ -56,7 +56,7 @@ export type ItemsSequence<I extends Identifier = Identifier, T extends Data = Da
  * @param item The item object to read the `id` from.
  * @returns The item's `id` identifier.
  * @example getIdentifier({ id: "abc", name: "Dave" }) // "abc"
- * @see https://dhoulb.github.io/shelving/util/item/getIdentifier
+ * @see https://shelving.cc/util/item/getIdentifier
  */
 export function getIdentifier<I extends Identifier, T extends Data>({ id }: Item<I, T>): I {
 	return id;
@@ -68,7 +68,7 @@ export function getIdentifier<I extends Identifier, T extends Data>({ id }: Item
  * @param entities The iterable of item objects to read identifiers from.
  * @returns An iterable yielding the `id` of each item.
  * @example Array.from(getIdentifiers([{ id: "a" }, { id: "b" }])) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/item/getIdentifiers
+ * @see https://shelving.cc/util/item/getIdentifiers
  */
 export function* getIdentifiers<I extends Identifier, T extends Data>(entities: Iterable<Item<I, T>>): Iterable<I> {
 	for (const { id } of entities) yield id;
@@ -81,7 +81,7 @@ export function* getIdentifiers<I extends Identifier, T extends Data>(entities: 
  * @param id The identifier to match against the object's `id` property.
  * @returns `true` if `item.id` equals `id`, otherwise `false`.
  * @example hasIdentifier({ id: "abc" }, "abc") // true
- * @see https://dhoulb.github.io/shelving/util/item/hasIdentifier
+ * @see https://shelving.cc/util/item/hasIdentifier
  */
 export function hasIdentifier<I extends Identifier, T extends Data>(item: T | Item<I, T>, id: I): item is Item<I, T> {
 	return item.id === id;
@@ -95,7 +95,7 @@ export function hasIdentifier<I extends Identifier, T extends Data>(item: T | It
  * @param data The data or item object to attach the identifier to.
  * @returns An item object with the given `id`.
  * @example getItem("abc", { name: "Dave" }) // { name: "Dave", id: "abc" }
- * @see https://dhoulb.github.io/shelving/util/item/getItem
+ * @see https://shelving.cc/util/item/getItem
  */
 export function getItem<I extends Identifier, T extends Data>(id: I, data: T | Item<I, T>): Item<I, T> {
 	return hasIdentifier(data, id) ? data : { ...data, id };

--- a/modules/util/iterate.ts
+++ b/modules/util/iterate.ts
@@ -3,7 +3,7 @@
  *
  * @param value The value to test.
  * @returns `true` if `value` is an object with a `Symbol.iterator` method, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/iterate/isIterable
+ * @see https://shelving.cc/util/iterate/isIterable
  */
 export function isIterable(value: unknown): value is Iterable<unknown> {
 	return typeof value === "object" && !!value && Symbol.iterator in value;
@@ -12,7 +12,7 @@ export function isIterable(value: unknown): value is Iterable<unknown> {
 /**
  * An iterable containing items or nested iterables of items.
  *
- * @see https://dhoulb.github.io/shelving/util/iterate/DeepIterable
+ * @see https://shelving.cc/util/iterate/DeepIterable
  */
 export type DeepIterable<T> = T | Iterable<DeepIterable<T>>;
 
@@ -22,7 +22,7 @@ export type DeepIterable<T> = T | Iterable<DeepIterable<T>>;
  * @param items The item or deeply-nested iterable of items to flatten.
  * @returns An iterable yielding every leaf item in order.
  * @example Array.from(flattenItems([1, [2, [3, 4]]])) // [1, 2, 3, 4]
- * @see https://dhoulb.github.io/shelving/util/iterate/flattenItems
+ * @see https://shelving.cc/util/iterate/flattenItems
  */
 export function* flattenItems<T>(items: DeepIterable<T>): Iterable<T> {
 	if (isIterable(items)) for (const item of items) yield* flattenItems(item);
@@ -36,7 +36,7 @@ export function* flattenItems<T>(items: DeepIterable<T>): Iterable<T> {
  * @param items The iterable to test.
  * @returns `true` if the iterable yields at least one item, otherwise `false`.
  * @example hasItems([1, 2, 3]) // true
- * @see https://dhoulb.github.io/shelving/util/iterate/hasItems
+ * @see https://shelving.cc/util/iterate/hasItems
  */
 export function hasItems(items: Iterable<unknown>): boolean {
 	for (const _unused of items) return true;
@@ -50,7 +50,7 @@ export function hasItems(items: Iterable<unknown>): boolean {
  * @param items The iterable to count.
  * @returns The number of items yielded by the iterable.
  * @example countItems([1, 2, 3]) // 3
- * @see https://dhoulb.github.io/shelving/util/iterate/countItems
+ * @see https://shelving.cc/util/iterate/countItems
  */
 export function countItems(items: Iterable<unknown>): number {
 	let count = 0;
@@ -67,7 +67,7 @@ export function countItems(items: Iterable<unknown>): number {
  * @param end The last number to yield (inclusive).
  * @returns An iterable yielding the numbers between `start` and `end`.
  * @example Array.from(getRange(1, 4)) // [1, 2, 3, 4]
- * @see https://dhoulb.github.io/shelving/util/iterate/getRange
+ * @see https://shelving.cc/util/iterate/getRange
  */
 export function* getRange(start: number, end: number): Iterable<number> {
 	if (start <= end) for (let num = start; num <= end; num++) yield num;
@@ -82,7 +82,7 @@ export function* getRange(start: number, end: number): Iterable<number> {
  * @param limit The maximum number of items to yield.
  * @returns An iterable yielding at most `limit` items.
  * @example Array.from(limitItems([1, 2, 3, 4], 2)) // [1, 2]
- * @see https://dhoulb.github.io/shelving/util/iterate/limitItems
+ * @see https://shelving.cc/util/iterate/limitItems
  */
 export function* limitItems<T>(items: Iterable<T>, limit: number): Iterable<T> {
 	let count = 0;
@@ -102,7 +102,7 @@ export function* limitItems<T>(items: Iterable<T>, limit: number): Iterable<T> {
  * @param pick The items to keep.
  * @returns An iterable yielding only the items found in `pick`.
  * @example Array.from(pickItems([1, 2, 3], 1, 3)) // [1, 3]
- * @see https://dhoulb.github.io/shelving/util/iterate/pickItems
+ * @see https://shelving.cc/util/iterate/pickItems
  */
 export function* pickItems<T>(items: Iterable<T>, ...pick: T[]): Iterable<T> {
 	for (const item of items) if (pick.includes(item)) yield item;
@@ -116,7 +116,7 @@ export function* pickItems<T>(items: Iterable<T>, ...pick: T[]): Iterable<T> {
  * @param omit The items to remove.
  * @returns An iterable yielding every item not found in `omit`.
  * @example Array.from(omitItems([1, 2, 3], 2)) // [1, 3]
- * @see https://dhoulb.github.io/shelving/util/iterate/omitItems
+ * @see https://shelving.cc/util/iterate/omitItems
  */
 export function* omitItems<T>(items: Iterable<T>, ...omit: T[]): Iterable<T> {
 	for (const item of items) if (!omit.includes(item)) yield item;
@@ -131,7 +131,7 @@ export function* omitItems<T>(items: Iterable<T>, ...omit: T[]): Iterable<T> {
  * @param initial The initial accumulated value.
  * @returns The final accumulated value, or `undefined` if the iterable is empty and no `initial` was given.
  * @example reduceItems([1, 2, 3], (a, b) => a + b, 0) // 6
- * @see https://dhoulb.github.io/shelving/util/iterate/reduceItems
+ * @see https://shelving.cc/util/iterate/reduceItems
  */
 export function reduceItems<T>(items: Iterable<T>, reducer: (previous: T, item: T) => T, initial: T): T;
 export function reduceItems<T>(items: Iterable<T>, reducer: (previous: T | undefined, item: T) => T, initial?: T): T | undefined;
@@ -151,7 +151,7 @@ export function reduceItems<T>(items: Iterable<T>, reducer: (previous: T | undef
  * @param size The maximum number of items per chunk.
  * @returns An iterable yielding arrays of up to `size` items.
  * @example Array.from(getChunks([1, 2, 3, 4, 5], 2)) // [[1, 2], [3, 4], [5]]
- * @see https://dhoulb.github.io/shelving/util/iterate/getChunks
+ * @see https://shelving.cc/util/iterate/getChunks
  */
 export function* getChunks<T>(items: Iterable<T>, size: number): Iterable<readonly T[]> {
 	let chunk: T[] = [];
@@ -172,7 +172,7 @@ export function* getChunks<T>(items: Iterable<T>, size: number): Iterable<readon
  * @param inputs Two or more iterables to merge.
  * @returns An iterable yielding every item from each input in sequence.
  * @example Array.from(mergeItems([1, 2], [3, 4])) // [1, 2, 3, 4]
- * @see https://dhoulb.github.io/shelving/util/iterate/mergeItems
+ * @see https://shelving.cc/util/iterate/mergeItems
  */
 export function* mergeItems<T>(...inputs: [Iterable<T>, Iterable<T>, ...Iterable<T>[]]): Iterable<T> {
 	for (const input of inputs) yield* input;
@@ -185,7 +185,7 @@ export function* mergeItems<T>(...inputs: [Iterable<T>, Iterable<T>, ...Iterable
  * @param separator The value to insert between each pair of items.
  * @returns An iterable yielding the items with `separator` between them.
  * @example Array.from(interleaveItems([1, 2, 3], 0)) // [1, 0, 2, 0, 3]
- * @see https://dhoulb.github.io/shelving/util/iterate/interleaveItems
+ * @see https://shelving.cc/util/iterate/interleaveItems
  */
 export function interleaveItems<T>(items: Iterable<T>, separator: T): Iterable<T>;
 export function interleaveItems<A, B>(items: Iterable<A>, separator: B): Iterable<A | B>;

--- a/modules/util/jwt.ts
+++ b/modules/util/jwt.ts
@@ -28,7 +28,7 @@ function _getKey(caller: AnyFunction, secret: PossibleBytes, ...usages: KeyUsage
  * Claims payload accepted when encoding a JWT.
  * - Extends `Data`, so any additional custom claims may be included alongside the standard `iat` / `nbf` / `exp` fields.
  *
- * @see https://dhoulb.github.io/shelving/util/jwt/TokenClaims
+ * @see https://shelving.cc/util/jwt/TokenClaims
  */
 export interface TokenClaims extends Data {
 	/**
@@ -59,7 +59,7 @@ export interface TokenClaims extends Data {
  * @returns A promise resolving to the signed JWT string token.
  * @throws `ValueError` If the `secret` is not a byte sequence of at least 64 bytes.
  * @example const token = await encodeToken({ sub: "user1" }, secret)
- * @see https://dhoulb.github.io/shelving/util/jwt/encodeToken
+ * @see https://shelving.cc/util/jwt/encodeToken
  */
 export async function encodeToken(
 	{ nbf = "now", iat = "now", exp = DAY * 30, ...claims }: TokenClaims,
@@ -89,7 +89,7 @@ export async function encodeToken(
 /**
  * Parts that make up a JSON Web Token — the raw encoded segments plus their decoded contents.
  *
- * @see https://dhoulb.github.io/shelving/util/jwt/TokenData
+ * @see https://shelving.cc/util/jwt/TokenData
  */
 export type TokenData = {
 	header: string;
@@ -109,7 +109,7 @@ export type TokenData = {
  * @returns A `TokenData` object with the raw segments and their decoded header, payload, and signature.
  * @throws `UnauthorizedError` If the token is malformed, or its segments are not valid Base64URL-encoded JSON.
  * @example splitToken("aaa.bbb.ccc") // { header, payload, signature, headerData, payloadData, signatureBytes }
- * @see https://dhoulb.github.io/shelving/util/jwt/splitToken
+ * @see https://shelving.cc/util/jwt/splitToken
  */
 export function splitToken(token: string, caller: AnyCaller = splitToken): TokenData {
 	// Split token.
@@ -156,7 +156,7 @@ export function splitToken(token: string, caller: AnyCaller = splitToken): Token
  * @throws `ValueError` If the `secret` is not a byte sequence of at least 64 bytes.
  * @throws `UnauthorizedError` If the token is malformed, the signature is incorrect, or the token is expired or not yet valid.
  * @example const { sub } = await verifyToken(token, secret)
- * @see https://dhoulb.github.io/shelving/util/jwt/verifyToken
+ * @see https://shelving.cc/util/jwt/verifyToken
  */
 export async function verifyToken(token: string, secret: PossibleBytes, caller: AnyCaller = verifyToken): Promise<Data> {
 	const { header, payload, signature, headerData, payloadData } = splitToken(token, caller);
@@ -190,7 +190,7 @@ export async function verifyToken(token: string, secret: PossibleBytes, caller: 
  * @param token The JWT string to set in the `Authorization` header.
  * @returns The same `Request` object that was passed in.
  * @example setRequestToken(request, token)
- * @see https://dhoulb.github.io/shelving/util/jwt/setRequestToken
+ * @see https://shelving.cc/util/jwt/setRequestToken
  */
 export function setRequestToken(request: Request, token: string): Request {
 	request.headers.set("Authorization", `Bearer ${token}`);
@@ -203,7 +203,7 @@ export function setRequestToken(request: Request, token: string): Request {
  * @param request The `Request` object possibly containing an `Authorization: Bearer {token}` header to extract the token from.
  * @returns The string token extracted from the `Authorization` header, or `undefined` if not set.
  * @example getRequestToken(request) // "eyJ..." or undefined
- * @see https://dhoulb.github.io/shelving/util/jwt/getRequestToken
+ * @see https://shelving.cc/util/jwt/getRequestToken
  */
 export function getRequestToken(request: Request): string | undefined {
 	const auth = request.headers.get("Authorization");
@@ -218,7 +218,7 @@ export function getRequestToken(request: Request): string | undefined {
  * @returns The string token extracted from the `Authorization` header.
  * @throws `UnauthorizedError` If the `Authorization` header is not set, or the JWT it contains is not well-formed.
  * @example requireRequestToken(request) // "eyJ..."
- * @see https://dhoulb.github.io/shelving/util/jwt/requireRequestToken
+ * @see https://shelving.cc/util/jwt/requireRequestToken
  */
 export function requireRequestToken(request: Request, caller: AnyCaller = requireRequestToken): string {
 	const token = getRequestToken(request);
@@ -236,7 +236,7 @@ export function requireRequestToken(request: Request, caller: AnyCaller = requir
  * @returns A promise resolving to the decoded payload data from the JWT.
  * @throws `UnauthorizedError` If the `Authorization` header is not set, the JWT it contains is not well-formed, or the JWT signature is invalid.
  * @example const { sub, iss, customClaim } = await verifyRequestToken(request, secret)
- * @see https://dhoulb.github.io/shelving/util/jwt/verifyRequestToken
+ * @see https://shelving.cc/util/jwt/verifyRequestToken
  */
 export function verifyRequestToken(request: Request, secret: PossibleBytes, caller: AnyCaller = verifyRequestToken): Promise<Data> {
 	const token = requireRequestToken(request, caller);

--- a/modules/util/lazy.ts
+++ b/modules/util/lazy.ts
@@ -4,7 +4,7 @@ import { isFunction } from "./function.js";
 /**
  * Lazy value: a plain value, or an initialiser function that returns that value.
  *
- * @see https://dhoulb.github.io/shelving/util/lazy/Lazy
+ * @see https://shelving.cc/util/lazy/Lazy
  */
 export type Lazy<T, A extends Arguments = []> = ((...args: A) => T) | T;
 
@@ -18,7 +18,7 @@ export type Lazy<T, A extends Arguments = []> = ((...args: A) => T) | T;
  * @returns The resolved value.
  * @example getLazy(() => 123) // 123
  * @example getLazy(123) // 123
- * @see https://dhoulb.github.io/shelving/util/lazy/getLazy
+ * @see https://shelving.cc/util/lazy/getLazy
  */
 export function getLazy<T, A extends Arguments>(value: (...args: A) => T, ...args: A): T; // Generics flow through this overload better than using `Lazy`
 export function getLazy<T, A extends Arguments>(value: Lazy<T, A>, ...args: A): T;

--- a/modules/util/link.ts
+++ b/modules/util/link.ts
@@ -8,7 +8,7 @@ import { getBasedURI, getURL, type ImmutableURL } from "./url.js";
 /**
  * Anything that can be turned into an `<a href>`.
  *
- * @see https://dhoulb.github.io/shelving/util/link/PossibleLink
+ * @see https://shelving.cc/util/link/PossibleLink
  */
 export type PossibleLink = PossibleURI;
 
@@ -34,7 +34,7 @@ export type PossibleLink = PossibleURI;
  * @example getLink("/schema", pageURL, siteRoot) // → "https://x.com/app/schema" when siteRoot is "https://x.com/app/"
  * @example getLink("./db", new URL("https://x.com/app/schema/")) // → "https://x.com/app/schema/db"
  * @example getLink("mailto:a@b") // → "mailto:a@b"
- * @see https://dhoulb.github.io/shelving/util/link/getLink
+ * @see https://shelving.cc/util/link/getLink
  */
 export function getLink(href: Nullish<PossibleLink>, url?: ImmutableURL, root: ImmutableURL | undefined = url): ImmutableURI | undefined {
 	if (!href) return;
@@ -57,7 +57,7 @@ export function getLink(href: Nullish<PossibleLink>, url?: ImmutableURL, root: I
  * @returns An absolute URI string.
  * @throws {RequiredError} If `href` cannot be resolved.
  * @example requireLink("mailto:a@b") // → "mailto:a@b"
- * @see https://dhoulb.github.io/shelving/util/link/requireLink
+ * @see https://shelving.cc/util/link/requireLink
  */
 export function requireLink(href: PossibleLink, url?: ImmutableURL, root?: ImmutableURL, caller: AnyCaller = requireLink): ImmutableURI {
 	const uri = getLink(href, url, root);

--- a/modules/util/log.ts
+++ b/modules/util/log.ts
@@ -9,7 +9,7 @@ import { debug, debugFullRequest, debugFullResponse, debugRequest } from "./debu
  * @param request The `Request` to log.
  * @returns A promise that resolves once the request has been logged.
  * @example await logRequest(request)
- * @see https://dhoulb.github.io/shelving/util/log/logRequest
+ * @see https://shelving.cc/util/log/logRequest
  */
 export async function logRequest(request: Request) {
 	console.log(`${ANSI_RIGHT} ${await debugFullRequest(request)}`);
@@ -22,7 +22,7 @@ export async function logRequest(request: Request) {
  * @param request The originating `Request`, included in the log for context.
  * @returns A promise that resolves once the response has been logged.
  * @example await logRequestResponse(response, request)
- * @see https://dhoulb.github.io/shelving/util/log/logRequestResponse
+ * @see https://shelving.cc/util/log/logRequestResponse
  */
 export async function logRequestResponse(response: Response, request: Request): Promise<void> {
 	console.log(`${ANSI_LEFT} ${debugRequest(request)}\n\n${await debugFullResponse(response)}`);
@@ -35,7 +35,7 @@ export async function logRequestResponse(response: Response, request: Request): 
  * @param request The originating `Request`, included in the log for context.
  * @returns Nothing.
  * @example logRequestError(error, request)
- * @see https://dhoulb.github.io/shelving/util/log/logRequestError
+ * @see https://shelving.cc/util/log/logRequestError
  */
 export function logRequestError(reason: unknown, request: Request): void {
 	console.error(`${ANSI_FAILURE} ${debugRequest(request)}\n\n${debug(reason)}`);

--- a/modules/util/map.ts
+++ b/modules/util/map.ts
@@ -6,56 +6,56 @@ import { isIterable, limitItems } from "./iterate.js";
 /**
  * `Map` that cannot be changed.
  *
- * @see https://dhoulb.github.io/shelving/util/map/ImmutableMap
+ * @see https://shelving.cc/util/map/ImmutableMap
  */
 export type ImmutableMap<K = unknown, T = unknown> = ReadonlyMap<K, T>;
 
 /**
  * Class for a `Map` that cannot be changed (so you can extend `Map` while implementing `ImmutableMap`).
  *
- * @see https://dhoulb.github.io/shelving/util/map/ImmutableMap
+ * @see https://shelving.cc/util/map/ImmutableMap
  */
 export const ImmutableMap: { new <K, T>(...params: ConstructorParameters<typeof Map<K, T>>): ImmutableMap<K, T> } = Map;
 
 /**
  * `Map` that can be changed.
  *
- * @see https://dhoulb.github.io/shelving/util/map/MutableMap
+ * @see https://shelving.cc/util/map/MutableMap
  */
 export type MutableMap<K = unknown, T = unknown> = Map<K, T>;
 
 /**
  * Extract the type for the key of a map.
  *
- * @see https://dhoulb.github.io/shelving/util/map/MapKey
+ * @see https://shelving.cc/util/map/MapKey
  */
 export type MapKey<X> = X extends ReadonlyMap<infer Y, unknown> ? Y : never;
 
 /**
  * Extract the type for the value of a map.
  *
- * @see https://dhoulb.github.io/shelving/util/map/MapValue
+ * @see https://shelving.cc/util/map/MapValue
  */
 export type MapValue<X> = X extends ReadonlyMap<unknown, infer Y> ? Y : never;
 
 /**
  * Get the type for an item of a map in entry format.
  *
- * @see https://dhoulb.github.io/shelving/util/map/MapItem
+ * @see https://shelving.cc/util/map/MapItem
  */
 export type MapItem<T extends ImmutableMap> = readonly [MapKey<T>, MapValue<T>];
 
 /**
  * Things that can be converted to maps.
  *
- * @see https://dhoulb.github.io/shelving/util/map/PossibleMap
+ * @see https://shelving.cc/util/map/PossibleMap
  */
 export type PossibleMap<K, T> = ImmutableMap<K, T> | Iterable<Entry<K, T>>;
 
 /**
  * Things that can be converted to maps with string keys.
  *
- * @see https://dhoulb.github.io/shelving/util/map/PossibleStringMap
+ * @see https://shelving.cc/util/map/PossibleStringMap
  */
 export type PossibleStringMap<K extends string, T> = PossibleMap<K, T> | { readonly [KK in K]: T };
 
@@ -65,7 +65,7 @@ export type PossibleStringMap<K extends string, T> = PossibleMap<K, T> | { reado
  * @param value The value to test.
  * @returns `true` if `value` is a `Map` instance, otherwise `false`.
  * @example isMap(new Map()) // true
- * @see https://dhoulb.github.io/shelving/util/map/isMap
+ * @see https://shelving.cc/util/map/isMap
  */
 export function isMap(value: unknown): value is ImmutableMap {
 	return value instanceof Map;
@@ -79,7 +79,7 @@ export function isMap(value: unknown): value is ImmutableMap {
  * @returns Nothing; narrows `value` to `ImmutableMap`.
  * @throws {RequiredError} If `value` is not a `Map` instance.
  * @example assertMap(new Map()); // passes
- * @see https://dhoulb.github.io/shelving/util/map/assertMap
+ * @see https://shelving.cc/util/map/assertMap
  */
 export function assertMap(value: unknown, caller: AnyCaller = assertMap): asserts value is ImmutableMap {
 	if (!isMap(value)) throw new RequiredError("Must be map", { received: value, caller });
@@ -91,7 +91,7 @@ export function assertMap(value: unknown, caller: AnyCaller = assertMap): assert
  * @param input The map, object, or iterable of entries to convert.
  * @returns An `ImmutableMap` — the input unchanged if it's already a `Map`, otherwise a new `Map`.
  * @example getMap({ a: 1, b: 2 }) // Map { "a" => 1, "b" => 2 }
- * @see https://dhoulb.github.io/shelving/util/map/getMap
+ * @see https://shelving.cc/util/map/getMap
  */
 export function getMap<K extends string, T>(input: PossibleStringMap<K, T>): ImmutableMap<K, T>;
 export function getMap<K, T>(input: PossibleMap<K, T>): ImmutableMap<K, T>;
@@ -107,7 +107,7 @@ export function getMap(input: PossibleMap<unknown, unknown> | { readonly [key: s
  * @param limit The maximum number of items to keep.
  * @returns An `ImmutableMap` with at most `limit` items (the input map unchanged if it already fits).
  * @example limitMap(new Map([["a", 1], ["b", 2]]), 1) // Map { "a" => 1 }
- * @see https://dhoulb.github.io/shelving/util/map/limitMap
+ * @see https://shelving.cc/util/map/limitMap
  */
 export function limitMap<T>(map: ImmutableMap<T>, limit: number): ImmutableMap<T> {
 	return limit > map.size ? map : new Map(limitItems(map, limit));
@@ -120,7 +120,7 @@ export function limitMap<T>(map: ImmutableMap<T>, limit: number): ImmutableMap<T
  * @param key The candidate key to test.
  * @returns `true` if `key` exists in `map`, otherwise `false`.
  * @example isMapItem(new Map([["a", 1]]), "a") // true
- * @see https://dhoulb.github.io/shelving/util/map/isMapItem
+ * @see https://shelving.cc/util/map/isMapItem
  */
 export function isMapItem<K, V>(map: ImmutableMap<K, V>, key: unknown): key is K {
 	return map.has(key as K);
@@ -135,7 +135,7 @@ export function isMapItem<K, V>(map: ImmutableMap<K, V>, key: unknown): key is K
  * @returns Nothing; narrows `key` to the map's key type.
  * @throws {RequiredError} If `key` does not exist in `map`.
  * @example assertMapItem(new Map([["a", 1]]), "a"); // passes
- * @see https://dhoulb.github.io/shelving/util/map/assertMapItem
+ * @see https://shelving.cc/util/map/assertMapItem
  */
 export function assertMapItem<K, V>(map: ImmutableMap<K, V>, key: unknown, caller: AnyCaller = assertMapItem): asserts key is K {
 	if (!isMapItem(map, key)) throw new RequiredError("Key must exist in map", { key, map, caller });
@@ -149,7 +149,7 @@ export function assertMapItem<K, V>(map: ImmutableMap<K, V>, key: unknown, calle
  * @param value The value to set.
  * @returns The `value` that was set.
  * @example setMapItem(map, "a", 1) // 1
- * @see https://dhoulb.github.io/shelving/util/map/setMapItem
+ * @see https://shelving.cc/util/map/setMapItem
  */
 export function setMapItem<K, T>(map: MutableMap<K, T>, key: K, value: T): T {
 	map.set(key, value);
@@ -163,7 +163,7 @@ export function setMapItem<K, T>(map: MutableMap<K, T>, key: K, value: T): T {
  * @param items Iterable of key/value entries to set.
  * @returns Nothing; mutates `map` in place.
  * @example setMapItems(map, [["a", 1], ["b", 2]]);
- * @see https://dhoulb.github.io/shelving/util/map/setMapItems
+ * @see https://shelving.cc/util/map/setMapItems
  */
 export function setMapItems<K, T>(map: MutableMap<K, T>, items: Iterable<MapItem<ImmutableMap<K, T>>>): void {
 	for (const [k, v] of items) map.set(k, v);
@@ -176,7 +176,7 @@ export function setMapItems<K, T>(map: MutableMap<K, T>, items: Iterable<MapItem
  * @param keys The keys to delete.
  * @returns Nothing; mutates `map` in place.
  * @example removeMapItems(map, "a", "b");
- * @see https://dhoulb.github.io/shelving/util/map/removeMapItems
+ * @see https://shelving.cc/util/map/removeMapItems
  */
 export function removeMapItems<K, T>(map: MutableMap<K, T>, ...keys: K[]): void {
 	for (const key of keys) map.delete(key);
@@ -189,7 +189,7 @@ export function removeMapItems<K, T>(map: MutableMap<K, T>, ...keys: K[]): void 
  * @param key The key to look up.
  * @returns The value for `key`, or `undefined` if it doesn't exist.
  * @example getMapItem(new Map([["a", 1]]), "a") // 1
- * @see https://dhoulb.github.io/shelving/util/map/getMapItem
+ * @see https://shelving.cc/util/map/getMapItem
  */
 export function getMapItem<K, T>(map: ImmutableMap<K, T>, key: K): T | undefined {
 	return map.get(key);
@@ -204,7 +204,7 @@ export function getMapItem<K, T>(map: ImmutableMap<K, T>, key: K): T | undefined
  * @returns The value for `key`.
  * @throws {RequiredError} If `key` does not exist in `map`.
  * @example requireMapItem(new Map([["a", 1]]), "a") // 1
- * @see https://dhoulb.github.io/shelving/util/map/requireMapItem
+ * @see https://shelving.cc/util/map/requireMapItem
  */
 export function requireMapItem<K, T>(map: ImmutableMap<K, T>, key: K, caller: AnyCaller = requireMapItem): T {
 	if (!map.has(key)) throw new RequiredError("Key must exist in map", { key, map, caller });

--- a/modules/util/merge.ts
+++ b/modules/util/merge.ts
@@ -21,7 +21,7 @@ function _merge(left: unknown, right: unknown, recursor: MergeRecursor) {
  * @param right The right value.
  * @returns The `right` value, always.
  * @example exactMerge(1, 2) // 2
- * @see https://dhoulb.github.io/shelving/util/merge/exactMerge
+ * @see https://shelving.cc/util/merge/exactMerge
  */
 export function exactMerge(_left: unknown, right: unknown): unknown {
 	return right;
@@ -40,7 +40,7 @@ export function exactMerge(_left: unknown, right: unknown): unknown {
  * - Will be `left` instance if no properties/items changed.
  * - Will be merged instance otherwise.
  * @example shallowMerge({ a: 1 }, { b: 2 }) // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/merge/shallowMerge
+ * @see https://shelving.cc/util/merge/shallowMerge
  */
 export function shallowMerge<L extends ImmutableObject, R extends ImmutableObject>(left: L, right: R): L & R;
 export function shallowMerge<L, R>(left: ImmutableArray<L>, right: ImmutableArray<R>): ImmutableArray<L | R>;
@@ -62,7 +62,7 @@ export function shallowMerge(left: unknown, right: unknown): unknown {
  * - Will be `left` instance if no properties/items changed.
  * - Will be a new merged instance otherwise.
  * @example deepMerge({ a: { b: 1 } }, { a: { c: 2 } }) // { a: { b: 1, c: 2 } }
- * @see https://dhoulb.github.io/shelving/util/merge/deepMerge
+ * @see https://shelving.cc/util/merge/deepMerge
  */
 export function deepMerge<L extends ImmutableObject, R extends ImmutableObject>(left: L, right: R): L & R;
 export function deepMerge<L, R>(left: ImmutableArray<L>, right: ImmutableArray<R>): ImmutableArray<L | R>;
@@ -84,7 +84,7 @@ export function deepMerge(left: unknown, right: unknown): unknown {
  * - Will be `left` instance if no items were added.
  * - Will be a new merged array otherwise.
  * @example mergeArray([1, 2], [2, 3]) // [1, 2, 3]
- * @see https://dhoulb.github.io/shelving/util/merge/mergeArray
+ * @see https://shelving.cc/util/merge/mergeArray
  */
 export function mergeArray<L, R>(left: ImmutableArray<L>, right: ImmutableArray<R> | ImmutableArray<L>): ImmutableArray<L | R>;
 export function mergeArray(left: ImmutableArray, right: ImmutableArray): ImmutableArray {
@@ -113,7 +113,7 @@ export function mergeArray(left: ImmutableArray, right: ImmutableArray): Immutab
  * - Will be `left` instance if no properties changed.
  * - Will be a new merged object otherwise.
  * @example mergeObject({ a: 1 }, { b: 2 }) // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/merge/mergeObject
+ * @see https://shelving.cc/util/merge/mergeObject
  */
 export function mergeObject<L extends ImmutableObject, R extends ImmutableObject>(left: L, right: R, recursor?: MergeRecursor): L & R;
 export function mergeObject(left: ImmutableObject, right: ImmutableObject, recursor: MergeRecursor = exactMerge): ImmutableObject {

--- a/modules/util/null.ts
+++ b/modules/util/null.ts
@@ -7,7 +7,7 @@ import type { AnyCaller } from "./function.js";
  *
  * @returns `null`, always.
  * @example getNull() // null
- * @see https://dhoulb.github.io/shelving/util/null/getNull
+ * @see https://shelving.cc/util/null/getNull
  */
 export function getNull(): null {
 	return null;
@@ -16,7 +16,7 @@ export function getNull(): null {
 /**
  * Nullable is the value or `null`.
  *
- * @see https://dhoulb.github.io/shelving/util/null/Nullable
+ * @see https://shelving.cc/util/null/Nullable
  */
 export type Nullable<T> = T | null;
 
@@ -25,7 +25,7 @@ export type Nullable<T> = T | null;
  *
  * @param value The value to test.
  * @returns `true` if `value` is `null`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/null/isNull
+ * @see https://shelving.cc/util/null/isNull
  */
 export function isNull(value: unknown): value is null {
 	return value === null;
@@ -38,7 +38,7 @@ export function isNull(value: unknown): value is null {
  * @param caller Function used to attribute a thrown error to the calling site.
  * @returns Nothing; narrows `value` to `T`.
  * @throws `RequiredError` if `value` is not `null`.
- * @see https://dhoulb.github.io/shelving/util/null/assertNull
+ * @see https://shelving.cc/util/null/assertNull
  */
 export function assertNull<T>(value: Nullable<T>, caller: AnyCaller = assertNull): asserts value is T {
 	if (value !== null) throw new RequiredError("Must be null", { received: value, caller });
@@ -49,7 +49,7 @@ export function assertNull<T>(value: Nullable<T>, caller: AnyCaller = assertNull
  *
  * @param value The value to test.
  * @returns `true` if `value` is not `null`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/null/notNull
+ * @see https://shelving.cc/util/null/notNull
  */
 export function notNull<T>(value: Nullable<T>): value is T {
 	return value !== null;
@@ -62,7 +62,7 @@ export function notNull<T>(value: Nullable<T>): value is T {
  * @param caller Function used to attribute a thrown error to the calling site.
  * @returns Nothing; narrows `value` to `T`.
  * @throws `RequiredError` if `value` is `null`.
- * @see https://dhoulb.github.io/shelving/util/null/assertNotNull
+ * @see https://shelving.cc/util/null/assertNotNull
  */
 export function assertNotNull<T>(value: Nullable<T>, caller: AnyCaller = assertNotNull): asserts value is T {
 	if (value === null) throw new RequiredError("Must not be null", { received: value, caller });
@@ -76,7 +76,7 @@ export function assertNotNull<T>(value: Nullable<T>, caller: AnyCaller = assertN
  * @returns The value, narrowed to `T`.
  * @throws RequiredError if `value` is `null`.
  * @example requireNotNull("a") // "a"
- * @see https://dhoulb.github.io/shelving/util/null/requireNotNull
+ * @see https://shelving.cc/util/null/requireNotNull
  */
 export function requireNotNull<T>(value: Nullable<T>, caller: AnyCaller = requireNotNull): T {
 	assertNotNull(value, caller);
@@ -86,7 +86,7 @@ export function requireNotNull<T>(value: Nullable<T>, caller: AnyCaller = requir
 /**
  * Nullish is the value or `null` or `undefined`.
  *
- * @see https://dhoulb.github.io/shelving/util/null/Nullish
+ * @see https://shelving.cc/util/null/Nullish
  */
 export type Nullish<T> = T | null | undefined;
 
@@ -95,7 +95,7 @@ export type Nullish<T> = T | null | undefined;
  *
  * @param value The value to test.
  * @returns `true` if `value` is `null` or `undefined`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/null/isNullish
+ * @see https://shelving.cc/util/null/isNullish
  */
 export function isNullish<T>(value: Nullish<T>): value is null | undefined {
 	return value === null || value === undefined;
@@ -108,7 +108,7 @@ export function isNullish<T>(value: Nullish<T>): value is null | undefined {
  * @param caller Function used to attribute a thrown error to the calling site.
  * @returns Nothing; narrows `value` to `T`.
  * @throws `RequiredError` if `value` is not `null` or `undefined`.
- * @see https://dhoulb.github.io/shelving/util/null/assertNullish
+ * @see https://shelving.cc/util/null/assertNullish
  */
 export function assertNullish<T>(value: Nullish<T>, caller: AnyCaller = assertNullish): asserts value is T {
 	if (value !== null && value !== undefined) throw new RequiredError("Must be null or undefined", { received: value, caller });
@@ -119,7 +119,7 @@ export function assertNullish<T>(value: Nullish<T>, caller: AnyCaller = assertNu
  *
  * @param value The value to test.
  * @returns `true` if `value` is not `null` and not `undefined`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/null/notNullish
+ * @see https://shelving.cc/util/null/notNullish
  */
 export function notNullish<T>(value: Nullish<T>): value is T {
 	return value !== null && value !== undefined;
@@ -132,7 +132,7 @@ export function notNullish<T>(value: Nullish<T>): value is T {
  * @param caller Function used to attribute a thrown error to the calling site.
  * @returns Nothing; narrows `value` to `T`.
  * @throws `RequiredError` if `value` is `null` or `undefined`.
- * @see https://dhoulb.github.io/shelving/util/null/assertNotNullish
+ * @see https://shelving.cc/util/null/assertNotNullish
  */
 export function assertNotNullish<T>(value: Nullish<T>, caller: AnyCaller = assertNotNullish): asserts value is T {
 	if (value === null || value === undefined) throw new RequiredError("Must not be null or undefined", { received: value, caller });
@@ -146,7 +146,7 @@ export function assertNotNullish<T>(value: Nullish<T>, caller: AnyCaller = asser
  * @returns The value, narrowed to `T`.
  * @throws RequiredError if `value` is `null` or `undefined`.
  * @example requireNotNullish("a") // "a"
- * @see https://dhoulb.github.io/shelving/util/null/requireNotNullish
+ * @see https://shelving.cc/util/null/requireNotNullish
  */
 export function requireNotNullish<T>(value: Nullish<T>, caller: AnyCaller = requireNotNullish): T {
 	assertNotNullish(value, caller);

--- a/modules/util/number.ts
+++ b/modules/util/number.ts
@@ -5,7 +5,7 @@ import type { AnyCaller } from "./function.js";
 /**
  * Values that can be converted to a number.
  *
- * @see https://dhoulb.github.io/shelving/util/number/PossibleNumber
+ * @see https://shelving.cc/util/number/PossibleNumber
  */
 export type PossibleNumber = number | string | Date;
 
@@ -17,7 +17,7 @@ export type PossibleNumber = number | string | Date;
  * @param max Maximum allowed value, inclusive (defaults to `+Infinity`).
  * @returns `true` if `value` is a finite number within range, otherwise `false`.
  * @example isNumber(17, 10, 20) // true
- * @see https://dhoulb.github.io/shelving/util/number/isNumber
+ * @see https://shelving.cc/util/number/isNumber
  */
 export function isNumber(value: unknown, min = Number.NEGATIVE_INFINITY, max = Number.POSITIVE_INFINITY): value is number {
 	return Number.isFinite(value) && (value as number) >= min && (value as number) <= max;
@@ -33,7 +33,7 @@ export function isNumber(value: unknown, min = Number.NEGATIVE_INFINITY, max = N
  * @returns Nothing; narrows `value` to `number`.
  * @throws `RequiredError` if `value` is not a finite number within range.
  * @example assertNumber(5, 0, 10); // passes
- * @see https://dhoulb.github.io/shelving/util/number/assertNumber
+ * @see https://shelving.cc/util/number/assertNumber
  */
 export function assertNumber(value: unknown, min?: number, max?: number, caller: AnyCaller = assertNumber): asserts value is number {
 	if (!isNumber(value, min, max))
@@ -57,7 +57,7 @@ export function assertNumber(value: unknown, min?: number, max?: number, caller:
  * @param value The value to convert.
  * @returns The finite number, or `undefined` if `value` cannot be converted.
  * @example getNumber("1.5kg") // 1.5
- * @see https://dhoulb.github.io/shelving/util/number/getNumber
+ * @see https://shelving.cc/util/number/getNumber
  */
 export function getNumber(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isFinite(value)) return value === 0 ? 0 : value;
@@ -76,7 +76,7 @@ const NOT_NUMERIC_REGEXP = /[^0-9-.]/g;
  * @returns The finite number.
  * @throws `RequiredError` if `value` cannot be converted to a finite number within range.
  * @example requireNumber("42") // 42
- * @see https://dhoulb.github.io/shelving/util/number/requireNumber
+ * @see https://shelving.cc/util/number/requireNumber
  */
 export function requireNumber(value: PossibleNumber, min?: number, max?: number, caller?: AnyCaller): number {
 	const num = getNumber(value);
@@ -92,7 +92,7 @@ export function requireNumber(value: PossibleNumber, min?: number, max?: number,
  * @param max Maximum allowed value, inclusive (defaults to `Number.MAX_SAFE_INTEGER`).
  * @returns `true` if `value` is an integer within range, otherwise `false`.
  * @example isInteger(5, 0, 10) // true
- * @see https://dhoulb.github.io/shelving/util/number/isInteger
+ * @see https://shelving.cc/util/number/isInteger
  */
 export function isInteger(value: unknown, min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER): value is number {
 	return Number.isInteger(value) && (value as number) >= min && (value as number) <= max;
@@ -108,7 +108,7 @@ export function isInteger(value: unknown, min = Number.MIN_SAFE_INTEGER, max = N
  * @returns Nothing; narrows `value` to `number`.
  * @throws `RequiredError` if `value` is not an integer within range.
  * @example assertInteger(5, 0, 10); // passes
- * @see https://dhoulb.github.io/shelving/util/number/assertInteger
+ * @see https://shelving.cc/util/number/assertInteger
  */
 export function assertInteger(value: unknown, min?: number, max?: number, caller: AnyCaller = assertInteger): asserts value is number {
 	if (!isInteger(value, min, max))
@@ -131,7 +131,7 @@ export function assertInteger(value: unknown, min?: number, max?: number, caller
  * @param value The value to convert.
  * @returns The integer, or `undefined` if `value` cannot be converted.
  * @example getInteger("42px") // 42
- * @see https://dhoulb.github.io/shelving/util/number/getInteger
+ * @see https://shelving.cc/util/number/getInteger
  */
 export function getInteger(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isInteger(value)) return value === 0 ? 0 : value;
@@ -149,7 +149,7 @@ export function getInteger(value: unknown): number | undefined {
  * @returns The integer.
  * @throws `RequiredError` if `value` cannot be converted to an integer within range.
  * @example requireInteger("42") // 42
- * @see https://dhoulb.github.io/shelving/util/number/requireInteger
+ * @see https://shelving.cc/util/number/requireInteger
  */
 export function requireInteger(value: PossibleNumber, min?: number, max?: number, caller: AnyCaller = requireInteger): number {
 	const num = getNumber(value);
@@ -165,7 +165,7 @@ export function requireInteger(value: PossibleNumber, min?: number, max?: number
  * @param max The end of the range, e.g. `20`
  * @returns `true` if `num` is between `min` and `max` (inclusive), otherwise `false`.
  * @example isBetween(17, 10, 20) // true
- * @see https://dhoulb.github.io/shelving/util/number/isBetween
+ * @see https://shelving.cc/util/number/isBetween
  */
 export function isBetween(num: number, min: number, max: number): boolean {
 	return num >= min && num <= max;
@@ -179,7 +179,7 @@ export function isBetween(num: number, min: number, max: number): boolean {
  *
  * @returns The number rounded to the specified step.
  * @example roundStep(17, 5) // 15
- * @see https://dhoulb.github.io/shelving/util/number/roundStep
+ * @see https://shelving.cc/util/number/roundStep
  */
 export function roundStep(num: number, step = 1): number {
 	return Math.round(num / step) * step;
@@ -195,7 +195,7 @@ export function roundStep(num: number, step = 1): number {
  *
  * @returns The number rounded to the specified precision.
  * @example roundNumber(1.2345, 2) // 1.23
- * @see https://dhoulb.github.io/shelving/util/number/roundNumber
+ * @see https://shelving.cc/util/number/roundNumber
  */
 export function roundNumber(num: number, precision = 0): number {
 	return Math.round(num * 10 ** precision) / 10 ** precision;
@@ -209,7 +209,7 @@ export function roundNumber(num: number, precision = 0): number {
  * @param precision Maximum number of digits shown after the decimal point (defaults to 0).
  * @returns The number truncated to the specified precision.
  * @example truncateNumber(1.2999, 2) // 1.29
- * @see https://dhoulb.github.io/shelving/util/number/truncateNumber
+ * @see https://shelving.cc/util/number/truncateNumber
  */
 export function truncateNumber(num: number, precision = 0): number {
 	return Math.trunc(num * 10 ** precision) / 10 ** precision;
@@ -225,7 +225,7 @@ export function truncateNumber(num: number, precision = 0): number {
  * @returns `num` clamped to lie between `min` and `max`.
  * @throws `ValueError` if `max` is less than `min`.
  * @example boundNumber(12, 2, 8) // 8
- * @see https://dhoulb.github.io/shelving/util/number/boundNumber
+ * @see https://shelving.cc/util/number/boundNumber
  */
 export function boundNumber(num: number, min: number, max: number): number {
 	if (max < min) throw new ValueError("Max must be more than min", { min, max, caller: wrapNumber });
@@ -245,7 +245,7 @@ export function boundNumber(num: number, min: number, max: number): number {
  * @returns `num` wrapped to lie between `min` and `max`.
  * @throws `ValueError` if `max` is less than `min`.
  * @example wrapNumber(12, 2, 8) // 6
- * @see https://dhoulb.github.io/shelving/util/number/wrapNumber
+ * @see https://shelving.cc/util/number/wrapNumber
  */
 export function wrapNumber(num: number, min: number, max: number): number {
 	if (max < min) throw new ValueError("Max must be more than min", { min, max, caller: wrapNumber });
@@ -261,7 +261,7 @@ export function wrapNumber(num: number, min: number, max: number): number {
  * @param denumerator The number representing the whole amount (defaults to 100).
  * @returns `numerator` expressed as a percentage of `denumerator`.
  * @example getPercent(1, 4) // 25
- * @see https://dhoulb.github.io/shelving/util/number/getPercent
+ * @see https://shelving.cc/util/number/getPercent
  */
 export function getPercent(numerator: number, denumerator = 100) {
 	return denumerator === 100 ? numerator : (100 / denumerator) * numerator;
@@ -273,7 +273,7 @@ export function getPercent(numerator: number, denumerator = 100) {
  * @param nums The iterable of numbers to sum.
  * @returns The total of all the numbers (`0` if `nums` is empty).
  * @example sumNumbers([1, 2, 3]) // 6
- * @see https://dhoulb.github.io/shelving/util/number/sumNumbers
+ * @see https://shelving.cc/util/number/sumNumbers
  */
 export function sumNumbers(nums: Iterable<number>): number {
 	let sum = 0;
@@ -288,7 +288,7 @@ export function sumNumbers(nums: Iterable<number>): number {
  * @param target The target number to find the closest match for.
  * @returns The number closest to `target`, or `undefined` if `nums` is empty.
  * @example getClosestNumber([1, 5, 10], 6) // 5
- * @see https://dhoulb.github.io/shelving/util/number/getClosestNumber
+ * @see https://shelving.cc/util/number/getClosestNumber
  */
 export function getClosestNumber<T extends number>(nums: Iterable<T>, target: number): T | undefined {
 	let closest: T | undefined;

--- a/modules/util/object.ts
+++ b/modules/util/object.ts
@@ -5,35 +5,35 @@ import { isIterable } from "./iterate.js";
 /**
  * Any readonly object.
  *
- * @see https://dhoulb.github.io/shelving/util/object/ImmutableObject
+ * @see https://shelving.cc/util/object/ImmutableObject
  */
 export type ImmutableObject<K extends PropertyKey = PropertyKey, T = unknown> = { readonly [KK in K]: T };
 
 /**
  * Any writable object.
  *
- * @see https://dhoulb.github.io/shelving/util/object/MutableObject
+ * @see https://shelving.cc/util/object/MutableObject
  */
 export type MutableObject<K extends PropertyKey = PropertyKey, T = unknown> = { [KK in K]: T };
 
 /**
  * Prop for an object, as a readonly key/value entry tuple.
  *
- * @see https://dhoulb.github.io/shelving/util/object/Prop
+ * @see https://shelving.cc/util/object/Prop
  */
 export type Prop<T> = readonly [keyof T, T[keyof T]];
 
 /**
  * Key for an object prop.
  *
- * @see https://dhoulb.github.io/shelving/util/object/Key
+ * @see https://shelving.cc/util/object/Key
  */
 export type Key<T> = keyof T;
 
 /**
  * Value for an object prop.
  *
- * @see https://dhoulb.github.io/shelving/util/object/Value
+ * @see https://shelving.cc/util/object/Value
  */
 export type Value<T> = T[keyof T];
 
@@ -41,7 +41,7 @@ export type Value<T> = T[keyof T];
  * Something that can be converted to an object.
  * - Either the object itself, or an iterable set of key/value entry tuples.
  *
- * @see https://dhoulb.github.io/shelving/util/object/PossibleObject
+ * @see https://shelving.cc/util/object/PossibleObject
  */
 export type PossibleObject<T> = T | Iterable<Prop<T>>;
 
@@ -50,7 +50,7 @@ export type PossibleObject<T> = T | Iterable<Prop<T>>;
  *
  * @param value The value to test.
  * @returns `true` if `value` is a non-null `object`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/object/isObject
+ * @see https://shelving.cc/util/object/isObject
  */
 export function isObject(value: unknown): value is ImmutableObject {
 	return typeof value === "object" && value !== null;
@@ -61,7 +61,7 @@ export function isObject(value: unknown): value is ImmutableObject {
  *
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not an `object`.
- * @see https://dhoulb.github.io/shelving/util/object/assertObject
+ * @see https://shelving.cc/util/object/assertObject
  */
 export function assertObject(value: unknown): asserts value is ImmutableObject {
 	if (!isObject(value)) throw new RequiredError("Must be object", { received: value, caller: assertObject });
@@ -73,7 +73,7 @@ export function assertObject(value: unknown): asserts value is ImmutableObject {
  *
  * @param value The value to test.
  * @returns `true` if `value` is a plain object, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/object/isPlainObject
+ * @see https://shelving.cc/util/object/isPlainObject
  */
 export function isPlainObject(value: unknown): value is ImmutableObject {
 	if (isObject(value)) {
@@ -88,7 +88,7 @@ export function isPlainObject(value: unknown): value is ImmutableObject {
  *
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not a plain object.
- * @see https://dhoulb.github.io/shelving/util/object/assertPlainObject
+ * @see https://shelving.cc/util/object/assertPlainObject
  */
 export function assertPlainObject(value: unknown): asserts value is ImmutableObject {
 	if (!isPlainObject(value)) throw new RequiredError("Must be plain object", { received: value, caller: assertPlainObject });
@@ -100,7 +100,7 @@ export function assertPlainObject(value: unknown): asserts value is ImmutableObj
  * @param obj The object to test against.
  * @param key The key to test for.
  * @returns `true` if `key` is an own prop of `obj`, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/object/isProp
+ * @see https://shelving.cc/util/object/isProp
  */
 export function isProp<T extends ImmutableObject>(obj: T, key: PropertyKey): key is keyof T {
 	return Object.hasOwn(obj, key);
@@ -112,7 +112,7 @@ export function isProp<T extends ImmutableObject>(obj: T, key: PropertyKey): key
  * @param obj The object to assert against.
  * @param key The key to assert is an own prop.
  * @throws {RequiredError} If `key` is not an own prop of `obj`.
- * @see https://dhoulb.github.io/shelving/util/object/assertProp
+ * @see https://shelving.cc/util/object/assertProp
  */
 export function assertProp<T extends ImmutableObject>(obj: T, key: PropertyKey): asserts key is keyof T {
 	if (!isProp(obj, key)) throw new RequiredError("Key must exist in object", { key, obj, caller: assertProp });
@@ -126,7 +126,7 @@ export function assertProp<T extends ImmutableObject>(obj: T, key: PropertyKey):
  * @returns The corresponding object.
  * @example
  * getObject([["a", 1], ["b", 2]]); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/object/getObject
+ * @see https://shelving.cc/util/object/getObject
  */
 export function getObject<T extends ImmutableObject>(obj: PossibleObject<T>): T {
 	return isIterable(obj) ? (Object.fromEntries(obj) as T) : obj;
@@ -137,7 +137,7 @@ export function getObject<T extends ImmutableObject>(obj: PossibleObject<T>): T 
  * - See https://github.com/microsoft/TypeScript/issues/24509
  * - Consistency with `Readonly<T>`
  *
- * @see https://dhoulb.github.io/shelving/util/object/Mutable
+ * @see https://shelving.cc/util/object/Mutable
  */
 export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -146,7 +146,7 @@ export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
  * - Any value that extends `UnknownObject` has its props made partial.
  * - Works deeply on nested objects too.
  *
- * @see https://dhoulb.github.io/shelving/util/object/DeepPartial
+ * @see https://shelving.cc/util/object/DeepPartial
  */
 export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
 
@@ -155,7 +155,7 @@ export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
  * - Any value that extends `UnknownObject` has its props made mutable.
  * - Works deeply on nested objects too.
  *
- * @see https://dhoulb.github.io/shelving/util/object/DeepMutable
+ * @see https://shelving.cc/util/object/DeepMutable
  */
 export type DeepMutable<T> = { -readonly [K in keyof T]: DeepMutable<T[K]> };
 
@@ -164,21 +164,21 @@ export type DeepMutable<T> = { -readonly [K in keyof T]: DeepMutable<T[K]> };
  * - Any value that extends `UnknownObject` has its props made readonly.
  * - Works deeply on nested objects too.
  *
- * @see https://dhoulb.github.io/shelving/util/object/DeepReadonly
+ * @see https://shelving.cc/util/object/DeepReadonly
  */
 export type DeepReadonly<T> = { +readonly [K in keyof T]: DeepReadonly<T[K]> };
 
 /**
  * Pick only the properties of an object that match a type.
  *
- * @see https://dhoulb.github.io/shelving/util/object/PickProps
+ * @see https://shelving.cc/util/object/PickProps
  */
 export type PickProps<T, TT> = Pick<T, { [K in keyof T]: T[K] extends TT ? K : never }[keyof T]>;
 
 /**
  * Omit the properties of an object that match a type.
  *
- * @see https://dhoulb.github.io/shelving/util/object/OmitProps
+ * @see https://shelving.cc/util/object/OmitProps
  */
 export type OmitProps<T, TT> = Omit<T, { [K in keyof T]: T[K] extends TT ? K : never }[keyof T]>;
 
@@ -189,7 +189,7 @@ export type OmitProps<T, TT> = Omit<T, { [K in keyof T]: T[K] extends TT ? K : n
  * @returns Iterable set of key/value entry tuples for the object.
  * @example
  * getProps({ a: 1, b: 2 }); // [["a", 1], ["b", 2]]
- * @see https://dhoulb.github.io/shelving/util/object/getProps
+ * @see https://shelving.cc/util/object/getProps
  */
 export function getProps<T>(obj: T): ImmutableArray<Prop<T>>;
 export function getProps<T>(obj: T | Partial<T>): ImmutableArray<Prop<T>>;
@@ -207,7 +207,7 @@ export function getProps(
  * @returns Iterable set of keys for the object.
  * @example
  * getKeys({ a: 1, b: 2 }); // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/object/getKeys
+ * @see https://shelving.cc/util/object/getKeys
  */
 export function getKeys<T>(obj: T): ImmutableArray<Key<T>>;
 export function getKeys<T>(obj: T | Partial<T>): ImmutableArray<Key<T>>;
@@ -224,7 +224,7 @@ export function getKeys(obj: ImmutableObject | Partial<ImmutableObject> | Iterab
  * @returns The value of the named prop.
  * @example
  * getProp({ a: 1, b: 2 }, "a"); // 1
- * @see https://dhoulb.github.io/shelving/util/object/getProp
+ * @see https://shelving.cc/util/object/getProp
  */
 export function getProp<T, K extends Key<T>>(obj: T, key: K): T[K] {
 	return obj[key];
@@ -238,7 +238,7 @@ export function getProp<T, K extends Key<T>>(obj: T, key: K): T[K] {
  * @returns A new object containing only the single prop.
  * @example
  * fromProp("a", 1); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/object/fromProp
+ * @see https://shelving.cc/util/object/fromProp
  */
 export function fromProp<K extends PropertyKey, V>(key: K, value: V): { readonly [KK in K]: V } {
 	return { [key]: value } as { readonly [KK in K]: V };
@@ -254,7 +254,7 @@ export function fromProp<K extends PropertyKey, V>(key: K, value: V): { readonly
  * @returns A new object including the set prop, or the original object if the value was unchanged.
  * @example
  * withProp({ a: 1 }, "b", 2); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/object/withProp
+ * @see https://shelving.cc/util/object/withProp
  */
 export function withProp<T extends ImmutableObject, K extends Key<T>>(input: T, key: K, value: T[K]): T {
 	return input[key] === value ? input : { __proto__: getPrototype(input), ...input, [key]: value };
@@ -269,7 +269,7 @@ export function withProp<T extends ImmutableObject, K extends Key<T>>(input: T, 
  * @returns A new object including the set props, or the original object if all values were unchanged.
  * @example
  * withProps({ a: 1 }, { b: 2, c: 3 }); // { a: 1, b: 2, c: 3 }
- * @see https://dhoulb.github.io/shelving/util/object/withProps
+ * @see https://shelving.cc/util/object/withProps
  */
 export function withProps<T>(input: T, props: Partial<T>): T;
 export function withProps<T>(input: T, props: T | Partial<T> | Iterable<Prop<T>>): T;
@@ -287,7 +287,7 @@ export function withProps<T>(input: T, props: T | Partial<T> | Iterable<Prop<T>>
  * @returns A new object without the removed props, or the original object if no keys were present.
  * @example
  * omitProps({ a: 1, b: 2, c: 3 }, "b", "c"); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/object/omitProps
+ * @see https://shelving.cc/util/object/omitProps
  */
 export function omitProps<T, K extends Key<T>>(input: T, ...keys: K[]): Omit<T, K>;
 export function omitProps(input: ImmutableObject, ...keys: (keyof ImmutableObject)[]): ImmutableObject {
@@ -308,7 +308,7 @@ function _hasntKey<T extends ImmutableObject>(this: Key<T>[], [key]: Prop<T>): b
  * @returns A new object without the removed prop, or the original object if the key was not present.
  * @example
  * omitProp({ a: 1, b: 2 }, "b"); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/object/omitProp
+ * @see https://shelving.cc/util/object/omitProp
  */
 export const omitProp: <T, K extends Key<T>>(input: T, key: K) => Omit<T, K> = omitProps;
 
@@ -320,7 +320,7 @@ export const omitProp: <T, K extends Key<T>>(input: T, key: K) => Omit<T, K> = o
  * @returns A new object containing only the picked props.
  * @example
  * pickProps({ a: 1, b: 2, c: 3 }, "a", "b"); // { a: 1, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/object/pickProps
+ * @see https://shelving.cc/util/object/pickProps
  */
 export function pickProps<T, K extends Key<T>>(obj: T, ...keys: K[]): Pick<T, K>;
 export function pickProps(input: ImmutableObject, ...keys: (keyof ImmutableObject)[]): ImmutableObject {
@@ -339,7 +339,7 @@ function _hasKey<T extends ImmutableObject>(this: Key<T>[], [key]: readonly [Key
  * @returns The value that was set.
  * @example
  * setProp(obj, "a", 1); // 1
- * @see https://dhoulb.github.io/shelving/util/object/setProp
+ * @see https://shelving.cc/util/object/setProp
  */
 export function setProp<T extends MutableObject, K extends Key<T>>(obj: T, key: K, value: T[K]): T[K] {
 	obj[key] = value;
@@ -353,7 +353,7 @@ export function setProp<T extends MutableObject, K extends Key<T>>(obj: T, key: 
  * @param entries The props to set, as an object or iterable set of key/value entry tuples.
  * @example
  * setProps(obj, { a: 1, b: 2 });
- * @see https://dhoulb.github.io/shelving/util/object/setProps
+ * @see https://shelving.cc/util/object/setProps
  */
 export function setProps<T extends MutableObject>(obj: T, entries: T | Partial<T> | Iterable<Prop<T>>): void {
 	for (const [k, v] of getProps<T>(entries)) obj[k] = v;
@@ -366,7 +366,7 @@ export function setProps<T extends MutableObject>(obj: T, entries: T | Partial<T
  * @param keys The keys of the props to remove.
  * @example
  * deleteProps(obj, "a", "b");
- * @see https://dhoulb.github.io/shelving/util/object/deleteProps
+ * @see https://shelving.cc/util/object/deleteProps
  */
 export function deleteProps<T extends MutableObject>(obj: T, ...keys: Key<T>[]): void {
 	for (const key of keys) delete obj[key];
@@ -379,7 +379,7 @@ export function deleteProps<T extends MutableObject>(obj: T, ...keys: Key<T>[]):
  * @param key The key of the prop to remove.
  * @example
  * deleteProp(obj, "a");
- * @see https://dhoulb.github.io/shelving/util/object/deleteProp
+ * @see https://shelving.cc/util/object/deleteProp
  */
 export const deleteProp: <T extends MutableObject>(input: T, key: Key<T>) => void = deleteProps;
 
@@ -391,7 +391,7 @@ export const deleteProp: <T extends MutableObject>(input: T, key: Key<T>) => voi
  * @returns The prototype of the object, or `null` if it has none.
  * @example
  * getPrototype({ a: 1 }); // Object.prototype
- * @see https://dhoulb.github.io/shelving/util/object/getPrototype
+ * @see https://shelving.cc/util/object/getPrototype
  */
 export function getPrototype<T>(obj: T): Partial<T> | null {
 	return Object.getPrototypeOf(obj) as Partial<T> | null;
@@ -404,7 +404,7 @@ export function getPrototype<T>(obj: T): Partial<T> | null {
  * @returns A new object with the same prototype and props as `input`.
  * @example
  * cloneObject({ a: 1 }); // { a: 1 }
- * @see https://dhoulb.github.io/shelving/util/object/cloneObject
+ * @see https://shelving.cc/util/object/cloneObject
  */
 export function cloneObject<T>(input: T): T {
 	return { __proto__: getPrototype(input), ...input };
@@ -420,7 +420,7 @@ export function cloneObject<T>(input: T): T {
  * @returns A new object with the changed prop, or the original object if the value was unchanged.
  * @example
  * cloneObjectWith({ a: 1 }, "a", 2); // { a: 2 }
- * @see https://dhoulb.github.io/shelving/util/object/cloneObjectWith
+ * @see https://shelving.cc/util/object/cloneObjectWith
  */
 export function cloneObjectWith<T, K extends Key<T>>(input: T, key: K, value: T[K]): T;
 export function cloneObjectWith<T, K extends string, V>(input: T, key: K, value: V): T & { [KK in K]: V };

--- a/modules/util/path.ts
+++ b/modules/util/path.ts
@@ -10,28 +10,28 @@ import type { Nullish } from "./null.js";
 /**
  * Absolute path string starting with a `/` slash.
  *
- * @see https://dhoulb.github.io/shelving/util/path/AbsolutePath
+ * @see https://shelving.cc/util/path/AbsolutePath
  */
 export type AbsolutePath = `/` | `/${string}`;
 
 /**
  * Relative path string that is `.` dot, or starts with `./` dot slash.
  *
- * @see https://dhoulb.github.io/shelving/util/path/RelativePath
+ * @see https://shelving.cc/util/path/RelativePath
  */
 export type RelativePath = `.` | `./` | `./${string}`;
 
 /**
  * Either an absolute or relative path.
  *
- * @see https://dhoulb.github.io/shelving/util/path/Path
+ * @see https://shelving.cc/util/path/Path
  */
 export type Path = AbsolutePath | RelativePath;
 
 /**
  * Things that can be converted to a path.
  *
- * @see https://dhoulb.github.io/shelving/util/path/PossiblePath
+ * @see https://shelving.cc/util/path/PossiblePath
  */
 export type PossiblePath = string | readonly string[];
 
@@ -41,7 +41,7 @@ export type PossiblePath = string | readonly string[];
  * @param path The path to test.
  * @returns `true` if `path` is an `AbsolutePath` starting with `/`, narrowing its type.
  * @example isAbsolutePath("/a/b") // true
- * @see https://dhoulb.github.io/shelving/util/path/isAbsolutePath
+ * @see https://shelving.cc/util/path/isAbsolutePath
  */
 export function isAbsolutePath(path: PossiblePath): path is AbsolutePath {
 	return typeof path === "string" && path.startsWith("/");
@@ -53,7 +53,7 @@ export function isAbsolutePath(path: PossiblePath): path is AbsolutePath {
  * @param path The path to test.
  * @returns `true` if `path` is a `RelativePath` (`.` or starting with `./`), narrowing its type.
  * @example isRelativePath("./a") // true
- * @see https://dhoulb.github.io/shelving/util/path/isRelativePath
+ * @see https://shelving.cc/util/path/isRelativePath
  */
 export function isRelativePath(path: PossiblePath): path is RelativePath {
 	return typeof path === "string" && (path === "." || path.startsWith("./"));
@@ -69,7 +69,7 @@ export function isRelativePath(path: PossiblePath): path is RelativePath {
  * @param inputBase Absolute path used for resolving relative paths in `inputPath`.
  * @returns Absolute path with a leading slash but no trailing slash, e.g. `/a/c/b`, or `undefined` if `inputPath` is not a valid path.
  * @example getPath("./a", "/b") // "/b/a"
- * @see https://dhoulb.github.io/shelving/util/path/getPath
+ * @see https://shelving.cc/util/path/getPath
  */
 export function getPath(inputPath: Nullish<PossiblePath>, inputBase: AbsolutePath = "/"): AbsolutePath | undefined {
 	if (isNullish(inputPath)) return;
@@ -87,7 +87,7 @@ export function getPath(inputPath: Nullish<PossiblePath>, inputBase: AbsolutePat
  * @param path The path to normalise.
  * @returns The normalised path, preserving the absolute/relative type of `path`.
  * @example cleanPath("/a//b/") // "/a/b"
- * @see https://dhoulb.github.io/shelving/util/path/cleanPath
+ * @see https://shelving.cc/util/path/cleanPath
  */
 export function cleanPath(path: AbsolutePath): AbsolutePath;
 export function cleanPath(path: string): string;
@@ -107,7 +107,7 @@ export function cleanPath(path: string): string {
  * @returns Absolute path with a leading slash but no trailing slash, e.g. `/a/c/b`.
  * @throws {RequiredError} If `path` is not a valid path.
  * @example requirePath("./a", "/b") // "/b/a"
- * @see https://dhoulb.github.io/shelving/util/path/requirePath
+ * @see https://shelving.cc/util/path/requirePath
  */
 export function requirePath(path: PossiblePath, base?: AbsolutePath, caller: AnyCaller = requirePath): AbsolutePath {
 	const output = getPath(path, base);
@@ -126,7 +126,7 @@ export function requirePath(path: PossiblePath, base?: AbsolutePath, caller: Any
  * @returns The remaining absolute path after stripping `base`, `/` for an exact match, or `undefined` if `target` is not under `base`.
  * @throws {RequiredError} If `target` or `base` is not a valid path.
  * @example matchPathPrefix("/a/b", "/a") // "/b"
- * @see https://dhoulb.github.io/shelving/util/path/matchPathPrefix
+ * @see https://shelving.cc/util/path/matchPathPrefix
  */
 export function matchPathPrefix(target: PossiblePath, base: PossiblePath, caller: AnyCaller = matchPathPrefix): AbsolutePath | undefined {
 	const basePath = requirePath(base, undefined, caller);
@@ -144,7 +144,7 @@ export function matchPathPrefix(target: PossiblePath, base: PossiblePath, caller
  * @param current Current path to test against.
  * @returns `true` if `target` is exactly `current`.
  * @example isPathActive("/a", "/a") // true
- * @see https://dhoulb.github.io/shelving/util/path/isPathActive
+ * @see https://shelving.cc/util/path/isPathActive
  */
 export function isPathActive(target: AbsolutePath, current: AbsolutePath): boolean {
 	return target === current;
@@ -158,7 +158,7 @@ export function isPathActive(target: AbsolutePath, current: AbsolutePath): boole
  * @param current Current path to test against.
  * @returns `true` if `current` is `target` or a descendant of `target`.
  * @example isPathProud("/a", "/a/b") // true
- * @see https://dhoulb.github.io/shelving/util/path/isPathProud
+ * @see https://shelving.cc/util/path/isPathProud
  */
 export function isPathProud(target: AbsolutePath, current: AbsolutePath): boolean {
 	return target === current || (target !== "/" && target.startsWith(`${current}/`));
@@ -171,7 +171,7 @@ export function isPathProud(target: AbsolutePath, current: AbsolutePath): boolea
  * @param path Path to split (an array of segments is returned as-is).
  * @returns Array of path segments.
  * @example splitPath("/a/b") // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/path/splitPath
+ * @see https://shelving.cc/util/path/splitPath
  */
 export function splitPath(path: PossiblePath): readonly string[] {
 	if (typeof path !== "string") return path;
@@ -182,7 +182,7 @@ export function splitPath(path: PossiblePath): readonly string[] {
 /**
  * A single argument accepted by `joinPath()` — either a string (full path or single segment) or an array of segments.
  *
- * @see https://dhoulb.github.io/shelving/util/path/PathPart
+ * @see https://shelving.cc/util/path/PathPart
  */
 export type PathPart = string | readonly string[];
 

--- a/modules/util/query.ts
+++ b/modules/util/query.ts
@@ -16,7 +16,7 @@ import type { Segments } from "./string.js";
  * - Keys encode filters: `key` (is), `!key` (not), arrays for in/out, `key<`/`key<=`/`key>`/`key>=` for ranges, and `key[]` for array contains.
  * - `$order` sets the sort order (prefix `!` for descending) and `$limit` caps the number of results.
  *
- * @see https://dhoulb.github.io/shelving/util/query/Query
+ * @see https://shelving.cc/util/query/Query
  */
 export type Query<T extends Data = Data> = {
 	readonly [K in LeafDataPath<T> as `${K}` | `!${K}`]?: LeafData<T>[K] | ImmutableArray<LeafData<T>[K]> | undefined; // is/not/in/out
@@ -38,7 +38,7 @@ export type Query<T extends Data = Data> = {
  *
  * - Discriminated by `operator`: `"is"`, `"not"`, `"in"`, `"out"`, `"contains"`, `"lt"`, `"lte"`, `"gt"`, or `"gte"`.
  *
- * @see https://dhoulb.github.io/shelving/util/query/QueryFilter
+ * @see https://shelving.cc/util/query/QueryFilter
  */
 export type QueryFilter =
 	| { key: Segments; operator: "is"; value: unknown }
@@ -54,7 +54,7 @@ export type QueryFilter =
 /**
  * A single sort order that can be applied to a list of data objects.
  *
- * @see https://dhoulb.github.io/shelving/util/query/QueryOrder
+ * @see https://shelving.cc/util/query/QueryOrder
  */
 export type QueryOrder = {
 	key: Segments;
@@ -82,7 +82,7 @@ const MATCHERS: {
  * @param query The query to extract filters from.
  * @returns Array of decoded `QueryFilter` objects (excludes `$order` and `$limit` and any `undefined` values).
  * @example getQueryFilters({ name: "Alice" }) // [{ key: ["name"], operator: "is", value: "Alice" }]
- * @see https://dhoulb.github.io/shelving/util/query/getQueryFilters
+ * @see https://shelving.cc/util/query/getQueryFilters
  */
 export function getQueryFilters<T extends Data>(query: Query<T>): ImmutableArray<QueryFilter> {
 	return Array.from(yieldQueryFilters(query));
@@ -109,7 +109,7 @@ function* yieldQueryFilters<T extends Data>(query: Query<T>): Iterable<QueryFilt
  * @param query The query to extract sort orders from (reads its `$order` prop).
  * @returns Array of decoded `QueryOrder` objects (`!`-prefixed keys are descending, others ascending).
  * @example getQueryOrders({ $order: "!date" }) // [{ key: ["date"], direction: "desc" }]
- * @see https://dhoulb.github.io/shelving/util/query/getQueryOrders
+ * @see https://shelving.cc/util/query/getQueryOrders
  */
 export function getQueryOrders<T extends Data>({ $order }: Query<T>): ImmutableArray<QueryOrder> {
 	return Array.from(yieldQueryOrders($order));
@@ -128,7 +128,7 @@ function* yieldQueryOrders(order: string | ImmutableArray<string | undefined> | 
  * @param query The query to read the limit from (reads its `$limit` prop).
  * @returns The maximum number of results, or `undefined` if the query is unlimited.
  * @example getQueryLimit({ $limit: 10 }) // 10
- * @see https://dhoulb.github.io/shelving/util/query/getQueryLimit
+ * @see https://shelving.cc/util/query/getQueryLimit
  */
 export function getQueryLimit<T extends Data>({ $limit }: Query<T>): number | undefined {
 	return $limit;
@@ -142,7 +142,7 @@ export function getQueryLimit<T extends Data>({ $limit }: Query<T>): number | un
  * @param query The query to apply (filters, sort order, and limit).
  * @returns Iterable of items matching the query, in sorted and limited order.
  * @example Array.from(queryItems(items, { name: "Alice", $limit: 1 })) // matching items
- * @see https://dhoulb.github.io/shelving/util/query/queryItems
+ * @see https://shelving.cc/util/query/queryItems
  */
 export function queryItems<T extends Data>(items: Iterable<T>, query: Query<T>): Iterable<T> {
 	return limitQueryItems(sortQueryItems(filterQueryItems(items, getQueryFilters(query)), getQueryOrders(query)), getQueryLimit(query));
@@ -156,7 +156,7 @@ export function queryItems<T extends Data>(items: Iterable<T>, query: Query<T>):
  * @param query The query to apply (filters, sort order, and limit).
  * @returns Iterable of matching items (skips sorting when the query has no limit).
  * @example Array.from(queryWritableItems(items, { name: "Alice" })) // matching items (unsorted)
- * @see https://dhoulb.github.io/shelving/util/query/queryWritableItems
+ * @see https://shelving.cc/util/query/queryWritableItems
  */
 export function queryWritableItems<T extends Data>(items: Iterable<T>, query: Query<T>): Iterable<T> {
 	return getQueryLimit(query) === undefined ? filterQueryItems(items, getQueryFilters(query)) : queryItems(items, query);
@@ -169,7 +169,7 @@ export function queryWritableItems<T extends Data>(items: Iterable<T>, query: Qu
  * @param filters The set of filters that the item must satisfy.
  * @returns `true` if the item matches every filter, `false` otherwise.
  * @example matchQueryItem({ name: "Alice" }, [{ key: ["name"], operator: "is", value: "Alice" }]) // true
- * @see https://dhoulb.github.io/shelving/util/query/matchQueryItem
+ * @see https://shelving.cc/util/query/matchQueryItem
  */
 export function matchQueryItem<T extends Data>(item: T, filters: ImmutableArray<QueryFilter>): boolean {
 	for (const { key, operator, value } of filters) {
@@ -186,7 +186,7 @@ export function matchQueryItem<T extends Data>(item: T, filters: ImmutableArray<
  * @param filters The set of filters that each yielded item must satisfy.
  * @yields Items that match every filter (yields all items when `filters` is empty).
  * @example Array.from(filterQueryItems(items, filters)) // matching items
- * @see https://dhoulb.github.io/shelving/util/query/filterQueryItems
+ * @see https://shelving.cc/util/query/filterQueryItems
  */
 export function* filterQueryItems<T extends Data>(items: Iterable<T>, filters: ImmutableArray<QueryFilter>): Iterable<T> {
 	if (filters.length) {

--- a/modules/util/random.ts
+++ b/modules/util/random.ts
@@ -10,7 +10,7 @@ import { requireDefined } from "./undefined.js";
  *
  * @example const dice = getRandom(1, 6); // e.g. `4`
  *
- * @see https://dhoulb.github.io/shelving/util/random/getRandom
+ * @see https://shelving.cc/util/random/getRandom
  */
 export function getRandom(min: number = Number.MIN_SAFE_INTEGER, max: number = Number.MAX_SAFE_INTEGER): number {
 	return Math.round(Math.random() * (max - min) + min);
@@ -27,7 +27,7 @@ export function getRandom(min: number = Number.MIN_SAFE_INTEGER, max: number = N
  *
  * @example const next = getRandomExcept(current, 1, 6); // any of `1`–`6` except `current`
  *
- * @see https://dhoulb.github.io/shelving/util/random/getRandomExcept
+ * @see https://shelving.cc/util/random/getRandomExcept
  */
 export function getRandomExcept(existing: number, min?: number, max?: number) {
 	let num: number;
@@ -47,7 +47,7 @@ export function getRandomExcept(existing: number, min?: number, max?: number) {
  *
  * @example const id = getRandomKey(); // e.g. `xs23r34hhsdx`
  *
- * @see https://dhoulb.github.io/shelving/util/random/getRandomKey
+ * @see https://shelving.cc/util/random/getRandomKey
  */
 export function getRandomKey(length = 12): string {
 	return Array.from({ length }, getRandomKeyCharacter).join("");
@@ -65,7 +65,7 @@ function getRandomKeyCharacter() {
  *
  * @example const letter = getRandomCharacter("abcde"); // e.g. `"c"`
  *
- * @see https://dhoulb.github.io/shelving/util/random/getRandomCharacter
+ * @see https://shelving.cc/util/random/getRandomCharacter
  */
 export function getRandomCharacter(str: string): string {
 	return str[getRandom(0, str.length - 1)] as string;
@@ -80,7 +80,7 @@ export function getRandomCharacter(str: string): string {
  *
  * @example const item = getRandomItem(["a", "b", "c"]); // e.g. `"b"`
  *
- * @see https://dhoulb.github.io/shelving/util/random/getRandomItem
+ * @see https://shelving.cc/util/random/getRandomItem
  */
 export function getRandomItem<T>(arr: ImmutableArray<T>): T {
 	return requireDefined<T>(arr[getRandom(0, arr.length - 1)]);

--- a/modules/util/regexp.ts
+++ b/modules/util/regexp.ts
@@ -8,28 +8,28 @@ import type { NotString } from "./string.js";
  * A thing that a string can be matched against.
  * - Either a `RegExp` instance, or a `string` that is matched using `===` equality.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/Matchable
+ * @see https://shelving.cc/util/regexp/Matchable
  */
 export type Matchable = string | RegExp;
 
 /**
  * A list of things that strings can be matched against.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/Matchables
+ * @see https://shelving.cc/util/regexp/Matchables
  */
 export type Matchables = ImmutableArray<Nullish<Matchable>>;
 
 /**
  * Regular expression that always matches everything.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/ALWAYS_REGEXP
+ * @see https://shelving.cc/util/regexp/ALWAYS_REGEXP
  */
 export const ALWAYS_REGEXP = /^.*$/;
 
 /**
  * Regular expression that never matches anything.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/NEVER_REGEXP
+ * @see https://shelving.cc/util/regexp/NEVER_REGEXP
  */
 export const NEVER_REGEXP = /^(?=a)a/;
 
@@ -37,7 +37,7 @@ export const NEVER_REGEXP = /^(?=a)a/;
  * Things that can be converted to a regular expression.
  * - Either a `RegExp` instance, or a `string` source for a regular expression.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/PossibleRegExp
+ * @see https://shelving.cc/util/regexp/PossibleRegExp
  */
 export type PossibleRegExp = string | RegExp;
 
@@ -46,7 +46,7 @@ export type PossibleRegExp = string | RegExp;
  *
  * @param value The value to test.
  * @returns `true` if `value` is a `RegExp` instance, narrowing its type.
- * @see https://dhoulb.github.io/shelving/util/regexp/isRegExp
+ * @see https://shelving.cc/util/regexp/isRegExp
  */
 export function isRegExp(value: unknown): value is RegExp {
 	return value instanceof RegExp;
@@ -57,7 +57,7 @@ export function isRegExp(value: unknown): value is RegExp {
  *
  * @param value The value to assert.
  * @throws {RequiredError} If `value` is not a `RegExp` instance.
- * @see https://dhoulb.github.io/shelving/util/regexp/assertRegExp
+ * @see https://shelving.cc/util/regexp/assertRegExp
  */
 export function assertRegExp(value: unknown): asserts value is RegExp {
 	if (!(value instanceof RegExp)) throw new RequiredError("Must be regular expression", { received: value, caller: assertRegExp });
@@ -72,7 +72,7 @@ export function assertRegExp(value: unknown): asserts value is RegExp {
  * @returns The corresponding `RegExp` instance.
  * @example
  * getRegExp("abc", "i"); // /abc/i
- * @see https://dhoulb.github.io/shelving/util/regexp/getRegExp
+ * @see https://shelving.cc/util/regexp/getRegExp
  */
 export function getRegExp<T extends NamedRegExpData>(
 	pattern: NamedRegExp<T>,
@@ -94,7 +94,7 @@ export function getRegExp(pattern: PossibleRegExp, flags?: string): RegExp {
  * @returns The string source of the regular expression.
  * @example
  * getRegExpSource(/abc/); // "abc"
- * @see https://dhoulb.github.io/shelving/util/regexp/getRegExpSource
+ * @see https://shelving.cc/util/regexp/getRegExpSource
  */
 export function getRegExpSource(regexp: PossibleRegExp): string {
 	return typeof regexp === "string" ? regexp : regexp.source;
@@ -108,7 +108,7 @@ export function getRegExpSource(regexp: PossibleRegExp): string {
  * @returns The escaped string, safe to use as a literal regular expression source.
  * @example
  * escapeRegExp("a.b"); // "a\\.b"
- * @see https://dhoulb.github.io/shelving/util/regexp/escapeRegExp
+ * @see https://shelving.cc/util/regexp/escapeRegExp
  */
 export function escapeRegExp(pattern: string): string {
 	return pattern.replace(REPLACE_ESCAPED, "\\$&");
@@ -124,7 +124,7 @@ const REPLACE_ESCAPED = /[-[\]/{}()*+?.\\^$|]/g;
  * @returns A `RegExp` that matches if any of the provided expressions match.
  * @example
  * createRegExpAny(["abc", "def"]); // /(?:abc)|(?:def)/
- * @see https://dhoulb.github.io/shelving/util/regexp/createRegExpAny
+ * @see https://shelving.cc/util/regexp/createRegExpAny
  */
 export function createRegExpAny(patterns: Iterable<PossibleRegExp> & NotString, flags?: string): RegExp {
 	const arr = requireArray(patterns).filter(Boolean);
@@ -143,7 +143,7 @@ export function createRegExpAny(patterns: Iterable<PossibleRegExp> & NotString, 
  * @returns A `RegExp` that matches only if all of the provided expressions match.
  * @example
  * createRegExpAll(["abc", "def"]); // /^(?=.*?(?:abc))(?=.*?(?:def))/
- * @see https://dhoulb.github.io/shelving/util/regexp/createRegExpAll
+ * @see https://shelving.cc/util/regexp/createRegExpAll
  */
 export function createRegExpAll(patterns: Iterable<PossibleRegExp> & NotString, flags?: string): RegExp {
 	const arr = requireArray(patterns).filter(Boolean);
@@ -156,7 +156,7 @@ export function createRegExpAll(patterns: Iterable<PossibleRegExp> & NotString, 
 /**
  * Regular expression match array whose full match is a specific string format.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/TypedRegExpExecArray
+ * @see https://shelving.cc/util/regexp/TypedRegExpExecArray
  */
 export interface TypedRegExpExecArray<T extends string = string> extends RegExpExecArray {
 	0: T;
@@ -165,7 +165,7 @@ export interface TypedRegExpExecArray<T extends string = string> extends RegExpE
 /**
  * Regular expression that matches a specific string format.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/TypedRegExp
+ * @see https://shelving.cc/util/regexp/TypedRegExp
  */
 export interface TypedRegExp<T extends string = string> extends RegExp {
 	exec(input: string): TypedRegExpExecArray<T> | null;
@@ -174,14 +174,14 @@ export interface TypedRegExp<T extends string = string> extends RegExp {
 /**
  * Set of named match groups from a regular expression.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/NamedRegExpData
+ * @see https://shelving.cc/util/regexp/NamedRegExpData
  */
 export type NamedRegExpData = { [named: string]: string };
 
 /**
  * Regular expression match array that contains the specified named groups.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/NamedRegExpExecArray
+ * @see https://shelving.cc/util/regexp/NamedRegExpExecArray
  */
 export interface NamedRegExpExecArray<T extends NamedRegExpData = NamedRegExpData> extends RegExpExecArray {
 	groups: T; // Groups is always set if a single `(?<named> placeholder)` appears in the RegExp.
@@ -190,7 +190,7 @@ export interface NamedRegExpExecArray<T extends NamedRegExpData = NamedRegExpDat
 /**
  * Regular expression that contains the specified named capture groups.
  *
- * @see https://dhoulb.github.io/shelving/util/regexp/NamedRegExp
+ * @see https://shelving.cc/util/regexp/NamedRegExp
  */
 export interface NamedRegExp<T extends NamedRegExpData = NamedRegExpData> extends RegExp {
 	exec(input: string): NamedRegExpExecArray<T> | null;
@@ -207,7 +207,7 @@ export interface NamedRegExp<T extends NamedRegExpData = NamedRegExpData> extend
  * @returns `true` if the string matches the regular expression, otherwise `false`.
  * @example
  * isMatch("abc", /b/); // true
- * @see https://dhoulb.github.io/shelving/util/regexp/isMatch
+ * @see https://shelving.cc/util/regexp/isMatch
  */
 export function isMatch(str: string, regexp: Matchable): boolean {
 	return typeof regexp === "string" ? regexp === str : regexp.test(str);
@@ -224,7 +224,7 @@ export function isMatch(str: string, regexp: Matchable): boolean {
  * @returns `true` if the string does not match the regular expression, otherwise `false`.
  * @example
  * notMatch("abc", /z/); // true
- * @see https://dhoulb.github.io/shelving/util/regexp/notMatch
+ * @see https://shelving.cc/util/regexp/notMatch
  */
 export function notMatch(str: string, regexp: Matchable): boolean {
 	return !isMatch(str, regexp);
@@ -242,7 +242,7 @@ export function notMatch(str: string, regexp: Matchable): boolean {
  * @returns `true` if every provided regular expression matches the string, otherwise `false`.
  * @example
  * allMatch("abc", /a/, /b/); // true
- * @see https://dhoulb.github.io/shelving/util/regexp/allMatch
+ * @see https://shelving.cc/util/regexp/allMatch
  */
 export function allMatch(str: string, ...regexps: Matchables): boolean {
 	for (const x of regexps) {
@@ -264,7 +264,7 @@ export function allMatch(str: string, ...regexps: Matchables): boolean {
  * @returns `true` if at least one provided regular expression matches the string, otherwise `false`.
  * @example
  * anyMatch("abc", /z/, /b/); // true
- * @see https://dhoulb.github.io/shelving/util/regexp/anyMatch
+ * @see https://shelving.cc/util/regexp/anyMatch
  */
 export function anyMatch(str: string, ...regexps: Matchables): boolean {
 	for (const x of regexps) {
@@ -286,7 +286,7 @@ export function anyMatch(str: string, ...regexps: Matchables): boolean {
  * @returns `true` if none of the provided regular expressions match the string, otherwise `false`.
  * @example
  * noneMatch("abc", /x/, /y/); // true
- * @see https://dhoulb.github.io/shelving/util/regexp/noneMatch
+ * @see https://shelving.cc/util/regexp/noneMatch
  */
 export function noneMatch(str: string, ...regexps: Matchables): boolean {
 	return !allMatch(str, ...regexps);
@@ -300,7 +300,7 @@ export function noneMatch(str: string, ...regexps: Matchables): boolean {
  * @returns The match array, or `undefined` if the string did not match.
  * @example
  * getMatch("abc", /b/); // ["b"]
- * @see https://dhoulb.github.io/shelving/util/regexp/getMatch
+ * @see https://shelving.cc/util/regexp/getMatch
  */
 export function getMatch<T extends NamedRegExpData>(str: string, regexp: NamedRegExp<T>): NamedRegExpExecArray<T> | undefined;
 export function getMatch<T extends string>(str: string, regexp: TypedRegExp<T>): TypedRegExpExecArray<T> | undefined;
@@ -318,7 +318,7 @@ export function getMatch(str: string, regexp: RegExp): RegExpExecArray | undefin
  * @throws {ValueError} If the string did not match the regular expression.
  * @example
  * requireMatch("abc", /b/); // ["b"]
- * @see https://dhoulb.github.io/shelving/util/regexp/requireMatch
+ * @see https://shelving.cc/util/regexp/requireMatch
  */
 export function requireMatch<T extends NamedRegExpData>(str: string, regexp: NamedRegExp<T>): NamedRegExpExecArray<T>;
 export function requireMatch<T extends string>(str: string, regexp: TypedRegExp<T>): TypedRegExpExecArray<T>;
@@ -337,7 +337,7 @@ export function requireMatch(str: string, regexp: RegExp): RegExpExecArray {
  * @returns The set of named match groups, or `undefined` if the string did not match.
  * @example
  * getMatchGroups("abc", /(?<first>a)/); // { first: "a" }
- * @see https://dhoulb.github.io/shelving/util/regexp/getMatchGroups
+ * @see https://shelving.cc/util/regexp/getMatchGroups
  */
 export function getMatchGroups<T extends NamedRegExpData>(str: string, regexp: NamedRegExp<T>): T | undefined;
 export function getMatchGroups(str: string, regexp: RegExp): NamedRegExpData | undefined;
@@ -354,7 +354,7 @@ export function getMatchGroups(str: string, regexp: RegExp): NamedRegExpData | u
  * @throws {ValueError} If the string did not match the regular expression.
  * @example
  * requireMatchGroups("abc", /(?<first>a)/); // { first: "a" }
- * @see https://dhoulb.github.io/shelving/util/regexp/requireMatchGroups
+ * @see https://shelving.cc/util/regexp/requireMatchGroups
  */
 export function requireMatchGroups<T extends NamedRegExpData>(str: string, regexp: NamedRegExp<T>): T;
 export function requireMatchGroups(str: string, regexp: RegExp): NamedRegExpData;

--- a/modules/util/sequence.ts
+++ b/modules/util/sequence.ts
@@ -7,7 +7,7 @@ import type { AnyCaller, ErrorCallback, ValueCallback } from "./function.js";
  * Result of an iterator that was aborted via an external signal rather than concluding itself.
  * - `done` is the `ABORT` symbol, distinguishing it from an iterator's own `done: true` result.
  *
- * @see https://dhoulb.github.io/shelving/util/sequence/IteratorAbortResult
+ * @see https://shelving.cc/util/sequence/IteratorAbortResult
  */
 export interface IteratorAbortResult<R> {
 	/** Always the `ABORT` symbol, marking this result as an external abort rather than the iterator finishing. */
@@ -20,7 +20,7 @@ export interface IteratorAbortResult<R> {
  * Result of stepping an iterator that may either yield, finish itself, or be aborted externally.
  * - Union of a normal `IteratorResult<T, R>` and an `IteratorAbortResult<R>`.
  *
- * @see https://dhoulb.github.io/shelving/util/sequence/IteratorAbortableResult
+ * @see https://shelving.cc/util/sequence/IteratorAbortableResult
  */
 export type IteratorAbortableResult<T, R> = IteratorResult<T, R> | IteratorAbortResult<R>;
 
@@ -55,7 +55,7 @@ async function _iteratorReturn<T, R, N>(
  * @param value The value to test.
  * @returns `true` if `value` is an `AsyncIterable`, narrowing its type.
  * @example isSequence((async function* () {})()) // true
- * @see https://dhoulb.github.io/shelving/util/sequence/isSequence
+ * @see https://shelving.cc/util/sequence/isSequence
  */
 export function isSequence(value: unknown): value is AsyncIterable<unknown> {
 	return typeof value === "object" && !!value && Symbol.asyncIterator in value;
@@ -70,7 +70,7 @@ export function isSequence(value: unknown): value is AsyncIterable<unknown> {
  * @returns The value the winning abort signal resolved with, or the source's own return value if it finishes first.
  * @throws {UnexpectedError} If the source iterator's `return()` does not return a `done` result.
  * @example for await (const item of repeatUntil(source, stopSignal)) doSomething(item);
- * @see https://dhoulb.github.io/shelving/util/sequence/repeatUntil
+ * @see https://shelving.cc/util/sequence/repeatUntil
  */
 export async function* repeatUntil<T = void, R = void, N = void>(
 	source: AsyncIterable<T, R | undefined, N | undefined>,
@@ -109,7 +109,7 @@ export async function* repeatUntil<T = void, R = void, N = void>(
  * @param ms The number of milliseconds to wait between each yield.
  * @returns An infinite async generator yielding `1`, `2`, `3`… one per interval.
  * @example for await (const count of repeatDelay(1000)) console.log(count); // 1, 2, 3… one per second
- * @see https://dhoulb.github.io/shelving/util/sequence/repeatDelay
+ * @see https://shelving.cc/util/sequence/repeatDelay
  */
 export async function* repeatDelay(ms: number): AsyncGenerator<number, void, void> {
 	let count = 1;
@@ -127,7 +127,7 @@ export async function* repeatDelay(ms: number): AsyncGenerator<number, void, voi
  * @param callback Callback invoked with each yielded item.
  * @returns An async generator that yields the same items as `sequence`.
  * @example for await (const item of callSequence(source, console.log)) use(item);
- * @see https://dhoulb.github.io/shelving/util/sequence/callSequence
+ * @see https://shelving.cc/util/sequence/callSequence
  */
 export async function* callSequence<T>(sequence: AsyncIterable<T, void, void>, callback: ValueCallback<T>): AsyncGenerator<T, void, void> {
 	for await (const item of sequence) {
@@ -151,7 +151,7 @@ export async function* callSequence<T>(sequence: AsyncIterable<T, void, void>, c
  * @returns Callback function that can end the sequence run, optionally with a return value.
  * @throws {UnexpectedError} If the source iterator's `return()` does not return a `done` result.
  * @example const stop = runSequence(source, onNext, onError, onReturn); stop(); // ends the run
- * @see https://dhoulb.github.io/shelving/util/sequence/runSequence
+ * @see https://shelving.cc/util/sequence/runSequence
  */
 export function runSequence<T, R, N>(
 	sequence: AsyncIterable<T, R | undefined, N | undefined>,
@@ -200,7 +200,7 @@ async function _runSequenceIterator<T, R, N>(
  * @param sequences The sequences to merge, drained one after another in order.
  * @returns An async iterable that yields every item from each sequence in turn.
  * @example for await (const item of mergeSequences(a, b)) use(item); // all of `a`, then all of `b`
- * @see https://dhoulb.github.io/shelving/util/sequence/mergeSequences
+ * @see https://shelving.cc/util/sequence/mergeSequences
  */
 export async function* mergeSequences<T>(...sequences: AsyncIterable<T>[]): AsyncIterable<T> {
 	for await (const sequence of sequences) yield* sequence;

--- a/modules/util/serialise.ts
+++ b/modules/util/serialise.ts
@@ -16,7 +16,7 @@ const R_QUOTE = /"/g;
  * @returns A consistent string representation of `value`, suitable for fingerprinting or equality comparison.
  * @throws {ValueError} If `value` cannot be serialised.
  * @example serialise({ b: 2, a: 1 }) // `{"a":1,"b":2}`
- * @see https://dhoulb.github.io/shelving/util/serialise/serialise
+ * @see https://shelving.cc/util/serialise/serialise
  */
 export function serialise(value: unknown): string {
 	if (value === true) return "true";

--- a/modules/util/set.ts
+++ b/modules/util/set.ts
@@ -5,28 +5,28 @@ import { limitItems } from "./iterate.js";
 /**
  * `Set` that cannot be changed.
  *
- * @see https://dhoulb.github.io/shelving/util/set/ImmutableSet
+ * @see https://shelving.cc/util/set/ImmutableSet
  */
 export type ImmutableSet<T = unknown> = ReadonlySet<T>;
 
 /**
  * `Set` that can be changed.
  *
- * @see https://dhoulb.github.io/shelving/util/set/MutableSet
+ * @see https://shelving.cc/util/set/MutableSet
  */
 export type MutableSet<T = unknown> = Set<T>;
 
 /**
  * Things that can be converted to sets.
  *
- * @see https://dhoulb.github.io/shelving/util/set/PossibleSet
+ * @see https://shelving.cc/util/set/PossibleSet
  */
 export type PossibleSet<T> = ImmutableSet<T> | Iterable<T>;
 
 /**
  * Get the type of the _items_ in a set.
  *
- * @see https://dhoulb.github.io/shelving/util/set/SetItem
+ * @see https://shelving.cc/util/set/SetItem
  */
 export type SetItem<X> = X extends ReadonlySet<infer Y> ? Y : never;
 
@@ -35,7 +35,7 @@ export type SetItem<X> = X extends ReadonlySet<infer Y> ? Y : never;
  *
  * @param value The value to check.
  * @returns `true` if `value` is a `Set` instance, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/set/isSet
+ * @see https://shelving.cc/util/set/isSet
  */
 export function isSet(value: unknown): value is ImmutableSet {
 	return value instanceof Set;
@@ -48,7 +48,7 @@ export function isSet(value: unknown): value is ImmutableSet {
  * @param caller Function to attribute a thrown error to (defaults to `assertSet`).
  * @throws {RequiredError} If `value` is not a `Set` instance.
  * @example assertSet(new Set()); // Passes.
- * @see https://dhoulb.github.io/shelving/util/set/assertSet
+ * @see https://shelving.cc/util/set/assertSet
  */
 export function assertSet(value: unknown, caller: AnyCaller = assertSet): asserts value is ImmutableSet {
 	if (!isSet(value)) throw new RequiredError("Must be set", { received: value, caller });
@@ -61,7 +61,7 @@ export function assertSet(value: unknown, caller: AnyCaller = assertSet): assert
  * @param value A `Set` or any iterable of items.
  * @returns A `Set` containing the items of `value`.
  * @example getSet(["a", "b"]) // Set { "a", "b" }
- * @see https://dhoulb.github.io/shelving/util/set/getSet
+ * @see https://shelving.cc/util/set/getSet
  */
 export function getSet<T>(value: PossibleSet<T>): ImmutableSet {
 	return isSet(value) ? value : new Set(value);
@@ -75,7 +75,7 @@ export function getSet<T>(value: PossibleSet<T>): ImmutableSet {
  * @param limit The maximum number of items to keep.
  * @returns A set containing at most `limit` items.
  * @example limitSet(new Set([1, 2, 3]), 2) // Set { 1, 2 }
- * @see https://dhoulb.github.io/shelving/util/set/limitSet
+ * @see https://shelving.cc/util/set/limitSet
  */
 export function limitSet<T>(set: ImmutableSet<T>, limit: number): ImmutableSet<T> {
 	return limit > set.size ? set : new Set(limitItems(set, limit));
@@ -87,7 +87,7 @@ export function limitSet<T>(set: ImmutableSet<T>, limit: number): ImmutableSet<T
  * @param set The set to look in.
  * @param item The value to check for membership.
  * @returns `true` if `item` exists in `set`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/set/isSetItem
+ * @see https://shelving.cc/util/set/isSetItem
  */
 export function isSetItem<T>(set: ImmutableSet<T>, item: unknown): item is T {
 	return set.has(item as T);
@@ -101,7 +101,7 @@ export function isSetItem<T>(set: ImmutableSet<T>, item: unknown): item is T {
  * @param caller Function to attribute a thrown error to (defaults to `assertSetItem`).
  * @throws {RequiredError} If `item` does not exist in `set`.
  * @example assertSetItem(new Set(["a"]), "a"); // Passes.
- * @see https://dhoulb.github.io/shelving/util/set/assertSetItem
+ * @see https://shelving.cc/util/set/assertSetItem
  */
 export function assertSetItem<T>(set: ImmutableSet<T>, item: unknown, caller: AnyCaller = assertSetItem): asserts item is T {
 	if (!isSetItem(set, item)) throw new RequiredError("Item must exist in set", { item, set, caller });
@@ -115,7 +115,7 @@ export function assertSetItem<T>(set: ImmutableSet<T>, item: unknown, caller: An
  * @param item The item to add.
  * @returns The added `item`.
  * @example addSetItem(set, "a") // "a"
- * @see https://dhoulb.github.io/shelving/util/set/addSetItem
+ * @see https://shelving.cc/util/set/addSetItem
  */
 export function addSetItem<T>(set: MutableSet<T>, item: T): T {
 	set.add(item);
@@ -130,7 +130,7 @@ export function addSetItem<T>(set: MutableSet<T>, item: T): T {
  * @param items The items to add.
  * @returns Nothing.
  * @example addSetItems(set, "a", "b");
- * @see https://dhoulb.github.io/shelving/util/set/addSetItems
+ * @see https://shelving.cc/util/set/addSetItems
  */
 export function addSetItems<T>(set: MutableSet<T>, ...items: T[]): void {
 	for (const item of items) set.add(item);
@@ -144,7 +144,7 @@ export function addSetItems<T>(set: MutableSet<T>, ...items: T[]): void {
  * @param items The items to remove.
  * @returns Nothing.
  * @example deleteSetItems(set, "a", "b");
- * @see https://dhoulb.github.io/shelving/util/set/deleteSetItems
+ * @see https://shelving.cc/util/set/deleteSetItems
  */
 export function deleteSetItems<T>(set: MutableSet<T>, ...items: T[]): void {
 	for (const item of items) set.delete(item);

--- a/modules/util/sort.ts
+++ b/modules/util/sort.ts
@@ -6,7 +6,7 @@ import type { Arguments } from "./function.js";
  * Function that can compare two values for sorting.
  * - Returns a negative number if `left` sorts before `right`, positive if after, or `0` if equally ranked (like `Array.prototype.sort()`).
  *
- * @see https://dhoulb.github.io/shelving/util/sort/Compare
+ * @see https://shelving.cc/util/sort/Compare
  */
 export type Compare<T, A extends Arguments = []> = (left: T, right: T, ...args: A) => number;
 
@@ -26,7 +26,7 @@ export type Compare<T, A extends Arguments = []> = (left: T, right: T, ...args: 
  * @param right The second value to rank.
  * @returns Number below zero if `left` is higher, number above zero if `right` is higher, or `0` if they're equally sorted.
  * @example compareAscending(1, 2) // -1
- * @see https://dhoulb.github.io/shelving/util/sort/compareAscending
+ * @see https://shelving.cc/util/sort/compareAscending
  */
 export function compareAscending(left: unknown, right: unknown): number {
 	// Exactly equal is easy.
@@ -76,7 +76,7 @@ export function compareAscending(left: unknown, right: unknown): number {
  * @param right The second value to rank.
  * @returns Number below zero if `right` is higher, number above zero if `left` is higher, or `0` if they're equally sorted.
  * @example compareDescending(1, 2) // 1
- * @see https://dhoulb.github.io/shelving/util/sort/compareDescending
+ * @see https://shelving.cc/util/sort/compareDescending
  */
 export function compareDescending(left: unknown, right: unknown): number {
 	return 0 - compareAscending(left, right);
@@ -146,7 +146,7 @@ function _quicksort<T, A extends Arguments>(
  * @param args Extra arguments forwarded to `compare` on each call.
  * @returns A sorted array (the original reference if it was an already-sorted array).
  * @example sortArray([3, 1, 2]) // [1, 2, 3]
- * @see https://dhoulb.github.io/shelving/util/sort/sortArray
+ * @see https://shelving.cc/util/sort/sortArray
  */
 export function sortArray<T, A extends Arguments = []>(
 	input: ImmutableArray<T> | Iterable<T>,

--- a/modules/util/source.ts
+++ b/modules/util/source.ts
@@ -6,7 +6,7 @@ import { isObject } from "./object.js";
 /**
  * Something that has a source of a specified type.
  *
- * @see https://dhoulb.github.io/shelving/util/source/Sourceable
+ * @see https://shelving.cc/util/source/Sourceable
  */
 export interface Sourceable<T> {
 	/** The wrapped source object this object delegates to. */
@@ -21,7 +21,7 @@ export interface Sourceable<T> {
  * @param value The object to start searching from.
  * @returns The first matching source instance, or `undefined` if none matches.
  * @example getSource(CacheProvider, provider) // CacheProvider instance or undefined
- * @see https://dhoulb.github.io/shelving/util/source/getSource
+ * @see https://shelving.cc/util/source/getSource
  */
 export function getSource<T>(type: Class<T>, value: unknown): T | undefined {
 	if (isObject(value)) {
@@ -40,7 +40,7 @@ export function getSource<T>(type: Class<T>, value: unknown): T | undefined {
  * @returns The first matching source instance.
  * @throws {RequiredError} If no source object is an instance of `type`.
  * @example requireSource(CacheProvider, provider) // CacheProvider instance
- * @see https://dhoulb.github.io/shelving/util/source/requireSource
+ * @see https://shelving.cc/util/source/requireSource
  */
 export function requireSource<T>(type: Class<T>, data: unknown, caller: AnyCaller = requireSource): T {
 	const source = getSource(type, data);

--- a/modules/util/start.ts
+++ b/modules/util/start.ts
@@ -4,14 +4,14 @@ import { type Arguments, BLACKHOLE } from "./function.js";
 /**
  * Callback function that starts something with multiple values and returns an optional stop callback.
  *
- * @see https://dhoulb.github.io/shelving/util/start/StartCallback
+ * @see https://shelving.cc/util/start/StartCallback
  */
 export type StartCallback<T extends Arguments = []> = (...values: T) => StopCallback | void;
 
 /**
  * Callback function that stops something.
  *
- * @see https://dhoulb.github.io/shelving/util/start/StopCallback
+ * @see https://shelving.cc/util/start/StopCallback
  */
 export type StopCallback = () => void;
 
@@ -20,7 +20,7 @@ export type StopCallback = () => void;
  * - Useful as a no-op default where a `StartCallback` is expected.
  *
  * @example STOPHOLE() // BLACKHOLE
- * @see https://dhoulb.github.io/shelving/util/start/STOPHOLE
+ * @see https://shelving.cc/util/start/STOPHOLE
  */
 export const STOPHOLE: (...args: Arguments) => StopCallback = () => BLACKHOLE;
 
@@ -33,7 +33,7 @@ export const STOPHOLE: (...args: Arguments) => StopCallback = () => BLACKHOLE;
  * const starter = new Starter(() => { console.log("start"); return () => console.log("stop"); });
  * starter.start();
  * starter.stop();
- * @see https://dhoulb.github.io/shelving/util/start/Starter
+ * @see https://shelving.cc/util/start/Starter
  */
 export class Starter<T extends Arguments = []> implements Disposable {
 	private readonly _start: StartCallback<T>;
@@ -55,7 +55,7 @@ export class Starter<T extends Arguments = []> implements Disposable {
 	 * @returns Nothing.
 	 * @throws {UnexpectedError} If the start callback throws.
 	 * @example starter.start();
-	 * @see https://dhoulb.github.io/shelving/util/start/Starter/start
+	 * @see https://shelving.cc/util/start/Starter/start
 	 */
 	start(...values: T): void {
 		if (this._started) return;
@@ -73,7 +73,7 @@ export class Starter<T extends Arguments = []> implements Disposable {
 	 * @returns Nothing.
 	 * @throws {UnexpectedError} If the stop callback throws.
 	 * @example starter.stop();
-	 * @see https://dhoulb.github.io/shelving/util/start/Starter/stop
+	 * @see https://shelving.cc/util/start/Starter/stop
 	 */
 	stop(): void {
 		if (!this._started) return;
@@ -94,7 +94,7 @@ export class Starter<T extends Arguments = []> implements Disposable {
 /**
  * Something that can be made into a `Starter`.
  *
- * @see https://dhoulb.github.io/shelving/util/start/PossibleStarter
+ * @see https://shelving.cc/util/start/PossibleStarter
  */
 export type PossibleStarter<T extends Arguments> = StartCallback<T> | Starter<T>;
 
@@ -104,7 +104,7 @@ export type PossibleStarter<T extends Arguments> = StartCallback<T> | Starter<T>
  *
  * @param start A `StartCallback` or an existing `Starter`.
  * @example getStarter(() => () => {}) // Starter instance
- * @see https://dhoulb.github.io/shelving/util/start/getStarter
+ * @see https://shelving.cc/util/start/getStarter
  */
 export function getStarter<T extends Arguments>(start: StartCallback<T> | Starter<T>): Starter<T> {
 	return typeof start === "function" ? new Starter(start) : start;

--- a/modules/util/string.ts
+++ b/modules/util/string.ts
@@ -11,21 +11,21 @@ import { isBetween } from "./number.js";
  * - Using `Iterable<string> & NotString` allows an iterable containing strings but not `string` itself.
  * - This helps catch this category of subtle errors.
  *
- * @see https://dhoulb.github.io/shelving/util/string/NotString
+ * @see https://shelving.cc/util/string/NotString
  */
 export type NotString = { toUpperCase?: never; toLowerCase?: never };
 
 /**
  * Things that can be reliably converted to a string with no confusion.
  *
- * @see https://dhoulb.github.io/shelving/util/string/PossibleString
+ * @see https://shelving.cc/util/string/PossibleString
  */
 export type PossibleString = boolean | string | number | Date;
 
 /**
  * Series of string segments with at least one segment (this is what you _actually_ get back when you split a string).
  *
- * @see https://dhoulb.github.io/shelving/util/string/Segments
+ * @see https://shelving.cc/util/string/Segments
  */
 export type Segments = readonly [string, ...string[]];
 
@@ -34,7 +34,7 @@ export type Segments = readonly [string, ...string[]];
  *
  * @param value The value to check.
  * @returns `true` if `value` is a `string`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isString
+ * @see https://shelving.cc/util/string/isString
  */
 export function isString(value: unknown): value is string {
 	return typeof value === "string";
@@ -47,7 +47,7 @@ export function isString(value: unknown): value is string {
  * @param caller Function to attribute a thrown error to (defaults to `assertString`).
  * @throws {RequiredError} If `value` is not a string.
  * @example assertString("a"); // Passes.
- * @see https://dhoulb.github.io/shelving/util/string/assertString
+ * @see https://shelving.cc/util/string/assertString
  */
 export function assertString(value: unknown, caller: AnyCaller = assertString): asserts value is string {
 	if (!isString(value)) throw new RequiredError(`Must be string`, { received: value, caller });
@@ -60,7 +60,7 @@ export function assertString(value: unknown, caller: AnyCaller = assertString): 
  * @param value The value to convert.
  * @returns The string representation of `value`, or `undefined` if it cannot be converted.
  * @example getString(123) // "123"
- * @see https://dhoulb.github.io/shelving/util/string/getString
+ * @see https://shelving.cc/util/string/getString
  */
 export function getString(value: unknown): string | undefined {
 	if (typeof value === "string") return value;
@@ -79,7 +79,7 @@ export function getString(value: unknown): string | undefined {
  * @returns The string representation of `value`.
  * @throws {RequiredError} If `value` cannot be converted to a string.
  * @example requireString(123) // "123"
- * @see https://dhoulb.github.io/shelving/util/string/requireString
+ * @see https://shelving.cc/util/string/requireString
  */
 export function requireString(value: PossibleString, caller: AnyCaller = requireString): string {
 	const str = getString(value);
@@ -94,7 +94,7 @@ export function requireString(value: PossibleString, caller: AnyCaller = require
  * @param min The minimum allowed length (defaults to `0`).
  * @param max The maximum allowed length (defaults to `Infinity`).
  * @returns `true` if `value` is a string within the length bounds, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isStringLength
+ * @see https://shelving.cc/util/string/isStringLength
  */
 export function isStringLength(value: unknown, min = 0, max = Number.POSITIVE_INFINITY): value is string {
 	return typeof value === "string" && value.length >= min && value.length <= max;
@@ -109,7 +109,7 @@ export function isStringLength(value: unknown, min = 0, max = Number.POSITIVE_IN
  * @param caller Function to attribute a thrown error to (defaults to `assertString`).
  * @throws {RequiredError} If `value` is not a string within the length bounds.
  * @example assertStringLength("abc", 1, 5); // Passes.
- * @see https://dhoulb.github.io/shelving/util/string/assertStringLength
+ * @see https://shelving.cc/util/string/assertStringLength
  */
 export function assertStringLength(value: unknown, min?: number, max?: number, caller: AnyCaller = assertString): asserts value is string {
 	if (!isStringLength(value, min, max))
@@ -126,7 +126,7 @@ export function assertStringLength(value: unknown, min?: number, max?: number, c
  * @returns The string representation of `value`.
  * @throws {RequiredError} If `value` cannot be converted to a string within the length bounds.
  * @example requireStringLength("abc", 1, 5) // "abc"
- * @see https://dhoulb.github.io/shelving/util/string/requireStringLength
+ * @see https://shelving.cc/util/string/requireStringLength
  */
 export function requireStringLength(value: PossibleString, min?: number, max?: number, caller: AnyCaller = requireString): string {
 	const str = getString(value);
@@ -141,7 +141,7 @@ export function requireStringLength(value: PossibleString, min?: number, max?: n
  * @param min The minimum allowed length (defaults to `0`).
  * @param max The maximum allowed length (defaults to `Infinity`).
  * @returns `true` if `str` is within the length bounds, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isStringBetween
+ * @see https://shelving.cc/util/string/isStringBetween
  */
 export function isStringBetween(str: string, min = 0, max = Number.POSITIVE_INFINITY): boolean {
 	return str.length >= min && str.length <= max;
@@ -155,7 +155,7 @@ export function isStringBetween(str: string, min = 0, max = Number.POSITIVE_INFI
  * @returns The joined string.
  * @throws {RequiredError} If `strs` is not a valid array of strings.
  * @example joinStrings(["a", "b"], "-") // "a-b"
- * @see https://dhoulb.github.io/shelving/util/string/joinStrings
+ * @see https://shelving.cc/util/string/joinStrings
  */
 export function joinStrings(strs: Iterable<string> & NotString, joiner = ""): string {
 	return requireArray(strs, undefined, undefined, joinStrings).join(joiner);
@@ -171,7 +171,7 @@ export function joinStrings(strs: Iterable<string> & NotString, joiner = ""): st
  * @param str The string to sanitize.
  * @returns The sanitized single-line string.
  * @example sanitizeText("\x00Nice!   ") // "Nice!"
- * @see https://dhoulb.github.io/shelving/util/string/sanitizeText
+ * @see https://shelving.cc/util/string/sanitizeText
  */
 export function sanitizeText(str: string): string {
 	return str
@@ -189,7 +189,7 @@ export function sanitizeText(str: string): string {
  * @param str The string to sanitize.
  * @returns The sanitized single-word string.
  * @example sanitizeWord("\x00 a b c "); // Returns `"abc"`
- * @see https://dhoulb.github.io/shelving/util/string/sanitizeWord
+ * @see https://shelving.cc/util/string/sanitizeWord
  */
 export function sanitizeWord(str: string): string {
 	return str
@@ -210,7 +210,7 @@ export function sanitizeWord(str: string): string {
  * @param str The string to sanitize.
  * @returns The sanitized multi-line string.
  * @example sanitizeMultilineText("\x00Line one\n\n\n\nLine two   ") // "Line one\n\nLine two"
- * @see https://dhoulb.github.io/shelving/util/string/sanitizeMultilineText
+ * @see https://shelving.cc/util/string/sanitizeMultilineText
  */
 export function sanitizeMultilineText(str: string): string {
 	return str
@@ -233,7 +233,7 @@ export function sanitizeMultilineText(str: string): string {
  * @param str The string to simplify.
  * @returns The simplified, lowercased string containing only numbers, letters, and single spaces.
  * @example simplifyString("Däve-is\nREALLY    éxcitable—apparęntly!!!    😂"); // Returns "dave is really excitable apparently"
- * @see https://dhoulb.github.io/shelving/util/string/simplifyString
+ * @see https://shelving.cc/util/string/simplifyString
  *
  * @todo Convert confusables (e.g. `ℵ` alef symbol or `℮` estimate symbol) to their letterlike equivalent (e.g. `N` and `e`).
  */
@@ -252,7 +252,7 @@ export function simplifyString(str: string): string {
  * @param str The string to convert.
  * @returns The `kebab-case` slug, or `undefined` if conversion resulted in an empty string.
  * @example getSlug("Hello World!") // "hello-world"
- * @see https://dhoulb.github.io/shelving/util/string/getSlug
+ * @see https://shelving.cc/util/string/getSlug
  */
 export function getSlug(str: string): string | undefined {
 	return simplifyString(str).replaceAll(" ", "-") || undefined;
@@ -266,7 +266,7 @@ export function getSlug(str: string): string | undefined {
  * @returns The `kebab-case` slug.
  * @throws {RequiredError} If conversion resulted in an empty string.
  * @example requireSlug("Hello World!") // "hello-world"
- * @see https://dhoulb.github.io/shelving/util/string/requireSlug
+ * @see https://shelving.cc/util/string/requireSlug
  */
 export function requireSlug(str: string, caller: AnyCaller = requireSlug): string {
 	const slug = getSlug(str);
@@ -280,7 +280,7 @@ export function requireSlug(str: string, caller: AnyCaller = requireSlug): strin
  * @param str The string to convert.
  * @returns The ref, or `undefined` if conversion resulted in an empty string.
  * @example getRef("Hello World!") // "helloworld"
- * @see https://dhoulb.github.io/shelving/util/string/getRef
+ * @see https://shelving.cc/util/string/getRef
  */
 export function getRef(str: string): string | undefined {
 	return simplifyString(str).replaceAll(" ", "") || undefined;
@@ -294,7 +294,7 @@ export function getRef(str: string): string | undefined {
  * @returns The ref.
  * @throws {RequiredError} If conversion resulted in an empty string.
  * @example requireRef("Hello World!") // "helloworld"
- * @see https://dhoulb.github.io/shelving/util/string/requireRef
+ * @see https://shelving.cc/util/string/requireRef
  */
 export function requireRef(str: string, caller: AnyCaller = requireRef): string {
 	const ref = getRef(str);
@@ -312,7 +312,7 @@ export function requireRef(str: string, caller: AnyCaller = requireRef): string 
  * @param str The string to extract words from.
  * @returns Array of the separate words and quoted phrases found in `str`.
  * @example getWords(`a "b c" d`) // ["a", "b c", "d"]
- * @see https://dhoulb.github.io/shelving/util/string/getWords
+ * @see https://shelving.cc/util/string/getWords
  */
 export function getWords(str: string): ImmutableArray<string> {
 	return Array.from(_getWords(str));
@@ -331,7 +331,7 @@ const WORD = /([^\s"]+)|"([^"]*)"|'([^']*)'/g; // Runs of characters without spa
  * @param str The string to read the first line from.
  * @returns The trimmed first line of `str` (everything before the first `\n` newline).
  * @example getFirstLine("first\nsecond") // "first"
- * @see https://dhoulb.github.io/shelving/util/string/getFirstLine
+ * @see https://shelving.cc/util/string/getFirstLine
  */
 export function getFirstLine(str: string): string {
 	const i = str.indexOf("\n");
@@ -343,7 +343,7 @@ export function getFirstLine(str: string): string {
  *
  * @param str The string whose first character is tested.
  * @returns `true` if the first character of `str` is an uppercase A–Z letter, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isUppercaseLetter
+ * @see https://shelving.cc/util/string/isUppercaseLetter
  */
 export function isUppercaseLetter(str: string): boolean {
 	return isBetween(str.charCodeAt(0), 65, 90);
@@ -354,7 +354,7 @@ export function isUppercaseLetter(str: string): boolean {
  *
  * @param str The string whose first character is tested.
  * @returns `true` if the first character of `str` is a lowercase a–z letter, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isLowercaseLetter
+ * @see https://shelving.cc/util/string/isLowercaseLetter
  */
 export function isLowercaseLetter(str: string): boolean {
 	return isBetween(str.charCodeAt(0), 97, 122);
@@ -370,7 +370,7 @@ export function isLowercaseLetter(str: string): boolean {
  * @param append The string to append when a limit is applied (defaults to `"…"`).
  * @returns `str` unchanged if it's shorter than `maxLength`, otherwise truncated with `append` added.
  * @example limitString("the quick brown fox", 9) // "the quick…"
- * @see https://dhoulb.github.io/shelving/util/string/limitString
+ * @see https://shelving.cc/util/string/limitString
  */
 export function limitString(str: string, maxLength: number, append = "…") {
 	if (str.length < maxLength) return str;
@@ -392,7 +392,7 @@ export function limitString(str: string, maxLength: number, append = "…") {
  * @returns Array of the divided segments.
  * @throws {ValueError} If `min` isn't met, or if any of the segments are empty.
  * @example splitString("a-b-c", "-", 2, 2) // ["a", "b-c"]
- * @see https://dhoulb.github.io/shelving/util/string/splitString
+ * @see https://shelving.cc/util/string/splitString
  */
 export function splitString(str: string, separator: string, min: 1, max: 1, caller?: AnyCaller): readonly [string];
 export function splitString(str: string, separator: string, min: 2, max: 2, caller?: AnyCaller): readonly [string, string];
@@ -444,7 +444,7 @@ export function splitString(
  * @param str The string to trim.
  * @returns `str` with whitespace trimmed from both ends.
  * @example ["  a  ", " b "].map(trimString) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/string/trimString
+ * @see https://shelving.cc/util/string/trimString
  */
 export function trimString(str: string): string {
 	return str.trim();
@@ -455,7 +455,7 @@ export function trimString(str: string): string {
  *
  * @param str The string to test.
  * @returns `true` if `str` has a length greater than zero, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/string/isNonEmptyString
+ * @see https://shelving.cc/util/string/isNonEmptyString
  */
 export function isNonEmptyString(str: string): boolean {
 	return str.length > 0;

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -30,21 +30,21 @@ type TemplateChunks = ImmutableArray<TemplateChunk>;
  * `ImmutableDictionary<PossibleString>` — Object containing named strings used for named placeholders, e.g. `{ val1: "Ellie", val2: 123 }`
  * `(placeholder: string) => string` — Function that returns the right string for a named `{placeholder}`.
  *
- * @see https://dhoulb.github.io/shelving/util/template/TemplateValues
+ * @see https://shelving.cc/util/template/TemplateValues
  */
 export type TemplateValues = PossibleString | ImmutableArray<unknown> | ImmutableDictionary<unknown> | ((placeholder: string) => string);
 
 /**
  * The output of matching a template is a dictionary in `{ myPlaceholder: "value" }` format.
  *
- * @see https://dhoulb.github.io/shelving/util/template/TemplateMatches
+ * @see https://shelving.cc/util/template/TemplateMatches
  */
 export type TemplateMatches = ImmutableDictionary<string>;
 
 /**
  * List of `{placeholders}` found in a template string.
  *
- * @see https://dhoulb.github.io/shelving/util/template/TemplatePlaceholders
+ * @see https://shelving.cc/util/template/TemplatePlaceholders
  */
 export type TemplatePlaceholders = ImmutableArray<string>;
 
@@ -106,7 +106,7 @@ function _splitTemplateCached(template: string, caller: AnyCaller): TemplateChun
  * @param template The template including template placeholders, e.g. `:name-${country}/{city}`
  * @returns Array of clean string names of found placeholders, e.g. `["name", "country", "city"]`
  * @example getPlaceholders(":name-${country}/{city}") // ["name", "country", "city"]
- * @see https://dhoulb.github.io/shelving/util/template/getPlaceholders
+ * @see https://shelving.cc/util/template/getPlaceholders
  */
 export function getPlaceholders(template: string): TemplatePlaceholders {
 	return _splitTemplateCached(template, getPlaceholders).map(_getPlaceholder);
@@ -126,7 +126,7 @@ function _getPlaceholder({ name }: TemplateChunk): string {
  * @returns An object containing values (e.g. `{ name: "Dave", country: "UK", city: "Manchester" }`), or `undefined` if no match.
  * @throws {ValueError} If two template placeholders are not separated by at least one character.
  * @example matchTemplate(":name-${country}/{city}", "Dave-UK/Manchester") // { name: "Dave", country: "UK", city: "Manchester" }
- * @see https://dhoulb.github.io/shelving/util/template/matchTemplate
+ * @see https://shelving.cc/util/template/matchTemplate
  */
 export function matchTemplate(template: string, target: string, caller: AnyCaller = matchTemplate): TemplateMatches | undefined {
 	return _matchTemplate(template, target, "", caller);
@@ -143,7 +143,7 @@ export function matchTemplate(template: string, target: string, caller: AnyCalle
  * @returns An object containing values (e.g. `{ name: "Dave" }`), or `undefined` if no match.
  * @throws {ValueError} If two template placeholders are not separated by at least one character.
  * @example matchPathTemplate("/users/{name}", "/users/Dave") // { name: "Dave" }
- * @see https://dhoulb.github.io/shelving/util/template/matchPathTemplate
+ * @see https://shelving.cc/util/template/matchPathTemplate
  */
 export function matchPathTemplate(
 	template: AbsolutePath,
@@ -201,7 +201,7 @@ function _matchTemplate(template: string, target: string, separator: string, cal
  * @param target The string containing values, e.g. `Dave-40`.
  * @returns An object of values for the first matching template, or `undefined` if none match.
  * @example matchTemplates([":name-:age", ":name"], "Dave-40") // { name: "Dave", age: "40" }
- * @see https://dhoulb.github.io/shelving/util/template/matchTemplates
+ * @see https://shelving.cc/util/template/matchTemplates
  */
 export function matchTemplates(templates: Iterable<string> & NotString, target: string): TemplateMatches | undefined {
 	for (const template of templates) {
@@ -217,7 +217,7 @@ export function matchTemplates(templates: Iterable<string> & NotString, target: 
  * @param target The path containing values, e.g. `/users/Dave`.
  * @returns An object of values for the first matching template, or `undefined` if none match.
  * @example matchPathTemplates(["/users/{name}", "/users"], "/users/Dave") // { name: "Dave" }
- * @see https://dhoulb.github.io/shelving/util/template/matchPathTemplates
+ * @see https://shelving.cc/util/template/matchPathTemplates
  */
 export function matchPathTemplates(templates: Iterable<AbsolutePath> & NotString, target: AbsolutePath): TemplateMatches | undefined {
 	for (const template of templates) {
@@ -235,7 +235,7 @@ export function matchPathTemplates(templates: Iterable<AbsolutePath> & NotString
  * @returns The rendered string, e.g. `Dave-UK/Manchester`
  * @throws {RequiredError} If a placeholder in the template string is not specified in values.
  * @example renderTemplate(":name-${country}/{city}", { name: "Dave", country: "UK", city: "Manchester" }) // "Dave-UK/Manchester"
- * @see https://dhoulb.github.io/shelving/util/template/renderTemplate
+ * @see https://shelving.cc/util/template/renderTemplate
  */
 export function renderTemplate(template: string, values: TemplateValues, caller: AnyCaller = renderTemplate): string {
 	const chunks = _splitTemplateCached(template, caller);
@@ -273,7 +273,7 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
  * @returns The rendered path, e.g. `/users/Dave`.
  * @throws {RequiredError} If a placeholder in the template string is not specified in values.
  * @example renderPathTemplate("/users/{name}", { name: "Dave" }) // "/users/Dave"
- * @see https://dhoulb.github.io/shelving/util/template/renderPathTemplate
+ * @see https://shelving.cc/util/template/renderPathTemplate
  */
 export function renderPathTemplate(template: AbsolutePath, values: TemplateValues, caller: AnyCaller = renderPathTemplate): AbsolutePath {
 	return renderTemplate(template, values, caller) as AbsolutePath;

--- a/modules/util/timeout.ts
+++ b/modules/util/timeout.ts
@@ -10,7 +10,7 @@ import type { Callback } from "./function.js";
  * const timeout = new Timeout(() => console.log("fired"), 1000);
  * timeout.set(); // Fires the callback after 1000ms.
  * timeout.clear(); // Cancels it before it fires.
- * @see https://dhoulb.github.io/shelving/util/timeout/Timeout
+ * @see https://shelving.cc/util/timeout/Timeout
  */
 export class Timeout {
 	private _callback: Callback | undefined;
@@ -23,7 +23,7 @@ export class Timeout {
 	 * @param callback The default callback to run when a timeout fires (used by `set()` when no callback is passed).
 	 * @param ms The default delay for any created timeouts (in ms).
 	 * @example new Timeout(() => console.log("fired"), 1000)
-	 * @see https://dhoulb.github.io/shelving/util/timeout/Timeout
+	 * @see https://shelving.cc/util/timeout/Timeout
 	 */
 	constructor(callback: Callback | undefined = undefined, ms = 0) {
 		this._callback = callback;
@@ -33,7 +33,7 @@ export class Timeout {
 	/**
 	 * Whether a timeout is currently pending.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/timeout/Timeout/exists
+	 * @see https://shelving.cc/util/timeout/Timeout/exists
 	 */
 	get exists(): boolean {
 		return !!this._timeout;
@@ -46,7 +46,7 @@ export class Timeout {
 	 * @param ms The delay for this timeout (in ms, defaults to the delay passed to the constructor).
 	 * @returns Nothing.
 	 * @example timeout.set(() => console.log("fired"), 500);
-	 * @see https://dhoulb.github.io/shelving/util/timeout/Timeout/set
+	 * @see https://shelving.cc/util/timeout/Timeout/set
 	 */
 	set(callback: Callback | undefined = this._callback, ms: number = this._ms): void {
 		this.clear();
@@ -58,7 +58,7 @@ export class Timeout {
 	 *
 	 * @returns Nothing.
 	 * @example timeout.clear();
-	 * @see https://dhoulb.github.io/shelving/util/timeout/Timeout/clear
+	 * @see https://shelving.cc/util/timeout/Timeout/clear
 	 */
 	clear(): void {
 		const timeout = this._timeout;

--- a/modules/util/transform.ts
+++ b/modules/util/transform.ts
@@ -9,7 +9,7 @@ import { getProps } from "./object.js";
 /**
  * Set of named transforms for a data object, keyed by prop name (or `undefined` to skip the transform for that prop).
  *
- * @see https://dhoulb.github.io/shelving/util/transform/Transforms
+ * @see https://shelving.cc/util/transform/Transforms
  */
 export type Transforms<I extends ImmutableObject, O extends ImmutableObject, A extends Arguments = []> = {
 	readonly [K in keyof I]?: (input: I[K], ...args: A) => O[K];
@@ -23,7 +23,7 @@ export type Transforms<I extends ImmutableObject, O extends ImmutableObject, A e
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns An iterable yielding each transformed item.
  * @example [...mapItems([1, 2], n => n * 2)] // [2, 4]
- * @see https://dhoulb.github.io/shelving/util/transform/mapItems
+ * @see https://shelving.cc/util/transform/mapItems
  */
 export function* mapItems<I, O, A extends Arguments = []>(items: Iterable<I>, transform: (v: I, ...args: A) => O, ...args: A): Iterable<O> {
 	for (const item of items) yield transform(item, ...args);
@@ -37,7 +37,7 @@ export function* mapItems<I, O, A extends Arguments = []>(items: Iterable<I>, tr
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns A new array containing each transformed item.
  * @example mapArray([1, 2], n => n * 2) // [2, 4]
- * @see https://dhoulb.github.io/shelving/util/transform/mapArray
+ * @see https://shelving.cc/util/transform/mapArray
  */
 export function mapArray<I, O, A extends Arguments = []>(
 	arr: Iterable<I>,
@@ -56,7 +56,7 @@ export function mapArray<I, O, A extends Arguments = []>(
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns A new object with the same keys and transformed values.
  * @example mapProps({ a: 1, b: 2 }, ([, v]) => v * 2) // { a: 2, b: 4 }
- * @see https://dhoulb.github.io/shelving/util/transform/mapProps
+ * @see https://shelving.cc/util/transform/mapProps
  */
 export function mapProps<I extends ImmutableObject, O extends ImmutableObject, A extends Arguments = []>(
 	obj: I,
@@ -75,7 +75,7 @@ export function mapProps<I extends ImmutableObject, O extends ImmutableObject, A
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns A new dictionary with the same keys and transformed values.
  * @example mapDictionary({ a: 1, b: 2 }, v => v * 2) // { a: 2, b: 4 }
- * @see https://dhoulb.github.io/shelving/util/transform/mapDictionary
+ * @see https://shelving.cc/util/transform/mapDictionary
  */
 export function mapDictionary<I, O, A extends Arguments = []>(
 	dictionary: ImmutableDictionary<I>,
@@ -94,7 +94,7 @@ export function mapDictionary<I, O, A extends Arguments = []>(
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns An iterable of `[key, transformedValue]` entries.
  * @example [...mapEntries([["a", 1]], ([, v]) => v * 2)] // [["a", 2]]
- * @see https://dhoulb.github.io/shelving/util/transform/mapEntries
+ * @see https://shelving.cc/util/transform/mapEntries
  */
 export function* mapEntries<K, I, O, A extends Arguments = []>(
 	entries: Iterable<Entry<K, I>>,
@@ -113,7 +113,7 @@ export function* mapEntries<K, I, O, A extends Arguments = []>(
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns An iterable of `[key, transformedValue]` entries.
  * @example [...mapEntryValues([["a", 1]], v => v * 2)] // [["a", 2]]
- * @see https://dhoulb.github.io/shelving/util/transform/mapEntryValues
+ * @see https://shelving.cc/util/transform/mapEntryValues
  */
 export function* mapEntryValues<K, I, O, A extends Arguments = []>(
 	entries: Iterable<Entry<K, I>>,
@@ -133,7 +133,7 @@ export function* mapEntryValues<K, I, O, A extends Arguments = []>(
  * @param args Additional arguments passed through to each transform.
  * @returns Transformed object (or same object if no changes were made).
  * @example transformObject({ a: 1, b: 2 }, { a: n => n + 10 }) // { a: 11, b: 2 }
- * @see https://dhoulb.github.io/shelving/util/transform/transformObject
+ * @see https://shelving.cc/util/transform/transformObject
  */
 export function transformObject<T extends ImmutableObject, A extends Arguments = []>(
 	obj: T,
@@ -186,7 +186,7 @@ export function transformObject<A extends Arguments = []>(
  * @param args Additional arguments passed through to `transform` on every call.
  * @returns An async iterable yielding each transformed item.
  * @example for await (const n of mapSequence(source, x => x * 2)) use(n);
- * @see https://dhoulb.github.io/shelving/util/transform/mapSequence
+ * @see https://shelving.cc/util/transform/mapSequence
  */
 export async function* mapSequence<I, O, A extends Arguments = []>(
 	sequence: AsyncIterable<I>,

--- a/modules/util/tree.ts
+++ b/modules/util/tree.ts
@@ -10,7 +10,7 @@ import { getWords } from "./string.js";
 /**
  * Props for a tree element — must have a `tree-` prefixed type.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/TreeElementProps
+ * @see https://shelving.cc/util/tree/TreeElementProps
  */
 export interface TreeElementProps extends ElementProps {
 	/**
@@ -60,7 +60,7 @@ export interface TreeElementProps extends ElementProps {
  * - Requires a string `key` prop (can be resolved to a path).
  * - Props can include `title`, `description`, and/or `content` to be useful.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/TreeElement
+ * @see https://shelving.cc/util/tree/TreeElement
  */
 export interface TreeElement<P extends TreeElementProps = TreeElementProps> extends Element<P> {
 	readonly key: string;
@@ -70,14 +70,14 @@ export interface TreeElement<P extends TreeElementProps = TreeElementProps> exte
 /**
  * Collection of tree elements.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/TreeElements
+ * @see https://shelving.cc/util/tree/TreeElements
  */
 export type TreeElements = Elements<TreeElement>;
 
 /**
  * A single parameter for a documented code symbol.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationParam
+ * @see https://shelving.cc/util/tree/DocumentationParam
  */
 export interface DocumentationParam {
 	readonly name: string;
@@ -94,7 +94,7 @@ export interface DocumentationParam {
 /**
  * A single `@returns` entry — multiple allowed to document union return types separately.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationReturn
+ * @see https://shelving.cc/util/tree/DocumentationReturn
  */
 export interface DocumentationReturn {
 	/** Type expression for the return value; renderers default to `"unknown"` when missing. */
@@ -105,7 +105,7 @@ export interface DocumentationReturn {
 /**
  * A single `@throws` entry — multiple allowed to document distinct error types.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationThrow
+ * @see https://shelving.cc/util/tree/DocumentationThrow
  */
 export interface DocumentationThrow {
 	/** Type expression for the thrown value; renderers default to `"unknown"` when missing. */
@@ -116,7 +116,7 @@ export interface DocumentationThrow {
 /**
  * A single `@example` entry — the example text/code block.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationExample
+ * @see https://shelving.cc/util/tree/DocumentationExample
  */
 export interface DocumentationExample {
 	readonly description?: string | undefined;
@@ -128,7 +128,7 @@ export interface DocumentationExample {
  * - All props are optional — not every kind uses every prop (e.g. `returns` only makes sense for functions).
  * - `signatures` is an array so overloaded function/method declarations can each contribute their own signature to the same documentation element.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationElementProps
+ * @see https://shelving.cc/util/tree/DocumentationElementProps
  */
 export interface DocumentationElementProps extends TreeElementProps {
 	// `name` is inherited from `TreeElementProps` — the declared symbol name (e.g. `"getFirst"`).
@@ -163,7 +163,7 @@ export interface DocumentationElementProps extends TreeElementProps {
  * Element representing a documented code symbol.
  * - The `kind` prop distinguishes specific symbol types (function, class, property, etc.) without baking the list in.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/DocumentationElement
+ * @see https://shelving.cc/util/tree/DocumentationElement
  */
 export interface DocumentationElement extends TreeElement<DocumentationElementProps> {
 	readonly type: "tree-documentation";
@@ -196,7 +196,7 @@ declare module "react" {
  * @param base An existing map to merge onto (copied, not mutated). Useful to combine several trees into one lookup.
  * @returns A new `Map` keyed by both flat key and canonical path, whose values are copies of every element stamped with its canonical `path`.
  * @example flattenTree(root).get("/schema/BooleanSchema") // the stamped `BooleanSchema` element
- * @see https://dhoulb.github.io/shelving/util/tree/flattenTree
+ * @see https://shelving.cc/util/tree/flattenTree
  */
 export function flattenTree(root: TreeElement, base?: ReadonlyMap<string, TreeElement>): Map<string, TreeElement> {
 	const map = new Map<string, TreeElement>(base);
@@ -226,7 +226,7 @@ function _flatKey(element: TreeElement): string {
 /**
  * Options for `searchTree()`.
  *
- * @see https://dhoulb.github.io/shelving/util/tree/SearchTreeOptions
+ * @see https://shelving.cc/util/tree/SearchTreeOptions
  */
 export interface SearchTreeOptions {
 	/** Maximum number of results to return (defaults to `20`). */
@@ -251,7 +251,7 @@ export interface SearchTreeOptions {
  * @param query The search string — bare words plus `"quoted phrases"`.
  * @returns The matching descendants, best first, capped at `limit`.
  * @example searchTree(root, "store", { limit: 10, filter: { kind: "class" } }) // up to 10 classes ranked for "store"
- * @see https://dhoulb.github.io/shelving/util/tree/searchTree
+ * @see https://shelving.cc/util/tree/searchTree
  */
 export function searchTree(scope: TreeElement, query: string, options?: SearchTreeOptions): TreeElement[] {
 	const { limit = 20, filter } = options ?? {};

--- a/modules/util/types.ts
+++ b/modules/util/types.ts
@@ -3,7 +3,7 @@
  *
  * - i.e. `A | B` becomes `A & B`
  *
- * @see https://dhoulb.github.io/shelving/util/types/UnionToIntersection
+ * @see https://shelving.cc/util/types/UnionToIntersection
  */
 export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 
@@ -12,6 +12,6 @@ export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never
  *
  * - i.e. `{ a: string } & { b: number }` becomes `{ a: string, b: number }`
  *
- * @see https://dhoulb.github.io/shelving/util/types/Resolve
+ * @see https://shelving.cc/util/types/Resolve
  */
 export type Resolve<T> = { [K in keyof T]: T[K] };

--- a/modules/util/undefined.ts
+++ b/modules/util/undefined.ts
@@ -8,7 +8,7 @@ import type { AnyCaller } from "./function.js";
  *
  * @returns Always `undefined`.
  * @example getUndefined() // undefined
- * @see https://dhoulb.github.io/shelving/util/undefined/getUndefined
+ * @see https://shelving.cc/util/undefined/getUndefined
  */
 export function getUndefined(): undefined {
 	return undefined;
@@ -19,7 +19,7 @@ export function getUndefined(): undefined {
  *
  * @param value The value to test.
  * @returns `true` if the value is `undefined`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/undefined/isUndefined
+ * @see https://shelving.cc/util/undefined/isUndefined
  */
 export function isUndefined(value: unknown): value is undefined {
 	return value === undefined;
@@ -30,7 +30,7 @@ export function isUndefined(value: unknown): value is undefined {
  *
  * @param value The value to test.
  * @returns `true` if the value is not `undefined`, otherwise `false`.
- * @see https://dhoulb.github.io/shelving/util/undefined/isDefined
+ * @see https://shelving.cc/util/undefined/isDefined
  */
 export function isDefined<T>(value: T | undefined): value is T {
 	return value !== undefined;
@@ -39,7 +39,7 @@ export function isDefined<T>(value: T | undefined): value is T {
 /**
  * Is a value defined (i.e. not `undefined`)? Alias for `isDefined()`.
  *
- * @see https://dhoulb.github.io/shelving/util/undefined/notUndefined
+ * @see https://shelving.cc/util/undefined/notUndefined
  */
 export const notUndefined = isDefined;
 
@@ -50,7 +50,7 @@ export const notUndefined = isDefined;
  * @param caller Function to attribute the thrown error to (defaults to `assertDefined`).
  * @throws `RequiredError` if the value is `undefined`.
  * @example assertDefined(value) // throws `RequiredError` if `value` is `undefined`
- * @see https://dhoulb.github.io/shelving/util/undefined/assertDefined
+ * @see https://shelving.cc/util/undefined/assertDefined
  */
 export function assertDefined<T>(value: T | undefined, caller: AnyCaller = assertDefined): asserts value is T {
 	if (value === undefined) throw new RequiredError("Must be defined", { received: value, caller });
@@ -64,7 +64,7 @@ export function assertDefined<T>(value: T | undefined, caller: AnyCaller = asser
  * @returns The value, guaranteed not to be `undefined`.
  * @throws `RequiredError` if the value is `undefined`.
  * @example requireDefined(value) // value (or throws if `undefined`)
- * @see https://dhoulb.github.io/shelving/util/undefined/requireDefined
+ * @see https://shelving.cc/util/undefined/requireDefined
  */
 export function requireDefined<T>(value: T | undefined, caller: AnyCaller = requireDefined): T {
 	assertDefined(value, caller);

--- a/modules/util/units.ts
+++ b/modules/util/units.ts
@@ -33,7 +33,7 @@ interface UnitProps<T extends string> extends UnitFormatOptions {
  * @param key String key for this unit, e.g. `kilometer`.
  * @param props Props to configure this unit (conversions and formatting options).
  * @example LENGTH_UNITS.require("kilometer").to(5, "meter") // 5000
- * @see https://dhoulb.github.io/shelving/util/units/Unit
+ * @see https://shelving.cc/util/units/Unit
  */
 export class Unit<K extends string> {
 	private readonly _to: Conversions<K> | undefined;
@@ -41,19 +41,19 @@ export class Unit<K extends string> {
 	/**
 	 * `UnitList` this unit belongs to.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/list
+	 * @see https://shelving.cc/util/units/Unit/list
 	 */
 	public readonly list: UnitList<K>;
 	/**
 	 * String key for this unit, e.g. `kilometer`
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/key
+	 * @see https://shelving.cc/util/units/Unit/key
 	 */
 	public readonly key: K;
 	/**
 	 * Possible options for formatting these units.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/options
+	 * @see https://shelving.cc/util/units/Unit/options
 	 */
 	public readonly options: Readonly<UnitFormatOptions> | undefined;
 
@@ -80,7 +80,7 @@ export class Unit<K extends string> {
 	 * @throws `RequiredError` if `targetKey` is not a unit in this list.
 	 * @throws `ValueError` if no conversion path exists to the target unit.
 	 * @example LENGTH_UNITS.require("kilometer").to(1, "meter") // 1000
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/to
+	 * @see https://shelving.cc/util/units/Unit/to
 	 */
 	to(amount: number, targetKey?: K): number {
 		const target = targetKey ? _requireUnit(this.to, this.list, targetKey) : this.list.base;
@@ -96,7 +96,7 @@ export class Unit<K extends string> {
 	 * @throws `RequiredError` if `sourceKey` is not a unit in this list.
 	 * @throws `ValueError` if no conversion path exists from the source unit.
 	 * @example LENGTH_UNITS.require("kilometer").from(1000, "meter") // 1
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/from
+	 * @see https://shelving.cc/util/units/Unit/from
 	 */
 	from(amount: number, sourceKey?: K): number {
 		const source = sourceKey ? _requireUnit(this.from, this.list, sourceKey) : this.list.base;
@@ -138,7 +138,7 @@ export class Unit<K extends string> {
 	 * @param options Formatting options merged over this unit's own `options`.
 	 * @returns The formatted unit string.
 	 * @example MASS_UNITS.require("kilogram").format(12) // "12 kg"
-	 * @see https://dhoulb.github.io/shelving/util/units/Unit/format
+	 * @see https://shelving.cc/util/units/Unit/format
 	 */
 	format(amount: number, options?: UnitFormatOptions): string {
 		return formatUnit(amount, this.key, { ...this.options, ...options });
@@ -153,13 +153,13 @@ export class Unit<K extends string> {
  *
  * @param units Set of units keyed by their string key — the first entry becomes the base unit.
  * @example new UnitList({ meter: {}, kilometer: { to: { meter: 1000 } } }).convert(1, "kilometer", "meter") // 1000
- * @see https://dhoulb.github.io/shelving/util/units/UnitList
+ * @see https://shelving.cc/util/units/UnitList
  */
 export class UnitList<K extends string> extends ImmutableMap<K, Unit<K>> {
 	/**
 	 * Base unit for this list (the first unit added).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/units/UnitList/base
+	 * @see https://shelving.cc/util/units/UnitList/base
 	 */
 	public readonly base!: Unit<K>;
 	constructor(units: ImmutableObject<K, UnitProps<K>>) {
@@ -181,7 +181,7 @@ export class UnitList<K extends string> extends ImmutableMap<K, Unit<K>> {
 	 * @throws `RequiredError` if `sourceKey` or `targetKey` is not a unit in this list.
 	 * @throws `ValueError` if no conversion path exists between the units.
 	 * @example LENGTH_UNITS.convert(1, "kilometer", "meter") // 1000
-	 * @see https://dhoulb.github.io/shelving/util/units/UnitList/convert
+	 * @see https://shelving.cc/util/units/UnitList/convert
 	 */
 	convert(amount: number, sourceKey: K, targetKey: K): number {
 		return _requireUnit(this.convert, this, sourceKey).to(amount, targetKey);
@@ -193,7 +193,7 @@ export class UnitList<K extends string> extends ImmutableMap<K, Unit<K>> {
 	 * @param key Key of the unit to retrieve.
 	 * @throws `RequiredError` if the unit key is not found.
 	 * @example LENGTH_UNITS.require("kilometer") // Unit instance
-	 * @see https://dhoulb.github.io/shelving/util/units/UnitList/require
+	 * @see https://shelving.cc/util/units/UnitList/require
 	 */
 	require(key: K): Unit<K> {
 		return _requireUnit(this.require, this, key);
@@ -239,7 +239,7 @@ const IMP_ML_PER_GAL = 4546090 / 1000;
 /**
  * Percentage units.
  *
- * @see https://dhoulb.github.io/shelving/util/units/PERCENT_UNITS
+ * @see https://shelving.cc/util/units/PERCENT_UNITS
  */
 export const PERCENT_UNITS = new UnitList({
 	percent: { abbr: "%", many: "percent" },
@@ -247,14 +247,14 @@ export const PERCENT_UNITS = new UnitList({
 /**
  * String key for a percentage unit.
  *
- * @see https://dhoulb.github.io/shelving/util/units/PercentUnitKey
+ * @see https://shelving.cc/util/units/PercentUnitKey
  */
 export type PercentUnitKey = MapKey<typeof PERCENT_UNITS>;
 
 /**
  * Point units.
  *
- * @see https://dhoulb.github.io/shelving/util/units/POINT_UNITS
+ * @see https://shelving.cc/util/units/POINT_UNITS
  */
 export const POINT_UNITS = new UnitList({
 	"basis-point": { abbr: "bp" },
@@ -263,14 +263,14 @@ export const POINT_UNITS = new UnitList({
 /**
  * String key for a point unit.
  *
- * @see https://dhoulb.github.io/shelving/util/units/PointUnitKey
+ * @see https://shelving.cc/util/units/PointUnitKey
  */
 export type PointUnitKey = MapKey<typeof POINT_UNITS>;
 
 /**
  * Angle units.
  *
- * @see https://dhoulb.github.io/shelving/util/units/ANGLE_UNITS
+ * @see https://shelving.cc/util/units/ANGLE_UNITS
  */
 export const ANGLE_UNITS = new UnitList({
 	degree: { abbr: "deg" },

--- a/modules/util/update.ts
+++ b/modules/util/update.ts
@@ -15,7 +15,7 @@ import { isDefined } from "./undefined.js";
  * Note: string templates infer best when you have fixed character(s) at the start,
  *   so our `Update` syntax always
  *
- * @see https://dhoulb.github.io/shelving/util/update/Updates
+ * @see https://shelving.cc/util/update/Updates
  */
 export type Updates<T extends Data = Data> = {
 	/**
@@ -53,7 +53,7 @@ export type Updates<T extends Data = Data> = {
  *
  * - Discriminated by `action`: `"set"`, `"with"` (add array items), `"omit"` (remove array items), or `"sum"` (add to a number).
  *
- * @see https://dhoulb.github.io/shelving/util/update/Update
+ * @see https://shelving.cc/util/update/Update
  */
 export type Update =
 	| { action: "set"; key: Segments; value: unknown } //
@@ -70,7 +70,7 @@ export type Update =
  * @returns Array of decoded `Update` objects.
  * @throws `RequiredError` if a `+=`/`-=` sum update has a non-number value.
  * @example getUpdates({ "+=count": 1 }) // [{ action: "sum", key: ["count"], value: 1 }]
- * @see https://dhoulb.github.io/shelving/util/update/getUpdates
+ * @see https://shelving.cc/util/update/getUpdates
  */
 export function getUpdates<T extends Data>(data: Updates<T>): ImmutableArray<Update> {
 	return getProps(data).map(_getUpdate).filter(isDefined);
@@ -103,7 +103,7 @@ function _getUpdate([key, value]: DataProp<Updates>): Update | undefined {
  * @returns The updated data object (or the original reference if nothing changed).
  * @throws `RequiredError` if a `+=`/`-=` sum update has a non-number value.
  * @example updateData({ count: 1 }, { "+=count": 2 }) // { count: 3 }
- * @see https://dhoulb.github.io/shelving/util/update/updateData
+ * @see https://shelving.cc/util/update/updateData
  */
 export function updateData<T extends Data>(data: T, updates: Updates<T>): T {
 	return reduceItems(getUpdates(updates), _updateProp, data);

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -17,21 +17,21 @@ import type { ImmutableURL, URLString } from "./url.js";
  * - URLs can be considered as "hierarchical URIs".
  * - All URLs are also URIs, but not all URIs are URLs.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/URIString
+ * @see https://shelving.cc/util/uri/URIString
  */
 export type URIString = `${string}:${string}`;
 
 /**
  * String for the search component of a URI, including the leading `?`
  *
- * @see https://dhoulb.github.io/shelving/util/uri/URISearch
+ * @see https://shelving.cc/util/uri/URISearch
  */
 export type URISearch = `?${string}`;
 
 /**
  * String for the hash component of a URI, including the leading `#`
  *
- * @see https://dhoulb.github.io/shelving/util/uri/URIHash
+ * @see https://shelving.cc/util/uri/URIHash
  */
 export type URIHash = `#${string}`;
 
@@ -41,7 +41,7 @@ export type URIHash = `#${string}`;
  * - Takes a URI string or URI object that already encodes a complete URI — no base parameter, so relative inputs are not accepted.
  * - To resolve a relative input against a base, use `getBasedURI()` from `url.ts`.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURIConstructor
+ * @see https://shelving.cc/util/uri/ImmutableURIConstructor
  */
 export interface ImmutableURIConstructor {
 	/**
@@ -50,7 +50,7 @@ export interface ImmutableURIConstructor {
 	 * @param input URI string or URI object that already encodes a complete URI.
 	 * @returns New `ImmutableURI` instance.
 	 * @throws {TypeError} If `input` is not a valid complete URI.
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURIConstructor/new
+	 * @see https://shelving.cc/util/uri/ImmutableURIConstructor/new
 	 */
 	new (input: URIString | ImmutableURI): ImmutableURI;
 }
@@ -66,87 +66,87 @@ export interface ImmutableURIConstructor {
  * - URLs can be considered as "hierarchical URIs".
  * - All URLs are also URIs, but not all URIs are URLs.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI
+ * @see https://shelving.cc/util/uri/ImmutableURI
  */
 export interface ImmutableURI extends URL {
 	/**
 	 * Hash component of the URI, including the leading `#` (empty string if absent).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/hash
+	 * @see https://shelving.cc/util/uri/ImmutableURI/hash
 	 */
 	readonly hash: URIHash | ``;
 	/**
 	 * Host component of the URI (hostname and port), or empty string for non-hierarchical URIs.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/host
+	 * @see https://shelving.cc/util/uri/ImmutableURI/host
 	 */
 	readonly host: string;
 	/**
 	 * Hostname component of the URI, or empty string for non-hierarchical URIs.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/hostname
+	 * @see https://shelving.cc/util/uri/ImmutableURI/hostname
 	 */
 	readonly hostname: string;
 	/**
 	 * Full URI string.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/href
+	 * @see https://shelving.cc/util/uri/ImmutableURI/href
 	 */
 	readonly href: URIString;
 	/**
 	 * Origin of the URI, or the string `"null"` for origins that cannot be serialised.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/origin
+	 * @see https://shelving.cc/util/uri/ImmutableURI/origin
 	 */
 	readonly origin: URIString | `null`;
 	/**
 	 * Password component of the URI (empty string if absent).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/password
+	 * @see https://shelving.cc/util/uri/ImmutableURI/password
 	 */
 	readonly password: string;
 	/**
 	 * Pathname component of the URI.
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/pathname
+	 * @see https://shelving.cc/util/uri/ImmutableURI/pathname
 	 */
 	readonly pathname: string;
 	/**
 	 * Port component of the URI (empty string if absent).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/port
+	 * @see https://shelving.cc/util/uri/ImmutableURI/port
 	 */
 	readonly port: string;
 	/**
 	 * Protocol scheme of the URI, including the trailing `:`
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/protocol
+	 * @see https://shelving.cc/util/uri/ImmutableURI/protocol
 	 */
 	readonly protocol: URIScheme;
 	/**
 	 * Search component of the URI, including the leading `?` (empty string if absent).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/search
+	 * @see https://shelving.cc/util/uri/ImmutableURI/search
 	 */
 	readonly search: URISearch | ``;
 	/**
 	 * Username component of the URI (empty string if absent).
 	 *
-	 * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI/username
+	 * @see https://shelving.cc/util/uri/ImmutableURI/username
 	 */
 	readonly username: string;
 }
 /**
  * Correctly-typed `URI` constructor (the builtin `URL` class typed as `ImmutableURIConstructor`).
  *
- * @see https://dhoulb.github.io/shelving/util/uri/ImmutableURI
+ * @see https://shelving.cc/util/uri/ImmutableURI
  */
 export const ImmutableURI = URL as ImmutableURIConstructor;
 
 /**
  * Values that can be converted to an `ImmutableURI` instance.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/PossibleURI
+ * @see https://shelving.cc/util/uri/PossibleURI
  */
 export type PossibleURI = string | URL;
 
@@ -156,7 +156,7 @@ export type PossibleURI = string | URL;
  * @param value The value to test.
  * @returns `true` if `value` is an `ImmutableURI`, narrowing its type.
  * @example isURI(new URL("http://x.com")) // true
- * @see https://dhoulb.github.io/shelving/util/uri/isURI
+ * @see https://shelving.cc/util/uri/isURI
  */
 export function isURI(value: unknown): value is ImmutableURI {
 	return value instanceof ImmutableURI;
@@ -168,7 +168,7 @@ export function isURI(value: unknown): value is ImmutableURI {
  * @param value The value to assert.
  * @param caller Function to attribute a thrown error to (defaults to `assertURI` itself).
  * @throws {RequiredError} If `value` is not a URI object.
- * @see https://dhoulb.github.io/shelving/util/uri/assertURI
+ * @see https://shelving.cc/util/uri/assertURI
  */
 export function assertURI(value: unknown, caller: AnyCaller = assertURI): asserts value is ImmutableURI {
 	if (!isURI(value)) throw new RequiredError("Invalid URI", { received: value, caller });
@@ -182,7 +182,7 @@ export function assertURI(value: unknown, caller: AnyCaller = assertURI): assert
  * @param possible Possible URI value to convert (a nullish value returns `undefined`).
  * @returns Converted `ImmutableURI`, or `undefined` if conversion fails.
  * @example getURI("http://shax.com") // URL { … }
- * @see https://dhoulb.github.io/shelving/util/uri/getURI
+ * @see https://shelving.cc/util/uri/getURI
  */
 export function getURI(possible: Nullish<PossibleURI>): ImmutableURI | undefined {
 	if (!possible) return;
@@ -202,7 +202,7 @@ export function getURI(possible: Nullish<PossibleURI>): ImmutableURI | undefined
  * @returns Converted `ImmutableURI`.
  * @throws {RequiredError} If `possible` cannot be converted to a valid URI.
  * @example requireURI("http://shax.com") // URL { … }
- * @see https://dhoulb.github.io/shelving/util/uri/requireURI
+ * @see https://shelving.cc/util/uri/requireURI
  */
 export function requireURI(possible: PossibleURI, caller: AnyCaller = requireURI): ImmutableURI {
 	const url = getURI(possible);
@@ -213,14 +213,14 @@ export function requireURI(possible: PossibleURI, caller: AnyCaller = requireURI
 /**
  * Type for a set of named URI parameters.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/URIParams
+ * @see https://shelving.cc/util/uri/URIParams
  */
 export type URIParams = ImmutableDictionary<string>;
 
 /**
  * Type for things that can be converted to named URI parameters.
  *
- * @see https://dhoulb.github.io/shelving/util/uri/PossibleURIParams
+ * @see https://shelving.cc/util/uri/PossibleURIParams
  */
 export type PossibleURIParams = PossibleURI | URLSearchParams | ImmutableDictionary<unknown>;
 
@@ -261,7 +261,7 @@ function* getURIEntries(params: PossibleURIParams, caller: AnyCaller = getURIPar
  * @throws {RequiredError} If `params` is a string or URL that cannot be converted to a valid URI.
  * @throws {ValueError} If any param value cannot be converted to a string.
  * @example getURIParams("http://x.com?a=1&b=2") // { a: "1", b: "2" }
- * @see https://dhoulb.github.io/shelving/util/uri/getURIParams
+ * @see https://shelving.cc/util/uri/getURIParams
  */
 export function getURIParams(params: PossibleURIParams, caller: AnyCaller = getURIParams): URIParams {
 	const output: MutableDictionary<string> = {};

--- a/modules/util/url.ts
+++ b/modules/util/url.ts
@@ -9,7 +9,7 @@ import type { ImmutableURI } from "./uri.js";
  * - The `//` at the start of a URL indicates that it has a hierarchical path component, so this makes it a URL.
  * - URLs have a concept of "absolute" or "relative" URLs, since they have a path.
  *
- * @see https://dhoulb.github.io/shelving/util/url/URLString
+ * @see https://shelving.cc/util/url/URLString
  */
 export type URLString = `${string}://${string}`;
 
@@ -20,7 +20,7 @@ export type URLString = `${string}://${string}`;
  * - If a path is provided as input, a base URL _must_ also be provided.
  * - The returned type is
  *
- * @see https://dhoulb.github.io/shelving/util/url/ImmutableURLConstructor
+ * @see https://shelving.cc/util/url/ImmutableURLConstructor
  */
 export interface ImmutableURLConstructor {
 	new (input: URLString | ImmutableURL, base?: URLString | ImmutableURL): ImmutableURL;
@@ -44,7 +44,7 @@ export interface ImmutableURLConstructor {
  * - You can tell the difference because a URL will have a non-empty `host` property, whereas URIs will never have a `host` (it will be `""` empty string).
  * - Javascript URLs are mutable which can lead to subtle bugs.
  *
- * @see https://dhoulb.github.io/shelving/util/url/ImmutableURL
+ * @see https://shelving.cc/util/url/ImmutableURL
  */
 export interface ImmutableURL extends ImmutableURI {
 	readonly href: URLString;
@@ -56,7 +56,7 @@ export const ImmutableURL = URL as ImmutableURLConstructor;
 /**
  * Values that can be converted to a URL instance.
  *
- * @see https://dhoulb.github.io/shelving/util/url/PossibleURL
+ * @see https://shelving.cc/util/url/PossibleURL
  */
 export type PossibleURL = string | URL;
 
@@ -69,7 +69,7 @@ export type PossibleURL = string | URL;
  *
  * @example if (isURL(value)) value.pathname; // `value` is narrowed to `ImmutableURL`
  *
- * @see https://dhoulb.github.io/shelving/util/url/isURL
+ * @see https://shelving.cc/util/url/isURL
  */
 export function isURL(value: unknown): value is ImmutableURL {
 	return value instanceof URL && _isURL(value);
@@ -89,7 +89,7 @@ function _isURL(uri: URL): uri is ImmutableURL {
  * assertURL(value);
  * value.pathname; // `value` is narrowed to `ImmutableURL`
  *
- * @see https://dhoulb.github.io/shelving/util/url/assertURL
+ * @see https://shelving.cc/util/url/assertURL
  */
 export function assertURL(value: unknown, caller: AnyCaller = assertURL): asserts value is ImmutableURL {
 	if (!isURL(value)) throw new RequiredError("Invalid URL", { received: value, caller });
@@ -110,7 +110,7 @@ export function assertURL(value: unknown, caller: AnyCaller = assertURL): assert
  *
  * @example getBasedURI("path/to/page", "http://example.com/base/"); // `http://example.com/base/path/to/page`
  *
- * @see https://dhoulb.github.io/shelving/util/url/getBasedURI
+ * @see https://shelving.cc/util/url/getBasedURI
  */
 export function getBasedURI(input: Nullish<PossibleURL>, base?: PossibleURL): ImmutableURI | undefined {
 	if (!input) return;
@@ -134,7 +134,7 @@ export function getBasedURI(input: Nullish<PossibleURL>, base?: PossibleURL): Im
  * getURL("/page", "http://example.com/"); // `http://example.com/page`
  * getURL("mailto:a@b.com"); // `undefined` — not a hierarchical URL
  *
- * @see https://dhoulb.github.io/shelving/util/url/getURL
+ * @see https://shelving.cc/util/url/getURL
  */
 export function getURL(target: Nullish<PossibleURL>, base?: PossibleURL): ImmutableURL | undefined {
 	const uri = getBasedURI(target, base);
@@ -152,7 +152,7 @@ export function getURL(target: Nullish<PossibleURL>, base?: PossibleURL): Immuta
  *
  * @example requireURL("/page", "http://example.com/"); // `http://example.com/page`
  *
- * @see https://dhoulb.github.io/shelving/util/url/requireURL
+ * @see https://shelving.cc/util/url/requireURL
  */
 export function requireURL(target: PossibleURL, base?: PossibleURL, caller: AnyCaller = requireURL): ImmutableURL {
 	const url = getURL(target, base);
@@ -178,7 +178,7 @@ export function requireURL(target: PossibleURL, base?: PossibleURL, caller: AnyC
  * @example matchURLPrefix("http://x.com/a/b", "http://x.com/a/"); // `/b`
  * @example matchURLPrefix("http://x.com/a/b/", "http://x.com/a/"); // `/b` (trailing slash normalised away)
  *
- * @see https://dhoulb.github.io/shelving/util/url/matchURLPrefix
+ * @see https://shelving.cc/util/url/matchURLPrefix
  */
 export function matchURLPrefix(
 	target: PossibleURL | undefined,
@@ -210,7 +210,7 @@ export function matchURLPrefix(
  *
  * @example isURLActive("http://x.com/a", "http://x.com/a"); // `true`
  *
- * @see https://dhoulb.github.io/shelving/util/url/isURLActive
+ * @see https://shelving.cc/util/url/isURLActive
  */
 export function isURLActive(target: PossibleURL | undefined, base: PossibleURL | undefined, caller: AnyCaller = isURLActive): boolean {
 	return !!target && !!base && matchURLPrefix(target, base, caller) === "/";
@@ -229,7 +229,7 @@ export function isURLActive(target: PossibleURL | undefined, base: PossibleURL |
  *
  * @example isURLProud("http://x.com/a/b", "http://x.com/a"); // `true`
  *
- * @see https://dhoulb.github.io/shelving/util/url/isURLProud
+ * @see https://shelving.cc/util/url/isURLProud
  */
 export function isURLProud(target: PossibleURL | undefined, base: PossibleURL | undefined, caller: AnyCaller = isURLProud): boolean {
 	return !!target && !!base && matchURLPrefix(target, base, caller) !== undefined;
@@ -238,7 +238,7 @@ export function isURLProud(target: PossibleURL | undefined, base: PossibleURL | 
 /**
  * BaseURL is a URL with a guaranteed trailing slash on pathname.
  *
- * @see https://dhoulb.github.io/shelving/util/url/BaseURL
+ * @see https://shelving.cc/util/url/BaseURL
  */
 export interface BaseURL extends ImmutableURL {
 	readonly pathname: `/` | `/${string}/`;
@@ -253,7 +253,7 @@ export interface BaseURL extends ImmutableURL {
  *
  * @example isBaseURL(new URL("http://x.com/a/")); // `true`
  *
- * @see https://dhoulb.github.io/shelving/util/url/isBaseURL
+ * @see https://shelving.cc/util/url/isBaseURL
  */
 export function isBaseURL(value: PossibleURL): value is BaseURL {
 	return isURL(value) && _isBaseURL(value);
@@ -272,7 +272,7 @@ function _isBaseURL(uri: URL): uri is BaseURL {
  *
  * @example getBaseURL("http://x.com/a"); // `http://x.com/a/`
  *
- * @see https://dhoulb.github.io/shelving/util/url/getBaseURL
+ * @see https://shelving.cc/util/url/getBaseURL
  */
 export function getBaseURL(input: Nullish<PossibleURL>): BaseURL | undefined {
 	if (!input) return;
@@ -295,7 +295,7 @@ export function getBaseURL(input: Nullish<PossibleURL>): BaseURL | undefined {
  *
  * @example requireBaseURL("http://x.com/a", requireBaseURL); // `http://x.com/a/`
  *
- * @see https://dhoulb.github.io/shelving/util/url/requireBaseURL
+ * @see https://shelving.cc/util/url/requireBaseURL
  */
 export function requireBaseURL(value: PossibleURL, caller: AnyCaller): BaseURL {
 	const url = getBaseURL(value);

--- a/modules/util/uuid.ts
+++ b/modules/util/uuid.ts
@@ -7,7 +7,7 @@ const R_NOT_LOWERCHAR = /[^0-9a-f]/g;
  *
  * @returns A random 32-character lowercase hex UUID string.
  * @example randomUUID() // "1b4e28ba2fa14931918f4c9bf9f12b3a"
- * @see https://dhoulb.github.io/shelving/util/uuid/randomUUID
+ * @see https://shelving.cc/util/uuid/randomUUID
  */
 export function randomUUID(): string {
 	return crypto.randomUUID().replace(R_NOT_LOWERCHAR, "");
@@ -23,7 +23,7 @@ export function randomUUID(): string {
  * @param value The value to convert/validate as a UUID.
  * @returns The normalised UUID string, or `undefined` if the value is not a valid UUID.
  * @example getUUID("1b4e28ba-2fa1-4931-918f-4c9bf9f12b3a") // "1b4e28ba2fa14931918f4c9bf9f12b3a"
- * @see https://dhoulb.github.io/shelving/util/uuid/getUUID
+ * @see https://shelving.cc/util/uuid/getUUID
  */
 export function getUUID(value: string): string | undefined {
 	if (typeof value !== "string" || !value) return;
@@ -40,7 +40,7 @@ export function getUUID(value: string): string | undefined {
  * @returns The normalised UUID string.
  * @throws `RequiredError` if the value is not a valid UUID.
  * @example requireUUID("1b4e28ba-2fa1-4931-918f-4c9bf9f12b3a") // "1b4e28ba2fa14931918f4c9bf9f12b3a"
- * @see https://dhoulb.github.io/shelving/util/uuid/requireUUID
+ * @see https://shelving.cc/util/uuid/requireUUID
  */
 export function requireUUID(value: string): string {
 	const uuid = getUUID(value);

--- a/modules/util/validate.ts
+++ b/modules/util/validate.ts
@@ -13,7 +13,7 @@ import type { MutableObject } from "./object.js";
 /**
  * Object that can validate an unknown value with its `validate()` method.
  *
- * @see https://dhoulb.github.io/shelving/util/validate/Validator
+ * @see https://shelving.cc/util/validate/Validator
  */
 export interface Validator<T> {
 	/**
@@ -24,7 +24,7 @@ export interface Validator<T> {
 	 * @throws `Error` If the value is invalid and cannot be fixed.
 	 * @throws `string` If the value is invalid and cannot be fixed and we want to explain why to an end user.
 	 * @example validator.validate(unsafeValue) // valid value (or throws)
-	 * @see https://dhoulb.github.io/shelving/util/validate/Validator/validate
+	 * @see https://shelving.cc/util/validate/Validator/validate
 	 */
 	validate(unsafeValue: unknown): T;
 }
@@ -32,21 +32,21 @@ export interface Validator<T> {
 /**
  * Extract the validated type from a `Validator`.
  *
- * @see https://dhoulb.github.io/shelving/util/validate/ValidatorType
+ * @see https://shelving.cc/util/validate/ValidatorType
  */
 export type ValidatorType<X> = X extends Validator<infer Y> ? Y : never;
 
 /**
  * A set of named validators in `{ name: Validator }` format.
  *
- * @see https://dhoulb.github.io/shelving/util/validate/Validators
+ * @see https://shelving.cc/util/validate/Validators
  */
 export type Validators<T extends Data = Data> = { readonly [K in keyof T]: Validator<T[K]> };
 
 /**
  * Extract the validated data type from a set of validators.
  *
- * @see https://dhoulb.github.io/shelving/util/validate/ValidatorsType
+ * @see https://shelving.cc/util/validate/ValidatorsType
  */
 export type ValidatorsType<T> = { readonly [K in keyof T]: ValidatorType<T[K]> };
 
@@ -60,7 +60,7 @@ export type ValidatorsType<T> = { readonly [K in keyof T]: ValidatorType<T[K]> }
  * @returns The valid value, or `undefined` if validation threw a string message.
  * @throws `Error` if the validator throws a non-string error.
  * @example getValid(unsafeValue, STRING) // valid string, or `undefined`
- * @see https://dhoulb.github.io/shelving/util/validate/getValid
+ * @see https://shelving.cc/util/validate/getValid
  */
 export function getValid<T>(value: unknown, validator: Validator<T>): T | undefined {
 	try {
@@ -83,7 +83,7 @@ export function getValid<T>(value: unknown, validator: Validator<T>): T | undefi
  * @throws `RequiredError` if validation threw a string message.
  * @throws `Error` if the validator throws a non-string error.
  * @example requireValid(unsafeValue, STRING) // valid string (or throws)
- * @see https://dhoulb.github.io/shelving/util/validate/requireValid
+ * @see https://shelving.cc/util/validate/requireValid
  */
 export function requireValid<T>(value: unknown, validator: Validator<T>, caller: AnyCaller = requireValid): T {
 	try {
@@ -104,7 +104,7 @@ export function requireValid<T>(value: unknown, validator: Validator<T>, caller:
  * @yields Valid items.
  * @throws `string` if one or more items did not validate (one `"index: message"` line per failure, joined by newlines).
  * @example Array.from(validateItems(["a", "b"], STRING)) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/validate/validateItems
+ * @see https://shelving.cc/util/validate/validateItems
  */
 export function* validateItems<T>(unsafeItems: PossibleArray<unknown>, validator: Validator<T>): Iterable<T> {
 	let index = 0;
@@ -131,7 +131,7 @@ export function* validateItems<T>(unsafeItems: PossibleArray<unknown>, validator
  * @returns Array with valid items.
  * @throws `string` if one or more items did not validate (one `"index: message"` line per failure, joined by newlines).
  * @example validateArray(["a", "b"], STRING) // ["a", "b"]
- * @see https://dhoulb.github.io/shelving/util/validate/validateArray
+ * @see https://shelving.cc/util/validate/validateArray
  */
 export function validateArray<T>(unsafeArray: PossibleArray<unknown>, validator: Validator<T>): ImmutableArray<T> {
 	let index = 0;
@@ -163,7 +163,7 @@ export function validateArray<T>(unsafeArray: PossibleArray<unknown>, validator:
  * @returns Dictionary with valid values.
  * @throws `string` if one or more entry values did not validate (one `"key: message"` line per failure, joined by newlines).
  * @example validateDictionary({ a: "1", b: "2" }, STRING) // { a: "1", b: "2" }
- * @see https://dhoulb.github.io/shelving/util/validate/validateDictionary
+ * @see https://shelving.cc/util/validate/validateDictionary
  */
 export function validateDictionary<T>(unsafeDictionary: PossibleDictionary<unknown>, validator: Validator<T>): ImmutableDictionary<T> {
 	let changed = false;
@@ -196,7 +196,7 @@ export function validateDictionary<T>(unsafeDictionary: PossibleDictionary<unkno
  * @returns Valid object.
  * @throws `string` if one or more props did not validate (one `"key: message"` line per failure, joined by newlines).
  * @example validateData({ name: "Alice" }, { name: STRING }) // { name: "Alice" }
- * @see https://dhoulb.github.io/shelving/util/validate/validateData
+ * @see https://shelving.cc/util/validate/validateData
  */
 export function validateData<T extends Data>(unsafeData: Data, validators: Validators<T>): T {
 	let changes = 0;

--- a/modules/util/xml.ts
+++ b/modules/util/xml.ts
@@ -12,7 +12,7 @@ import { isDefined } from "./undefined.js";
  * @param value The raw string value.
  * @returns The escaped XML-safe string.
  * @example escapeXML(`Tom & "Jerry"`) // "Tom &amp; &quot;Jerry&quot;"
- * @see https://dhoulb.github.io/shelving/util/xml/escapeXML
+ * @see https://shelving.cc/util/xml/escapeXML
  */
 export function escapeXML(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
@@ -31,7 +31,7 @@ export function escapeXML(value: string): string {
  * @throws `RequiredError` if a key is not a valid XML element name.
  * @throws `RequiredError` if a value cannot be converted to XML.
  * @example getXML({ user: { name: "Alice", age: 30 } }) // "<user><name>Alice</name><age>30</age></user>"
- * @see https://dhoulb.github.io/shelving/util/xml/getXML
+ * @see https://shelving.cc/util/xml/getXML
  */
 export function getXML(data: Data, caller: AnyCaller = getXML): string {
 	return Array.from(_yieldXML(data, caller)).join("");


### PR DESCRIPTION
## Summary

The docs site moved to the custom domain **`shelving.cc`**, and its page URLs now use the **package export subpath** rather than the full source-file path. This sweep updates every `@see` docblock link across the codebase to match, plus the supporting documentation.

## URL scheme

New canonical form is `https://shelving.cc/<package>/<name>`, where `<package>` is the symbol's `package.json` export subpath:

- **Single-index packages** collapse the whole source-file path to the top folder:
  - `…/db/store/QueryStore/QueryStore` → `https://shelving.cc/db/QueryStore`
  - `…/ui/misc/Catcher/ErrorPageProps` → `https://shelving.cc/ui/ErrorPageProps`
- **Wildcard / multi-entry exports keep their subpath:**
  - `…/util/async/notAsync` → `https://shelving.cc/util/async/notAsync` (from `"./util/*"`)
  - `firestore/<client|lite|server>/…` similarly
- Class members append the member name: `…/schema/BooleanSchema/BooleanSchema/validate` → `https://shelving.cc/schema/BooleanSchema/validate`

## What changed

- **~2,109 `@see` links** rewritten across 356 module files (domain + path collapse).
- **`README.md`** — docs link → `https://shelving.cc/`.
- **`AGENTS.md`** — updated the `@see` convention to the new domain + package-subpath scheme, refreshed the PR-preview URL, and added a **Docs site** subsection describing the GitHub Pages custom-domain deployment (`docs` branch, `CNAME` written by the workflow, package-relative page URLs).
- Merged `main` (which moved the `docs.yaml` workflow to `shelving.cc` + `cname:`), and **fixed `Icon.tsx`** — main's `StatusIcon`→`Icon` rename left its `@see` links and docblock prose pointing at the old `StatusIcon` page.

## How it was done

Extracted the full list up front with a script that computed each file's expected URL prefix and **flagged 22 anomalies** before any edits. Those resolved into clean groups (cross-references / stale paths → same-package token, file-named self-refs → domain-only swap, test fixtures → domain-only swap), all handled explicitly. Final sweep confirms **zero** `dhoulb.github.io/shelving` occurrences remain anywhere; Biome passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyudFtJLXkZGcKWoMyGX8j)_