### PR TITLE
Add Loader and PageLoader components for suspense handling

### DIFF
--- a/modules/ui/misc/Loader.tsx
+++ b/modules/ui/misc/Loader.tsx
@@ -1,0 +1,49 @@
+import { type ReactElement, type ReactNode, Suspense } from "react";
+import { CenteredLayout } from "../layout/CenteredLayout.js";
+import type { ChildProps } from "../util/props.js";
+import { Catcher, PageCatcher } from "./Catcher.js";
+import { LOADING } from "./Loading.js";
+
+/**
+ * Props for `<Loader>` and `<PageLoader>` — the `children` to load plus an optional `fallback` shown while they suspend.
+ *
+ * @see https://shelving.cc/ui/LoaderProps
+ */
+export interface LoaderProps extends ChildProps {
+	/** Element rendered while `children` suspend (defaults to `LOADING`). */
+	readonly fallback?: ReactNode | undefined;
+}
+
+/**
+ * Load a component.
+ *
+ * - Wrapped in `<Catcher>` so child components can throw errors.
+ * - Wrapped in `<Suspense>` so child components can throw promises.
+ *
+ * @kind component
+ * @see https://shelving.cc/ui/Loader
+ */
+export function Loader({ children, fallback = LOADING }: LoaderProps): ReactElement {
+	return (
+		<Catcher>
+			<Suspense fallback={fallback}>{children}</Suspense>
+		</Catcher>
+	);
+}
+
+/**
+ * Load a page.
+ *
+ * - Wrapped in `<PageCatcher>` so child components can throw errors.
+ * - Wrapped in `<Suspense>` so child components can throw promises.
+ *
+ * @kind component
+ * @see https://shelving.cc/ui/PageLoader
+ */
+export function PageLoader({ children, fallback = <CenteredLayout>{LOADING}</CenteredLayout> }: LoaderProps): ReactElement {
+	return (
+		<PageCatcher>
+			<Suspense fallback={fallback}>{children}</Suspense>
+		</PageCatcher>
+	);
+}

--- a/modules/ui/misc/index.tsx
+++ b/modules/ui/misc/index.tsx
@@ -1,5 +1,6 @@
 export * from "./Catcher.js";
 export * from "./Icon.js";
+export * from "./Loader.js";
 export * from "./Loading.js";
 export * from "./Mapper.js";
 export * from "./Markup.js";


### PR DESCRIPTION
## Summary
Introduces two new wrapper components (`Loader` and `PageLoader`) that combine error boundary and suspense functionality for loading async components.

## Changes
- **New file: `modules/ui/misc/Loader.tsx`**
  - `Loader` component: Wraps children in `<Catcher>` and `<Suspense>` with customizable fallback (defaults to `LOADING`)
  - `PageLoader` component: Wraps children in `<PageCatcher>` and `<Suspense>` with centered layout fallback
  - `LoaderProps` interface: Extends `ChildProps` with optional `fallback` prop
  - Full JSDoc documentation with links to shelving.cc

- **Updated: `modules/ui/misc/index.tsx`**
  - Exported new `Loader.js` module

## Implementation Details
Both components follow the same pattern: combining error handling (via `Catcher`/`PageCatcher`) with React's `Suspense` to handle both thrown errors and promises from async components. The `PageLoader` variant includes centered layout styling for full-page loading states.

https://claude.ai/code/session_01WWpCpf5jkJ7szGj5PJMiZS