### PR TITLE
Refactor ErrorPage to use ErrorNotice component

### DIFF
--- a/modules/ui/form/Button.md
+++ b/modules/ui/form/Button.md
@@ -60,6 +60,8 @@ import { getButtonClass } from "shelving/ui";
 | `--button-radius` | Corner radius | `var(--radius-xsmall)` (8px) |
 | `--button-padding` | Inner padding | `var(--space-small)` (12px) |
 | `--button-small-padding` | Inner padding when `small` | `var(--space-xxsmall)` (4px) |
+| `--button-gap` | Gap between icon and label | `var(--space-small)` (12px) |
+| `--button-small-gap` | Gap between icon and label when `small` | `var(--space-xxsmall)` (4px) |
 | `--button-space` | Outer block margin | `var(--space-small)` (12px) |
 | `--button-font` | Font family | `var(--font-body)` |
 | `--button-weight` | Font weight | `var(--weight-strong)` (700) |

--- a/modules/ui/form/Button.module.css
+++ b/modules/ui/form/Button.module.css
@@ -28,6 +28,7 @@
 		/* Content */
 		overflow: hidden;
 		word-break: normal;
+		gap: var(--button-gap, var(--space-small));
 		justify-content: center;
 		align-items: center;
 
@@ -61,6 +62,7 @@
 
 		/* Variants */
 		&.small {
+			gap: var(--button-small-gap, var(--space-xxsmall));
 			padding-block: var(--button-small-padding, var(--space-xxsmall));
 			padding-inline: var(--button-small-padding, var(--space-xxsmall));
 		}

--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -2,16 +2,12 @@ import { ArrowPathIcon } from "@heroicons/react/24/solid";
 import { Component, createContext, type ReactElement, type ReactNode, use } from "react";
 import { getMessage } from "../../util/error.js";
 import type { Callback } from "../../util/function.js";
-import { Card } from "../block/Card.js";
 import { Paragraph } from "../block/Paragraph.js";
-import { Row } from "../block/Row.js";
-import { Subheading } from "../block/Subheading.js";
 import { Button, type ButtonVariants } from "../form/Button.js";
 import { CenteredLayout } from "../layout/CenteredLayout.js";
 import { Notice } from "../notice/Notice.js";
 import { Page } from "../page/Page.js";
 import type { ChildProps, OptionalChildProps } from "../util/props.js";
-import { Icon } from "./Icon.js";
 
 const RetryContext = createContext<Callback | undefined>(undefined);
 RetryContext.displayName = "RetryContext";
@@ -137,26 +133,16 @@ export function PageCatcher({ children }: ChildProps): ReactElement {
 }
 
 /**
- * Render a caught error as a full-page `<Page>` with an error `<Card>` and retry button.
- *
- * - Uses `getMessage()` to extract a human-readable message, falling back to `"Unknown error"`.
+ * Render a caught error as a full-page `<Page>` with a centered `<ErrorNotice>`.
  *
  * @kind component
  * @see https://shelving.cc/ui/ErrorPage
  */
 export function ErrorPage({ reason }: ErrorProps): ReactElement {
-	const message = getMessage(reason) ?? "Unknown error";
 	return (
 		<Page title="Error">
 			<CenteredLayout>
-				<Card status="error">
-					<Subheading>
-						<Row left>
-							<Icon status="error" /> {message}
-						</Row>
-					</Subheading>
-					<RetryButton />
-				</Card>
+				<ErrorNotice reason={reason} />
 			</CenteredLayout>
 		</Page>
 	);


### PR DESCRIPTION
## Summary
Simplifies the `ErrorPage` component by delegating error rendering to the `ErrorNotice` component, reducing code duplication and improving maintainability.

## Changes
- **ErrorPage component**: Removed inline error card rendering (Card, Subheading, Row, Icon) and replaced with a single `<ErrorNotice>` component call
- **Removed imports**: Cleaned up unused imports (Card, Row, Subheading, Icon) from Catcher.tsx
- **Button styling**: Added CSS custom properties for controlling gap between icon and label:
  - `--button-gap`: Gap for normal buttons (defaults to `var(--space-small)`)
  - `--button-small-gap`: Gap for small buttons (defaults to `var(--space-xxsmall)`)
- **Documentation**: Updated Button.md to document the new gap CSS variables

## Implementation Details
The refactoring consolidates error display logic into the `ErrorNotice` component, which now handles message extraction, icon rendering, and layout. This reduces the `ErrorPage` component to a simple wrapper that provides page structure and centering.

https://claude.ai/code/session_01Ni28y6m5ewtGtuwfJE14nC