### PR TITLE
fix: tighten URLStore.requireParam return type to string

### DIFF
--- a/modules/store/URLStore.test.ts
+++ b/modules/store/URLStore.test.ts
@@ -60,7 +60,8 @@ describe("getParam()", () => {
 describe("requireParam()", () => {
 	test("returns param value", () => {
 		const store = new URLStore("https://example.com/path?foo=bar");
-		expect(store.requireParam("foo")).toBe("bar");
+		const value: string = store.requireParam("foo"); // `requireParam()` returns `string`, never `string | undefined`.
+		expect(value).toBe("bar");
 	});
 	test("throws for missing param", () => {
 		const store = new URLStore("https://example.com/path");

--- a/modules/store/URLStore.ts
+++ b/modules/store/URLStore.ts
@@ -169,7 +169,7 @@ export class URLStore extends BusyStore<ImmutableURL, PossibleURL> {
 	 * @example store.requireParam("page");
 	 * @see https://shelving.cc/store/URLStore/requireParam
 	 */
-	requireParam(key: string): string | undefined {
+	requireParam(key: string): string {
 		return requireURIParam(this.value.searchParams, key, getSetter(this, "requireParam"));
 	}
 


### PR DESCRIPTION
## Summary

`URLStore.requireParam` declared a return type of `string | undefined`, which is wider than its actual contract and contradicts the `require*` throw-on-missing convention in `AGENTS.md` (*"Returns value or throws `RequiredError`"*).

It delegates to `requireURIParam`, which already throws `RequiredError` when the param is missing and otherwise returns `string` — so the spurious `undefined` only pushed needless narrowing onto callers.

## Changes

- `modules/store/URLStore.ts` — narrow `requireParam` return type from `string | undefined` to `string`.
- `modules/store/URLStore.test.ts` — add a compile-time `const value: string = ...` assertion to lock the return type.

`requireURIParam` in `modules/util/uri.ts` was already correctly typed as `string`, so no change was needed there.

## Verification

- `bun run test:type` — clean
- `bun test modules/store/URLStore.test.ts` — 29 pass

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyZsoWyRmz3A5RfXvngCbU)_