### PR TITLE
fix: correct inverted filter guard in SQLProvider.sqlWhere

### DIFF
--- a/modules/db/provider/SQLProvider.ts
+++ b/modules/db/provider/SQLProvider.ts
@@ -284,7 +284,7 @@ export abstract class SQLProvider<I extends Identifier = Identifier, T extends D
 	 */
 	sqlWhere(query: Query<Item>) {
 		const filters = getQueryFilters(query);
-		if (filters.length) return this.sql``;
+		if (!filters.length) return this.sql``;
 		return this.sql` WHERE ${this.sqlConcat(
 			filters.map(filter => this.sqlFilter(filter)),
 			" AND ",


### PR DESCRIPTION
The guard returned an empty fragment when filters existed and reached the
WHERE builder when there were none, so SQL-backed queries dropped their
WHERE clause and filterless queries emitted a broken trailing WHERE.

Closes #215

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xc9R3RTjWKgMaCU8ZiCPqb