### PR TITLE
fix: return isArray() fast-path result in isArrayItem

### DIFF
--- a/modules/util/array.ts
+++ b/modules/util/array.ts
@@ -142,7 +142,7 @@ export function requireArray<T>(list: PossibleArray<T>, min?: number, max?: numb
  * @see https://shelving.cc/util/array/isArrayItem
  */
 export function isArrayItem<T>(list: PossibleArray<T>, item: unknown): item is T {
-	if (isArray(list)) list.includes(item as T);
+	if (isArray(list)) return list.includes(item as T);
 	for (const i of list) if (i === item) return true;
 	return false;
 }


### PR DESCRIPTION
## Summary

Fixes the dead fast-path line in `isArrayItem` (`modules/util/array.ts`).

The `isArray(list)` branch computed `list.includes(item as T)` but discarded the result (no `return`), then fell through to the generic iterable loop. The function still returned the correct value via the loop, so this was an ineffective line rather than a wrong-answer bug — but the branch was clearly meant to be a fast path using the native `Array.prototype.includes`.

```diff
-	if (isArray(list)) list.includes(item as T);
+	if (isArray(list)) return list.includes(item as T);
```

## Testing

- `bun run test:type` — passes
- `bun run test:unit` — 1189 pass, 0 fail
- `bun run test:lint` — only pre-existing warnings in unrelated UI files (`CheckboxInput.tsx`, `RadioInput.tsx`); none from this change

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015q2XgVBpnBzD8hkrkidTyw)_