### PR TITLE
fix: compare InspectSequence._first against sentinel not the throwing getter

### DIFF
--- a/modules/sequence/InspectSequence.test.ts
+++ b/modules/sequence/InspectSequence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { InspectSequence } from "../index.js";
+
+// Build an `InspectSequence` wrapping a simple async generator source.
+async function* _numbers(): AsyncGenerator<number, string, undefined> {
+	yield 1;
+	yield 2;
+	yield 3;
+	return "done";
+}
+
+describe("InspectSequence", () => {
+	test("captures first/last/count as values pass through", async () => {
+		const sequence = new InspectSequence(_numbers());
+
+		// Nothing iterated yet.
+		expect(sequence.count).toBe(0);
+		expect(sequence.done).toBe(false);
+		expect(() => sequence.first).toThrow("Iteration not started");
+		expect(() => sequence.last).toThrow("Iteration not started");
+
+		// First value — must not throw while `_first` is still unset.
+		const r1 = await sequence.next();
+		expect(r1).toEqual({ value: 1, done: false });
+		expect(sequence.first).toBe(1);
+		expect(sequence.last).toBe(1);
+		expect(sequence.count).toBe(1);
+
+		// Subsequent values advance `last`/`count` but keep `first`.
+		await sequence.next();
+		const r3 = await sequence.next();
+		expect(r3).toEqual({ value: 3, done: false });
+		expect(sequence.first).toBe(1);
+		expect(sequence.last).toBe(3);
+		expect(sequence.count).toBe(3);
+
+		// Return value is captured when the source finishes.
+		const rEnd = await sequence.next();
+		expect(rEnd.done).toBe(true);
+		expect(sequence.done).toBe(true);
+		expect(sequence.returned).toBe("done");
+		expect(sequence.count).toBe(3);
+	});
+});

--- a/modules/sequence/InspectSequence.ts
+++ b/modules/sequence/InspectSequence.ts
@@ -101,7 +101,7 @@ export class InspectSequence<T, R, N> extends ThroughSequence<T, R, N> {
 	/** Capture a result. */
 	private _inspect(result: IteratorResult<T, R | undefined>): IteratorResult<T, R | undefined> {
 		if (!result.done) {
-			if (this.first === undefined) this._first = result.value;
+			if (this._first === _NOVALUE) this._first = result.value;
 			this._last = result.value;
 			this._count++;
 		} else {


### PR DESCRIPTION
`_inspect` used `this.first === undefined` to detect the first emitted
value, but the `first` getter throws `UnexpectedError("Iteration not
started")` while `_first` is still `_NOVALUE` — so the first-value capture
path threw instead of recording the value.

Compare against the private `_NOVALUE` sentinel field directly. Add a test
covering first/last/count/returned tracking on a live inspected sequence,
which was previously uncovered.

Fixes #216

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KoNRJ6MnQAWRnqBr6d9iir