### PR TITLE
refactor: single-flatten the tree shared via TreeContext

### DIFF
--- a/modules/ui/docs/DocumentationApp.tsx
+++ b/modules/ui/docs/DocumentationApp.tsx
@@ -14,7 +14,7 @@ export function DocumentationApp({
 		"/search": DocumentationSearchPage,
 	},
 	sidebar = (
-		<TreeSidebar tree={tree}>
+		<TreeSidebar>
 			<Menu>
 				<MenuItem href="/search">Search</MenuItem>
 			</Menu>

--- a/modules/ui/misc/Mapper.md
+++ b/modules/ui/misc/Mapper.md
@@ -6,7 +6,7 @@ Creates a `[Mapping, Mapper]` component pair backed by a private React context. 
 
 - Each call to `createMapper()` creates its own context — independent mappers don't interfere with each other.
 - Unmapped element types fall through and render as themselves (e.g. an unmapped `<tree-foo>` appears as a raw `<tree-foo>` element).
-- Any extra props passed to `Mapper` (the type parameter `E`) are spread onto every dispatched child, so you can thread shared context like a `path` into each renderer.
+- Each dispatched child is rendered with its own `props` only — the mapper threads no extra props, so any context a renderer needs (URL paths, etc.) must already live on the element (e.g. the canonical `path` stamped by `flattenTree()`).
 
 ## Usage
 
@@ -24,13 +24,4 @@ const [TreeMapping, TreeMapper] = createMapper({
 <TreeMapping mapping={{ "tree-element": SpecialTreeRow }}>
   <TreeMapper>{walkElements(children)}</TreeMapper>
 </TreeMapping>
-```
-
-```tsx
-// With extra props threaded into every dispatched child.
-const [TreeMenuMapping, TreeMenuMapper] = createMapper<{ path?: AbsolutePath }>({
-  "tree-element": TreeMenuItem,
-});
-
-<TreeMenuMapper path="/foo">{queryElements(children, query)}</TreeMenuMapper>
 ```

--- a/modules/ui/misc/Mapper.md
+++ b/modules/ui/misc/Mapper.md
@@ -6,7 +6,6 @@ Creates a `[Mapping, Mapper]` component pair backed by a private React context. 
 
 - Each call to `createMapper()` creates its own context — independent mappers don't interfere with each other.
 - Unmapped element types fall through and render as themselves (e.g. an unmapped `<tree-foo>` appears as a raw `<tree-foo>` element).
-- Each dispatched child is rendered with its own `props` only — the mapper threads no extra props, so any context a renderer needs (URL paths, etc.) must already live on the element (e.g. the canonical `path` stamped by `flattenTree()`).
 
 ## Usage
 

--- a/modules/ui/misc/Mapper.tsx
+++ b/modules/ui/misc/Mapper.tsx
@@ -6,12 +6,12 @@ import type { ChildProps } from "../util/props.js";
 /**
  * Dispatch table from a `JSX.IntrinsicElements` key to a renderer component.
  * - Each entry is optional — unmapped elements fall through and render as themselves (e.g. an unmapped `<tree-foo>` appears as a raw `<tree-foo>` HTML element).
- * - Per-entry component receives `JSX.IntrinsicElements[K] & E` — the declared props for that element type, plus any extra props `E` the mapper is configured to thread through.
+ * - Per-entry component receives `JSX.IntrinsicElements[K]` — the declared props for that element type.
  *
  * @see https://shelving.cc/ui/Mapping
  */
-export type Mapping<E = unknown> = {
-	[K in keyof JSX.IntrinsicElements]?: ComponentType<JSX.IntrinsicElements[K] & E>;
+export type Mapping = {
+	[K in keyof JSX.IntrinsicElements]?: ComponentType<JSX.IntrinsicElements[K]>;
 };
 
 /**
@@ -19,21 +19,20 @@ export type Mapping<E = unknown> = {
  *
  * @see https://shelving.cc/ui/MappingProps
  */
-export interface MappingProps<E = unknown> extends ChildProps {
+export interface MappingProps extends ChildProps {
 	/** Mapping entries that extend or override the inherited mapping inside this subtree. */
-	readonly mapping: Mapping<E>;
+	readonly mapping: Mapping;
 }
 
 /**
  * Props for the `Mapper` component returned by `createMapper()`.
  * - `children` holds the pre-walked elements to dispatch.
- * - All other props are spread onto every mapped child as additional props (`E`).
  *
  * @see https://shelving.cc/ui/MapperProps
  */
-export type MapperProps<E = unknown> = E & {
+export interface MapperProps {
 	readonly children?: Elements;
-};
+}
 
 // Indexing the heterogeneous `Mapping` by an arbitrary string is unsafe by design — per-key value types diverge.
 // biome-ignore lint/suspicious/noExplicitAny: Each mapping value is a `ComponentType<P>` with its own `P`; we accept `any` for dispatch.
@@ -47,37 +46,32 @@ type AnyMapping = Record<string, ComponentType<any> | undefined>;
  *
  * Each call creates its own context — independent mappers don't interfere with each other.
  *
- * @typeParam E The shape of any extra props the mapper threads through to every dispatched child. Defaults to `unknown` (no extras).
  * @param defaults The initial mapping of element types to renderer components.
  * @returns A `[Mapping, Mapper]` tuple of components sharing a private context.
  *
  * @example
- * // No extras:
  * const [TreeCardMapping, TreeCardMapper] = createMapper({
  *   "tree-element": TreeCard,
  * });
  * <TreeCardMapper>{walkElements(children)}</TreeCardMapper>
  *
  * @example
- * // With extras (`path` threaded into every dispatched child):
- * const [TreeMenuMapping, TreeMenuMapper] = createMapper<{ path?: AbsolutePath }>({
- *   "tree-element": TreeMenuItem,
- * });
- * <TreeMenuMapper path="/foo">{queryElements(children, query)}</TreeMenuMapper>
+ * // Override one entry inside a subtree:
+ * <TreeCardMapping mapping={{ "tree-element": SpecialTreeCard }}>
+ *   <TreeCardMapper>{walkElements(children)}</TreeCardMapper>
+ * </TreeCardMapping>
  *
  * @see https://shelving.cc/ui/createMapper
  */
-export function createMapper<E = unknown>(
-	defaults: Mapping<E> = {},
-): [Mapping: FunctionComponent<MappingProps<E>>, Mapper: FunctionComponent<MapperProps<E>>] {
+export function createMapper(defaults: Mapping = {}): [Mapping: FunctionComponent<MappingProps>, Mapper: FunctionComponent<MapperProps>] {
 	const Context = createContext<AnyMapping>(defaults);
 
-	function Mapping({ mapping, children }: MappingProps<E>): ReactNode {
+	function Mapping({ mapping, children }: MappingProps): ReactNode {
 		const inherited = use(Context);
 		return <Context value={{ ...inherited, ...mapping }}>{children}</Context>;
 	}
 
-	function Mapper({ children, ...extras }: MapperProps<E>): ReactNode {
+	function Mapper({ children }: MapperProps): ReactNode {
 		const mapping = use(Context);
 		const items: ReactNode[] = [];
 		for (const element of walkElements(children)) {
@@ -87,7 +81,7 @@ export function createMapper<E = unknown>(
 			}
 			const Component = mapping[element.type];
 			if (Component) {
-				items.push(<Component key={element.key} {...extras} {...element.props} />);
+				items.push(<Component key={element.key} {...element.props} />);
 			} else {
 				items.push(element);
 			}

--- a/modules/ui/tree/TreeApp.tsx
+++ b/modules/ui/tree/TreeApp.tsx
@@ -7,6 +7,7 @@ import { Navigation } from "../router/Navigation.js";
 import { Router } from "../router/Router.js";
 import type { Routes } from "../router/Routes.js";
 import type { PossibleMeta } from "../util/index.js";
+import { TreeProvider } from "./TreeContext.js";
 import { TreeRouter } from "./TreeRouter.js";
 import { TreeSidebar } from "./TreeSidebar.js";
 
@@ -31,6 +32,7 @@ export interface TreeAppProps extends PossibleMeta {
  * Top-level app component for a tree-based documentation site.
  *
  * - Wraps `<App>` with error catching and a sidebar layout.
+ * - Flattens `tree` once via `<TreeProvider>` wrapping both the sidebar and the router, so everything below shares a single `useTreeMap()` lookup — nothing re-flattens.
  * - The sidebar shows a `<TreeSidebar>` (root as a home link + a menu of its children).
  * - `/` renders the root via `<TreePage>`; `/**` catches every deeper path and feeds the full sub-path into `<TreePage>`.
  * - Element rendering uses the default mappings on `<TreePage>`, `<TreeMenu>`, `<TreeCards>`.
@@ -41,15 +43,17 @@ export interface TreeAppProps extends PossibleMeta {
  * @example <TreeApp tree={tree} title="Docs" />
  * @see https://shelving.cc/ui/TreeApp
  */
-export function TreeApp({ tree, routes, sidebar = <TreeSidebar tree={tree} />, ...meta }: TreeAppProps): ReactElement {
+export function TreeApp({ tree, routes, sidebar = <TreeSidebar />, ...meta }: TreeAppProps): ReactElement {
 	const fallback = routes && <Router routes={routes} />;
 	return (
 		<App {...meta}>
 			<Navigation>
 				<PageCatcher>
-					<SidebarLayout sidebar={sidebar}>
-						<TreeRouter tree={tree} fallback={fallback} />
-					</SidebarLayout>
+					<TreeProvider tree={tree}>
+						<SidebarLayout sidebar={sidebar}>
+							<TreeRouter fallback={fallback} />
+						</SidebarLayout>
+					</TreeProvider>
 				</PageCatcher>
 			</Navigation>
 		</App>

--- a/modules/ui/tree/TreeMenu.md
+++ b/modules/ui/tree/TreeMenu.md
@@ -5,7 +5,7 @@ A sidebar navigation menu built from the children of a root tree element. Each c
 **Things to know:**
 
 - Only directories and files appear, plus documentation symbols of `kind: "module"` — functions, classes, methods, properties, etc. are kept off the navigation (they still get their own pages via `<TreeApp>`).
-- Each item computes its own href by appending its `name` to the parent `path` (defaulting to `/`).
+- Each item links straight to its element's own canonical `path` (stamped by `flattenTree()`), so feed it a flattened element — e.g. `useTreeMap().get("/")` — rather than a raw extracted tree.
 - It is a `[Mapping, Mapper]` pair: wrap any subtree in `<TreeMenuMapping mapping={…}>` to swap the per-type menu-item renderer without touching the rest of the site. `<TreeSidebar>` shares this same mapper.
 - Use it directly for finer layout control; otherwise `<TreeApp>` wires a `<TreeSidebar>` (a home link plus this menu) for you.
 
@@ -13,9 +13,10 @@ A sidebar navigation menu built from the children of a root tree element. Each c
 
 ```tsx
 import { TreeMenu } from "shelving/ui";
+import { useTreeMap } from "shelving/ui";
 
-// Just the navigation menu from a subtree's children.
-<TreeMenu tree={section} path="/docs" />
+// Just the navigation menu from the flattened root's children.
+<TreeMenu tree={useTreeMap().get("/")} />
 ```
 
 Override the menu-item renderer for one element type:

--- a/modules/ui/tree/TreeMenu.tsx
+++ b/modules/ui/tree/TreeMenu.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { type Element, filterElements } from "../../util/element.js";
-import { type AbsolutePath, joinPath } from "../../util/path.js";
 import type { TreeElement, TreeElementProps } from "../../util/tree.js";
 import { Menu, MenuItem } from "../menu/Menu.js";
 import { createMapper } from "../misc/Mapper.js";
@@ -23,33 +22,26 @@ export function matchMenuElement(element: Element): boolean {
 	return false;
 }
 
-/** Extras threaded through `TreeMenuMapper` to every menu item — the parent's URL path. */
-interface TreeMenuExtras {
-	/** URL path of the parent element. Each item appends its own `name` to compute its own path. Defaults to `/`. */
-	readonly path: AbsolutePath;
-}
-
 /**
  * Default menu item renderer for any `tree-*` element.
  *
- * - Computes its own URL path by appending its `name` to the parent's `path`.
+ * - Links straight to the element's own canonical `path` (stamped by `flattenTree()`), so the menu must be fed the flattened tree's elements.
  * - Passes both the label and the nested `<TreeMenuMapper>` to `<MenuItem>`; `<MenuItem>` itself decides whether to reveal the nested submenu based on the current URL.
  *
- * @param props The tree element props plus the parent's `path`.
+ * @param props The tree element props — `path` is the canonical URL to link to.
  * @returns A `<MenuItem>` for the element, with a nested `<Menu>` when it has menu-eligible children.
  * @kind component
- * @example <TreeMenuItem {...element.props} path="/" />
+ * @example <TreeMenuItem {...element.props} />
  * @see https://shelving.cc/ui/TreeMenuItem
  */
-export function TreeMenuItem({ path = "/", name, title, children }: TreeElementProps & TreeMenuExtras): ReactNode {
-	const href = joinPath(path, name);
+export function TreeMenuItem({ path, name, title, children }: TreeElementProps): ReactNode {
 	const submenu = Array.from(filterElements(children, matchMenuElement));
 	return (
-		<MenuItem href={href}>
+		<MenuItem href={path}>
 			{title ?? name}
 			{submenu.length ? (
 				<Menu>
-					<TreeMenuMapper path={href}>{submenu}</TreeMenuMapper>
+					<TreeMenuMapper>{submenu}</TreeMenuMapper>
 				</Menu>
 			) : null}
 		</MenuItem>
@@ -61,7 +53,7 @@ export function TreeMenuItem({ path = "/", name, title, children }: TreeElementP
  *
  * @see https://shelving.cc/ui/TreeMenuMapping
  */
-export const [TreeMenuMapping, TreeMenuMapper] = createMapper<TreeMenuExtras>({
+export const [TreeMenuMapping, TreeMenuMapper] = createMapper({
 	"tree-element": TreeMenuItem,
 	"tree-documentation": TreeMenuItem,
 });
@@ -72,28 +64,27 @@ export const [TreeMenuMapping, TreeMenuMapper] = createMapper<TreeMenuExtras>({
  * @see https://shelving.cc/ui/TreeMenuProps
  */
 export interface TreeMenuProps {
-	/** Root element whose children become the navigation links. */
+	/** Root element whose children become the navigation links. Must be a flattened element (from `useTreeMap()`) so each child carries its canonical `path`. */
 	readonly tree: TreeElement;
-	/** URL path of the root — children get `path + their.name`. Defaults to `/`. */
-	readonly path?: AbsolutePath | undefined;
 }
 
 /**
  * Sidebar navigation menu built from the children of a root tree element.
  *
- * - Renders each child via `<TreeMenuItem>` (the default mapping for `tree-element`).
+ * - Renders each child via `<TreeMenuItem>` (the default mapping for `tree-element`), linking to each child's stamped `path`.
+ * - Pass a flattened element (e.g. `useTreeMap().get("/")`) so its children carry their canonical `path`.
  * - To customise renderers for specific types, wrap in `<TreeMenuMapping mapping={…}>`.
  * - Only directories and files appear — code symbols are kept off the navigation.
  *
  * @kind component
  * @returns A `<Menu>` of navigation links to the root's children.
- * @example <TreeMenu tree={tree} />
+ * @example <TreeMenu tree={useTreeMap().get("/")} />
  * @see https://shelving.cc/ui/TreeMenu
  */
-export function TreeMenu({ path = "/", tree }: TreeMenuProps): ReactNode {
+export function TreeMenu({ tree }: TreeMenuProps): ReactNode {
 	return (
 		<Menu>
-			<TreeMenuMapper path={path}>{filterElements(tree.props.children, matchMenuElement)}</TreeMenuMapper>
+			<TreeMenuMapper>{filterElements(tree.props.children, matchMenuElement)}</TreeMenuMapper>
 		</Menu>
 	);
 }

--- a/modules/ui/tree/TreeRouter.test.tsx
+++ b/modules/ui/tree/TreeRouter.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { TreeElement } from "../../util/tree.js";
 import { MetaContext } from "../misc/MetaContext.js";
 import { createMeta } from "../util/meta.js";
+import { TreeProvider } from "./TreeContext.js";
 import { TreeRouter } from "./TreeRouter.js";
 
 /** Minimal tree: root → `util` directory → `array` file. */
@@ -26,7 +27,9 @@ describe("TreeRouter", () => {
 	test("card links include an APP_URL subfolder exactly once", () => {
 		const html = renderToStaticMarkup(
 			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./util" })}>
-				<TreeRouter tree={tree} />
+				<TreeProvider tree={tree}>
+					<TreeRouter />
+				</TreeProvider>
 			</MetaContext>,
 		);
 		expect(html).toContain('href="http://x.com/sub/util/array"');
@@ -36,7 +39,9 @@ describe("TreeRouter", () => {
 	test("root page card links include an APP_URL subfolder exactly once", () => {
 		const html = renderToStaticMarkup(
 			<MetaContext value={createMeta({ root: "http://x.com/sub/", url: "./" })}>
-				<TreeRouter tree={tree} />
+				<TreeProvider tree={tree}>
+					<TreeRouter />
+				</TreeProvider>
 			</MetaContext>,
 		);
 		expect(html).toContain('href="http://x.com/sub/util"');

--- a/modules/ui/tree/TreeRouter.tsx
+++ b/modules/ui/tree/TreeRouter.tsx
@@ -1,12 +1,11 @@
 import type { ReactElement, ReactNode } from "react";
 import { NotFoundError } from "../../error/RequestError.js";
 import type { AbsolutePath } from "../../util/path.js";
-import type { TreeElement } from "../../util/tree.js";
 import { DocumentationPage } from "../docs/DocumentationPage.js";
 import { createMapper } from "../misc/Mapper.js";
 import { MetaContext, requireMetaURL } from "../misc/MetaContext.js";
 import type { PossibleMeta } from "../util/index.js";
-import { TreeProvider, useTreeMap } from "./TreeContext.js";
+import { useTreeMap } from "./TreeContext.js";
 import { TreePage } from "./TreePage.js";
 
 /**
@@ -25,9 +24,6 @@ export const [TreeRouterMapping, TreeRouterMapper] = createMapper({
  * @see https://shelving.cc/ui/TreeRouterProps
  */
 export interface TreeRouterProps extends PossibleMeta {
-	/** The tree of elements to match routes for. */
-	readonly tree: TreeElement;
-
 	/**
 	 * Optional fallback element.
 	 * - Explicit `null` means fallback to nothing (router will not throw `NotFoundError`).
@@ -38,7 +34,7 @@ export interface TreeRouterProps extends PossibleMeta {
 /**
  * Resolve a URL path to a tree element and render it as a full page.
  *
- * - Flattens the tree once (via `<TreeProvider>`) into a `path` → element map, then resolves the current URL with a single `map.get(path)`.
+ * - Reads the flattened `path` → element map from the surrounding `<TreeProvider>` (`useTreeMap()`), then resolves the current URL with a single `map.get(path)`.
  * - `/` renders the root itself; deeper paths render the matching descendant (composite module names like `/util/string` resolve for free — they're whole keys in the map).
  * - The resolved element is already stamped with its canonical `path`, so the page and its cards link straight to their own paths — nothing needs threading.
  * - To override the renderer for a specific element type, wrap in `<TreeRouterMapping mapping={…}>`.
@@ -46,17 +42,14 @@ export interface TreeRouterProps extends PossibleMeta {
  * @returns The resolved element rendered as a page, or the `fallback`.
  * @throws `NotFoundError` When no element matches the URL and no `fallback` is given.
  * @kind component
- * @example <TreeRouter tree={tree} />
+ * @example <TreeProvider tree={tree}><TreeRouter /></TreeProvider>
  * @see https://shelving.cc/ui/TreeRouter
  */
-export function TreeRouter({ tree, fallback, ...meta }: TreeRouterProps): ReactNode {
+export function TreeRouter({ fallback, ...meta }: TreeRouterProps): ReactNode {
 	const { path, ...combined } = requireMetaURL(meta);
-	// `<TreeProvider>` flattens the tree (memoised) and exposes it as a lookup map so descendants — the route resolver below, plus `<TreeButton>` / breadcrumbs — all resolve against the one map.
 	return (
 		<MetaContext value={combined}>
-			<TreeProvider tree={tree}>
-				<TreeRoute path={path} fallback={fallback} />
-			</TreeProvider>
+			<TreeRoute path={path} fallback={fallback} />
 		</MetaContext>
 	);
 }

--- a/modules/ui/tree/TreeSidebar.md
+++ b/modules/ui/tree/TreeSidebar.md
@@ -4,10 +4,11 @@ The default sidebar for a tree-based site: a single "home" link for the root ele
 
 **Things to know:**
 
-- The home link uses `path` as its href (defaulting to `/`); children's hrefs are computed by appending their `name` to the root path.
+- Reads the flattened tree from the surrounding `<TreeProvider>` (`useTreeMap().get("/")`), so it takes no `tree` prop — mount it anywhere inside a `<TreeApp>` / `<TreeProvider>`.
+- The home link points at `/`; children's hrefs use each element's stamped canonical `path`.
 - The children render through the same mapper as `<TreeMenu>`, so customise them by wrapping in `<TreeMenuMapping mapping={…}>`.
 - Only directories, files, and `kind: "module"` symbols appear — code symbols are kept off the navigation.
-- Use it directly for finer layout control outside `<TreeApp>`.
+- Use it directly for finer layout control outside the default `<TreeApp>` sidebar.
 
 ## Usage
 
@@ -15,5 +16,5 @@ The default sidebar for a tree-based site: a single "home" link for the root ele
 import { TreeSidebar } from "shelving/ui";
 
 // A home link + children menu combined — the default sidebar.
-<TreeSidebar tree={root} />
+<TreeSidebar />
 ```

--- a/modules/ui/tree/TreeSidebar.tsx
+++ b/modules/ui/tree/TreeSidebar.tsx
@@ -1,50 +1,45 @@
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { filterElements } from "../../util/element.js";
-import type { AbsolutePath } from "../../util/path.js";
-import { flattenTree, searchTree, type TreeElement } from "../../util/tree.js";
+import { searchTree } from "../../util/tree.js";
 import { Divider } from "../block/Divider.js";
 import { TextInput } from "../form/TextInput.js";
 import { Menu, MenuItem } from "../menu/Menu.js";
 import type { OptionalChildProps } from "../util/index.js";
+import { useTreeMap } from "./TreeContext.js";
 import { matchMenuElement, TreeMenuMapper } from "./TreeMenu.js";
 
 /**
- * Props for the `TreeSidebar` component — the root tree element plus its URL path.
+ * Props for the `TreeSidebar` component.
  *
  * @see https://shelving.cc/ui/TreeSidebarProps
  */
-export interface TreeSidebarProps extends OptionalChildProps {
-	/** Root element of the tree. */
-	readonly tree: TreeElement;
-	/** URL path of the root — defaults to `/`. Children are rendered with `path + their.name`. */
-	readonly path?: AbsolutePath | undefined;
-}
+export interface TreeSidebarProps extends OptionalChildProps {}
 
 /**
- * Sidebar built from a tree element, in three sections separated by dividers.
+ * Sidebar built from the surrounding tree, in three sections separated by dividers.
  *
  * - **Middle:** a `<TextInput>` search-as-you-type filter.
  * - **Bottom:** the root's children as a `<TreeMenuMapper>` — swapped for a flat ranked list of results (capped at 20) while the search holds a query.
  *
- * Child and result hrefs use each element's canonical `path` (or `joinPath(parent, name)` as a fallback). To customise child renderers wrap in `<TreeMenuMapping mapping={…}>` (same context as `<TreeMenu>`).
+ * Reads the flattened tree from the surrounding `<TreeProvider>` (`useTreeMap().get("/")`), so child and result hrefs use each element's stamped canonical `path`. To customise child renderers wrap in `<TreeMenuMapping mapping={…}>` (same context as `<TreeMenu>`).
  *
  * @kind component
  * @returns The sectioned sidebar — home/index links, a search input, and either the tree menu or search results.
- * @example <TreeSidebar tree={tree} />
+ * @example <TreeSidebar />
  * @see https://shelving.cc/ui/TreeSidebar
  */
-export function TreeSidebar({ tree, path = "/", children }: TreeSidebarProps): ReactNode {
+export function TreeSidebar({ children }: TreeSidebarProps): ReactNode {
 	const [query, setQuery] = useState("");
 	const trimmed = query.trim();
 
-	// Flatten once so search results carry a canonical `path` (and a unique `key`) for their links (the sidebar sits outside the router's `<TreeProvider>`).
-	const root = useMemo(() => flattenTree(tree).get("/") ?? tree, [tree]);
-	const results = trimmed ? searchTree(root, trimmed, { limit: 20 }) : null;
+	// The flattened root from context — its children (and descendants) already carry their canonical `path` and unique `key`.
+	const root = useTreeMap().get("/");
+	const results = root && trimmed ? searchTree(root, trimmed, { limit: 20 }) : null;
 
 	return (
 		<>
 			<Menu>
-				<MenuItem href={path}>Home</MenuItem>
+				<MenuItem href="/">Home</MenuItem>
 			</Menu>
 			{children}
 			<Divider />
@@ -53,12 +48,12 @@ export function TreeSidebar({ tree, path = "/", children }: TreeSidebarProps): R
 			<Menu>
 				{results ? (
 					results.map(el => (
-						<MenuItem key={el.key} href={el.props.path ?? path}>
+						<MenuItem key={el.key} href={el.props.path ?? "/"}>
 							{el.props.title ?? el.props.name}
 						</MenuItem>
 					))
 				) : (
-					<TreeMenuMapper path={path}>{filterElements(tree.props.children, matchMenuElement)}</TreeMenuMapper>
+					<TreeMenuMapper>{filterElements(root?.props.children, matchMenuElement)}</TreeMenuMapper>
 				)}
 			</Menu>
 		</>


### PR DESCRIPTION
## Summary

Removes the double-flatten between `util/tree` and `ui/tree`. The tree is now flattened **once** and shared through `TreeContext`; nothing downstream re-flattens or passes a `tree` prop around (except `TreeApp`, which seeds the context).

### The core change

`<TreeProvider>` is hoisted out of `<TreeRouter>` and into `<TreeApp>`, where it wraps **both** the sidebar and the router. Previously the provider lived inside `TreeRouter`, so the sidebar sat *outside* it and `TreeSidebar` had to re-`flattenTree()` the same tree in a `useMemo`.

### Changes

- **`TreeApp`** — wraps `<SidebarLayout>` in `<TreeProvider>`; default sidebar is now `<TreeSidebar />` (no `tree` prop).
- **`TreeSidebar`** — reads `useTreeMap().get("/")` instead of re-flattening; drops its `tree` and `path` props.
- **`TreeRouter`** — consumes the ambient map; drops its `tree` prop and its own `<TreeProvider>`.
- **`createMapper` / `Mapper`** — drops the `Extras` (`E`) generic; no longer spreads extra props onto dispatched children.
- **`TreeMenu` / `TreeMenuItem`** — links straight to each element's stamped canonical `path` instead of threading a parent `path` and recomputing with `joinPath`. Relies on being fed flattened (stamped) elements, the same way `TreeCard` already does.
- **`DocumentationApp`** — drops `tree` from `<TreeSidebar>`.
- **`DocumentationSearchPage`** — unchanged (already read root from context).
- Updated colocated tests (`TreeRouter.test`) and per-symbol docs (`Mapper.md`, `TreeMenu.md`, `TreeSidebar.md`).

### Notes

- `createMapper` losing its `E` type parameter is a public-API signature change; `TreeMenu` was its only generic consumer.
- `<TreeMenu>` / `<TreeRouter>` now expect a flattened element / surrounding `<TreeProvider>` respectively — documented in their docblocks.

### Testing

- `bun run test:type` ✅
- `bun run test:unit` ✅ (1183 pass)
- `bun run test:lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSS38qTGWpJmqz9hWRg2Gp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSS38qTGWpJmqz9hWRg2Gp)_