### PR TITLE
fix: correct caller attribution in QueryStore.last and EndpointCache.refresh

### DIFF
--- a/modules/api/cache/EndpointCache.ts
+++ b/modules/api/cache/EndpointCache.ts
@@ -107,7 +107,7 @@ export class EndpointCache<P = unknown, R = unknown> implements AsyncDisposable 
 	 * @example await cache.refresh({ id: "abc" })
 	 * @see https://shelving.cc/api/EndpointCache/refresh
 	 */
-	async refresh(payload: P, maxAge?: number, caller: AnyCaller = this.invalidate): Promise<void> {
+	async refresh(payload: P, maxAge?: number, caller: AnyCaller = this.refresh): Promise<void> {
 		await this.get(payload, caller)?.refresh(maxAge);
 	}
 

--- a/modules/db/store/QueryStore.ts
+++ b/modules/db/store/QueryStore.ts
@@ -108,7 +108,7 @@ export class QueryStore<I extends Identifier, T extends Data> extends FetchStore
 				provider: this.provider,
 				collection: this.collection.name,
 				query: this.query,
-				caller: getGetter(this, "first"),
+				caller: getGetter(this, "last"),
 			});
 		return last;
 	}


### PR DESCRIPTION
Fixes two copy-paste `caller:` labels that misattributed thrown errors (cosmetic — wrong call-site name in error chains, no behavioural change).

## Changes

- **`QueryStore.last`** (`modules/db/store/QueryStore.ts`) — the `last` getter threw with the `first` getter's name; now uses `getGetter(this, "last")`.
- **`EndpointCache.refresh`** (`modules/api/cache/EndpointCache.ts`) — the `refresh` method defaulted its `caller` to `this.invalidate`; now defaults to `this.refresh`.

## Verification

- `bun run fix` — clean
- `bun run test:type` — clean

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKphjuzQ8My6uZmxFuc8B5)_