### PR TITLE
test: import from the shelving/* barrel, not relative source paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ These prefixes are reserved for the upcoming UI / component layer. Don't repurpo
 - Barrel files (`index.ts`) re-export with `export * from "./X.js"`, alphabetically sorted
 - Keep barrel exports in sync when moving or adding files
 - In source files, always import from the declaration file directly (e.g. `../../util/array.js`), never from a barrel
-- In test files, always import from the highest applicable barrel (e.g. `shelving/util` not `../../util/array.js`) — this verifies the barrel export exists
+- In test files, always import from the public `shelving/*` barrel, not a relative source path (e.g. `shelving/schema` not `../StringSchema.js`, `shelving/util/array` not `../../util/array.js`) — this verifies the barrel actually re-exports the token. Enforced by a Biome `noRestrictedImports` rule; fixtures under `modules/test` are exempt and stay relative. Resolution of `shelving/*` to source in dev is wired via `tsconfig.json` `paths`
 - `verbatimModuleSyntax` is on — `import type { ... }` is mandatory for type-only imports. Inline `type` in mixed imports: `import { type Foo, bar }`
 
 ## Types
@@ -412,7 +412,7 @@ Checklist:
 - When changing runtime behaviour, update or add the closest colocated `*.test.ts`
 - When changing TypeScript inference or public generic behaviour, include compile-time assignment checks in tests in addition to runtime assertions
 - Reuse fixtures and helpers from `modules/test/` when they fit, especially for collection, provider, and query tests
-- Test files always import from the highest possible barrel file, so the test also ensures the barrel export
+- Test files always import from the public `shelving/*` barrel (never a relative `../` source path), so the test also ensures the barrel export — enforced by a Biome `noRestrictedImports` rule (`modules/test` fixtures exempt)
 - Test descriptions are lowercase sentence fragments: `test("formats from leading 0", ...)`
 - Use `expect.unreachable()` to assert that a code path should not be reached (in catch blocks testing thrown errors)
 

--- a/biome.json
+++ b/biome.json
@@ -95,6 +95,26 @@
 			"javascript": {
 				"globals": ["test", "describe", "expect"]
 			}
+		},
+		{
+			"includes": ["**/*.test.ts", "**/*.test.tsx"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": {
+							"level": "error",
+							"options": {
+								"patterns": [
+									{
+										"group": ["./**", "../**", "!**/test", "!**/test/**"],
+										"message": "Test files must import from the public 'shelving/*' barrel, not a relative source path — this verifies the barrel actually re-exports the token (see AGENTS.md → Testing). Fixtures under 'modules/test' are exempt."
+									}
+								]
+							}
+						}
+					}
+				}
+			}
 		}
 	]
 }

--- a/modules/api/cache/APICache.test.ts
+++ b/modules/api/cache/APICache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { APICache, DATA, GET, MockAPIProvider, runMicrotasks, STRING } from "../../index.js";
-import { ClientAPIProvider } from "../provider/ClientAPIProvider.js";
+import { APICache, ClientAPIProvider, GET, MockAPIProvider } from "shelving/api";
+import { DATA, STRING } from "shelving/schema";
+import { runMicrotasks } from "shelving/util/async";
 
 describe("APICache", () => {
 	test("creates endpoint stores that fetch through the configured provider", async () => {

--- a/modules/api/cache/EndpointCache.test.ts
+++ b/modules/api/cache/EndpointCache.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, EndpointCache, GET, MockAPIProvider, runMicrotasks, STRING } from "../../index.js";
+import { EndpointCache, GET, MockAPIProvider } from "shelving/api";
+import { DATA, STRING } from "shelving/schema";
+import { runMicrotasks } from "shelving/util/async";
 
 describe("EndpointCache", () => {
 	test("reuses the same store for deeply equal payloads", () => {

--- a/modules/api/endpoint/Endpoint.test.ts
+++ b/modules/api/endpoint/Endpoint.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, POST, STRING } from "../../index.js";
+import { GET, POST } from "shelving/api";
+import { DATA, STRING } from "shelving/schema";
 
 describe("Endpoint.toString()", () => {
 	test("toString should include method and path", () => {

--- a/modules/api/endpoint/util.test.ts
+++ b/modules/api/endpoint/util.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, handleEndpoints, INTEGER, MethodNotAllowedError, NotFoundError, POST, STRING, ValueError } from "../../index.js";
+import { GET, handleEndpoints, POST } from "shelving/api";
+import { MethodNotAllowedError, NotFoundError, ValueError } from "shelving/error";
+import { DATA, INTEGER, STRING } from "shelving/schema";
 
 const PAYLOAD = DATA({ id: INTEGER });
 

--- a/modules/api/provider/ClientAPIProvider.test.ts
+++ b/modules/api/provider/ClientAPIProvider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { ClientAPIProvider, DATA, GET, POST, RequiredError, ResponseError, STRING, ValidationAPIProvider } from "../../index.js";
+import { ClientAPIProvider, GET, POST, ValidationAPIProvider } from "shelving/api";
+import { RequiredError, ResponseError } from "shelving/error";
+import { DATA, STRING } from "shelving/schema";
 
 describe("ClientAPIProvider", () => {
 	test("createRequest() renders placeholders into the URL and omits them from the remaining payload", () => {

--- a/modules/api/provider/JSONAPIProvider.test.ts
+++ b/modules/api/provider/JSONAPIProvider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, JSONAPIProvider, POST, ResponseError, STRING } from "../../index.js";
+import { GET, JSONAPIProvider, POST } from "shelving/api";
+import { ResponseError } from "shelving/error";
+import { DATA, STRING } from "shelving/schema";
 
 describe("JSONAPIProvider", () => {
 	test("createRequest() serializes POST payloads as JSON bodies", async () => {

--- a/modules/api/provider/MockAPIProvider.test.ts
+++ b/modules/api/provider/MockAPIProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, MockAPIProvider, POST, ResponseError, STRING, ValidationAPIProvider } from "../../index.js";
-import { ClientAPIProvider } from "./ClientAPIProvider.js";
+import { ClientAPIProvider, GET, MockAPIProvider, POST, ValidationAPIProvider } from "shelving/api";
+import { ResponseError } from "shelving/error";
+import { DATA, STRING } from "shelving/schema";
 
 describe("MockAPIProvider", () => {
 	test("fetch() returns parsed handler responses and logs the resolved result", async () => {

--- a/modules/api/provider/MockEndpointAPIProvider.test.ts
+++ b/modules/api/provider/MockEndpointAPIProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, MockEndpointAPIProvider, NotFoundError, POST, STRING } from "../../index.js";
-import { ClientAPIProvider } from "./ClientAPIProvider.js";
+import { ClientAPIProvider, GET, MockEndpointAPIProvider, POST } from "shelving/api";
+import { NotFoundError } from "shelving/error";
+import { DATA, STRING } from "shelving/schema";
 
 describe("MockEndpointAPIProvider", () => {
 	test("fetch() routes requests through endpoint handlers and logs successful calls", async () => {

--- a/modules/api/provider/ValidationAPIProvider.test.ts
+++ b/modules/api/provider/ValidationAPIProvider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, GET, MockAPIProvider, POST, REQUIRED_STRING, ResponseError, STRING, ValidationAPIProvider } from "../../index.js";
+import { GET, MockAPIProvider, POST, ValidationAPIProvider } from "shelving/api";
+import { ResponseError } from "shelving/error";
+import { DATA, REQUIRED_STRING, STRING } from "shelving/schema";
 
 describe("ValidationAPIProvider", () => {
 	test("validates payloads before calling the source provider", async () => {

--- a/modules/api/provider/XMLAPIProvider.test.ts
+++ b/modules/api/provider/XMLAPIProvider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { DATA, type Endpoint, GET, POST, RequiredError, STRING, XMLAPIProvider } from "../../index.js";
+import { type Endpoint, GET, POST, XMLAPIProvider } from "shelving/api";
+import { RequiredError } from "shelving/error";
+import { DATA, STRING } from "shelving/schema";
 
 describe("XMLAPIProvider", () => {
 	test("createRequest() serializes POST payloads as XML bodies", async () => {

--- a/modules/api/store/EndpointStore.test.ts
+++ b/modules/api/store/EndpointStore.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { createDeferred, DATA, EndpointStore, GET, MockAPIProvider, runMicrotasks, STRING } from "../../index.js";
+import { EndpointStore, GET, MockAPIProvider } from "shelving/api";
+import { DATA, STRING } from "shelving/schema";
+import { createDeferred, runMicrotasks } from "shelving/util/async";
 import { EXPECT_PROMISELIKE } from "../../test/index.js";
 
 describe("EndpointStore", () => {

--- a/modules/cloudflare/CloudflareD1Provider.test.ts
+++ b/modules/cloudflare/CloudflareD1Provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { CloudflareD1Provider, type D1Database, type D1PreparedStatement, type D1Value } from "./index.js";
+import { CloudflareD1Provider, type D1Database, type D1PreparedStatement, type D1Value } from "shelving/cloudflare";
 
 type D1Call = {
 	readonly query: string;

--- a/modules/db/cache/CollectionCache.test.ts
+++ b/modules/db/cache/CollectionCache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { CollectionCache, ItemStore, MockDBProvider, QueryStore, runMicrotasks } from "../../index.js";
+import { CollectionCache, ItemStore, MockDBProvider, QueryStore } from "shelving/db";
+import { runMicrotasks } from "shelving/util/async";
 import { BASICS_COLLECTION, basic1, basic2 } from "../../test/index.js";
 
 describe("CollectionCache", () => {

--- a/modules/db/cache/DBCache.test.ts
+++ b/modules/db/cache/DBCache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { CacheDBProvider, CollectionCache, DBCache, MockDBProvider, runMicrotasks } from "../../index.js";
+import { CacheDBProvider, CollectionCache, DBCache, MockDBProvider } from "shelving/db";
+import { runMicrotasks } from "shelving/util/async";
 import { BASICS_COLLECTION, basic1, basic2, PEOPLE_COLLECTION, person1 } from "../../test/index.js";
 
 describe("DBCache", () => {

--- a/modules/db/migrate/PostgreSQLMigrator.test.ts
+++ b/modules/db/migrate/PostgreSQLMigrator.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { DATA, INTEGER, PostgreSQLMigrator, SQLProvider, STRING } from "../../index.js";
-import type { Schema } from "../../schema/Schema.js";
+import { PostgreSQLMigrator, SQLProvider } from "shelving/db";
+import { DATA, INTEGER, type Schema, STRING } from "shelving/schema";
 
 class TestSQLProvider extends SQLProvider {
 	override async exec<T extends Record<string, unknown> = Record<string, unknown>>(

--- a/modules/db/migrate/SQLiteMigrator.test.ts
+++ b/modules/db/migrate/SQLiteMigrator.test.ts
@@ -1,6 +1,8 @@
 import { Database, type SQLQueryBindings } from "bun:sqlite";
 import { expect, test } from "bun:test";
-import { ARRAY, COLLECTION, DATA, type Data, INTEGER, type SQLFragment, SQLiteMigrator, SQLProvider, STRING } from "../../index.js";
+import { COLLECTION, type SQLFragment, SQLiteMigrator, SQLProvider } from "shelving/db";
+import { ARRAY, DATA, INTEGER, STRING } from "shelving/schema";
+import type { Data } from "shelving/util/data";
 import { BASIC_SCHEMA } from "../../test/index.js";
 
 const BASICS_COLLECTION = COLLECTION("basics", INTEGER, BASIC_SCHEMA);

--- a/modules/db/provider/CacheDBProvider.test.ts
+++ b/modules/db/provider/CacheDBProvider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { CacheDBProvider, MemoryDBProvider, runMicrotasks, runSequence } from "../../index.js";
+import { CacheDBProvider, MemoryDBProvider } from "shelving/db";
+import { runMicrotasks } from "shelving/util/async";
+import { runSequence } from "shelving/util/sequence";
 import { BASICS_COLLECTION, basic1, basic2, expectOrderedItems } from "../../test/index.js";
 
 describe("CacheDBProvider", () => {

--- a/modules/db/provider/ChangesDBProvider.test.ts
+++ b/modules/db/provider/ChangesDBProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ChangesDBProvider, MockDBProvider } from "../../index.js";
+import { ChangesDBProvider, MockDBProvider } from "shelving/db";
 import { BASICS_COLLECTION, basic1, basic999 } from "../../test/index.js";
 
 describe("ChangesDBProvider", () => {

--- a/modules/db/provider/MemoryDBProvider.test.ts
+++ b/modules/db/provider/MemoryDBProvider.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { type ImmutableArray, type Item, MemoryDBProvider, type OptionalItem, runMicrotasks, runSequence } from "../../index.js";
+import { MemoryDBProvider } from "shelving/db";
+import type { ImmutableArray } from "shelving/util/array";
+import { runMicrotasks } from "shelving/util/async";
+import type { Item, OptionalItem } from "shelving/util/item";
+import { runSequence } from "shelving/util/sequence";
 import {
 	BASICS_COLLECTION,
 	type BasicData,

--- a/modules/db/provider/ValidationDBProvider.test.ts
+++ b/modules/db/provider/ValidationDBProvider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { MockDBProvider, ValidationDBProvider, ValueError } from "../../index.js";
+import { MockDBProvider, ValidationDBProvider } from "shelving/db";
+import { ValueError } from "shelving/error";
 import { BASICS_COLLECTION, basic1, basic2, basic999 } from "../../test/index.js";
 
 describe("ValidationDBProvider", () => {

--- a/modules/error/RequestError.test.ts
+++ b/modules/error/RequestError.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ForbiddenError, NotFoundError, RequestError, UnauthorizedError, UnprocessableError } from "../index.js";
+import { ForbiddenError, NotFoundError, RequestError, UnauthorizedError, UnprocessableError } from "shelving/error";
 
 describe("RequestError", () => {
 	test("code is correct", () => {

--- a/modules/error/ValueError.test.ts
+++ b/modules/error/ValueError.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ValueError } from "../index.js";
+import { ValueError } from "shelving/error";
 
 describe("ValueError", () => {
 	test("caller argument works correctly in ValueError", () => {

--- a/modules/extract/DirectoryExtractor.test.ts
+++ b/modules/extract/DirectoryExtractor.test.ts
@@ -2,9 +2,9 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AbsolutePath } from "../util/path.js";
-import type { TreeElement } from "../util/tree.js";
-import { DirectoryExtractor } from "./DirectoryExtractor.js";
+import { DirectoryExtractor } from "shelving/extract";
+import type { AbsolutePath } from "shelving/util/path";
+import type { TreeElement } from "shelving/util/tree";
 
 let root: string;
 

--- a/modules/extract/IndexExtractor.test.ts
+++ b/modules/extract/IndexExtractor.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { AbsolutePath } from "../util/path.js";
-import type { TreeElement } from "../util/tree.js";
-import { Extractor } from "./Extractor.js";
-import { IndexExtractor } from "./IndexExtractor.js";
+import { Extractor, IndexExtractor } from "shelving/extract";
+import type { AbsolutePath } from "shelving/util/path";
+import type { TreeElement } from "shelving/util/tree";
 
 function _file(key: string, props: Partial<TreeElement["props"]> = {}): TreeElement {
 	const [name] = key.split(".");

--- a/modules/extract/MarkupExtractor.test.ts
+++ b/modules/extract/MarkupExtractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { BunFile } from "bun";
-import { extractMarkdownProps, MarkupExtractor } from "./index.js";
+import { extractMarkdownProps, MarkupExtractor } from "shelving/extract";
 
 const extractor = new MarkupExtractor();
 

--- a/modules/extract/MergingExtractor.test.ts
+++ b/modules/extract/MergingExtractor.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { AbsolutePath } from "../util/path.js";
-import type { TreeElement } from "../util/tree.js";
-import { Extractor } from "./Extractor.js";
-import { MergingExtractor } from "./MergingExtractor.js";
+import { Extractor, MergingExtractor } from "shelving/extract";
+import type { AbsolutePath } from "shelving/util/path";
+import type { TreeElement } from "shelving/util/tree";
 
 /** Helper to build a file `tree-element` for tests. */
 function _file(key: string, props: Partial<TreeElement["props"]> = {}): TreeElement {

--- a/modules/extract/ModuleExtractor.test.ts
+++ b/modules/extract/ModuleExtractor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { AbsolutePath } from "../util/path.js";
-import type { DocumentationElement, TreeElement } from "../util/tree.js";
-import { ModuleExtractor } from "./ModuleExtractor.js";
+import { ModuleExtractor } from "shelving/extract";
+import type { AbsolutePath } from "shelving/util/path";
+import type { DocumentationElement, TreeElement } from "shelving/util/tree";
 
 function _file(key: string, props: Partial<TreeElement["props"]> = {}): TreeElement {
 	const [name] = key.split(".");

--- a/modules/extract/PackageExtractor.test.ts
+++ b/modules/extract/PackageExtractor.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AbsolutePath } from "../util/path.js";
-import type { TreeElement } from "../util/tree.js";
-import { DirectoryExtractor } from "./DirectoryExtractor.js";
-import { IndexExtractor } from "./IndexExtractor.js";
-import { MergingExtractor } from "./MergingExtractor.js";
-import { PackageExtractor } from "./PackageExtractor.js";
+import { DirectoryExtractor, IndexExtractor, MergingExtractor, PackageExtractor } from "shelving/extract";
+import type { AbsolutePath } from "shelving/util/path";
+import type { TreeElement } from "shelving/util/tree";
 
 /** Build a self-contained source tree on disk (independent per test, so concurrent runs don't collide). */
 async function _setup(
@@ -117,7 +114,7 @@ describe("PackageExtractor", () => {
 	});
 
 	test("respects custom extensions when resolving exports to source files", async () => {
-		const { TypescriptExtractor } = await import("./TypescriptExtractor.js");
+		const { TypescriptExtractor } = await import("shelving/extract");
 		const { root, tree, cleanup } = await _setup(async r => {
 			await mkdir(join(r, "api"), { recursive: true });
 			await writeFile(join(r, "api", "mts-only.mts"), "export const X = 1;");

--- a/modules/extract/TypescriptExtractor.test.ts
+++ b/modules/extract/TypescriptExtractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { BunFile } from "bun";
-import { TypescriptExtractor } from "./index.js";
+import { TypescriptExtractor } from "shelving/extract";
 
 const extractor = new TypescriptExtractor();
 

--- a/modules/markup/MarkupParser.test.ts
+++ b/modules/markup/MarkupParser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { isValidElement } from "react";
 import { renderToString } from "react-dom/server";
-import { MarkupParser } from "./index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/blockquote.test.ts
+++ b/modules/markup/rule/blockquote.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/code.test.ts
+++ b/modules/markup/rule/code.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/heading.test.ts
+++ b/modules/markup/rule/heading.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/inline.test.ts
+++ b/modules/markup/rule/inline.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/linebreak.test.ts
+++ b/modules/markup/rule/linebreak.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/link.test.ts
+++ b/modules/markup/rule/link.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
-import { type Element, type ElementProps, requireURL } from "../../index.js";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
+import type { Element, ElementProps } from "shelving/util/element";
+import { requireURL } from "shelving/util/url";
 
 const PARSER = new MarkupParser();
 const NOFOLLOW_PARSER = new MarkupParser({ rel: "nofollow ugc" });

--- a/modules/markup/rule/ordered.test.ts
+++ b/modules/markup/rule/ordered.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/paragraph.test.ts
+++ b/modules/markup/rule/paragraph.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/separator.test.ts
+++ b/modules/markup/rule/separator.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/table.test.ts
+++ b/modules/markup/rule/table.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/markup/rule/unordered.test.ts
+++ b/modules/markup/rule/unordered.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { MarkupParser } from "../index.js";
+import { MarkupParser } from "shelving/markup";
 
 const PARSER = new MarkupParser();
 

--- a/modules/schema/AddressSchema.test.ts
+++ b/modules/schema/AddressSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { AddressData, Schema } from "../index.js";
-import { ADDRESS, AddressSchema, formatAddress, NULLABLE_ADDRESS } from "../index.js";
+import { ADDRESS, type AddressData, AddressSchema, formatAddress, NULLABLE_ADDRESS, type Schema } from "shelving/schema";
 
 test("TypeScript", () => {
 	const s1: Schema<AddressData | null> = NULLABLE_ADDRESS;

--- a/modules/schema/ArraySchema.test.ts
+++ b/modules/schema/ArraySchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { ARRAY, ArraySchema, DATA, NUMBER, STRING } from "../index.js";
+import { ARRAY, ArraySchema, DATA, NUMBER, type Schema, STRING } from "shelving/schema";
 
 // Vars.
 const stringArray = ["a", "b", "c"];

--- a/modules/schema/BooleanSchema.test.ts
+++ b/modules/schema/BooleanSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { BOOLEAN, BooleanSchema } from "../index.js";
+import { BOOLEAN, BooleanSchema, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/ChoiceSchema.test.ts
+++ b/modules/schema/ChoiceSchema.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { CHOICE, ChoiceSchema } from "../index.js";
+import { CHOICE, ChoiceSchema, type Schema } from "shelving/schema";
 
 test("TypeScript", () => {
 	// String object options.

--- a/modules/schema/ColorSchema.test.ts
+++ b/modules/schema/ColorSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { COLOR, ColorSchema, NULLABLE_COLOR } from "../index.js";
+import { COLOR, ColorSchema, NULLABLE_COLOR, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/CountrySchema.test.ts
+++ b/modules/schema/CountrySchema.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { COUNTRY, CountrySchema, getCountry, NULLABLE_COUNTRY } from "../index.js";
-import type { Country } from "../util/geo.js";
+import { COUNTRY, CountrySchema, NULLABLE_COUNTRY, type Schema } from "shelving/schema";
+import { type Country, getCountry } from "shelving/util/geo";
 
 test("TypeScript", () => {
 	const s1: Schema<Country | null> = NULLABLE_COUNTRY;

--- a/modules/schema/CurrencyAmountSchema.test.ts
+++ b/modules/schema/CurrencyAmountSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { CURRENCY_AMOUNT, CurrencyAmountSchema, NULLABLE_CURRENCY_AMOUNT } from "./CurrencyAmountSchema.js";
-import type { Schema } from "./Schema.js";
+import { CURRENCY_AMOUNT, CurrencyAmountSchema, NULLABLE_CURRENCY_AMOUNT, type Schema } from "shelving/schema";
 
 test("TypeScript", () => {
 	const s1: Schema<number> = CURRENCY_AMOUNT("GBP");

--- a/modules/schema/CurrencyCodeSchema.test.ts
+++ b/modules/schema/CurrencyCodeSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { CURRENCY_CODE, CurrencyCodeSchema, NULLABLE_CURRENCY_CODE } from "../index.js";
+import { CURRENCY_CODE, CurrencyCodeSchema, NULLABLE_CURRENCY_CODE, type Schema } from "shelving/schema";
 
 test("TypeScript", () => {
 	// Test currencyCode.optional

--- a/modules/schema/DataSchema.test.ts
+++ b/modules/schema/DataSchema.test.ts
@@ -13,7 +13,7 @@ import {
 	type Schema,
 	STRING,
 	StringSchema,
-} from "../index.js";
+} from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/DateSchema.test.ts
+++ b/modules/schema/DateSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { DATE, DateSchema, formatDate, NULLABLE_DATE } from "../index.js";
+import { DATE, DateSchema, NULLABLE_DATE, type Schema } from "shelving/schema";
+import { formatDate } from "shelving/util/format";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/DateTimeSchema.test.ts
+++ b/modules/schema/DateTimeSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { DATETIME, DateTimeSchema, formatDateTime, NULLABLE_DATETIME } from "../index.js";
+import { DATETIME, DateTimeSchema, NULLABLE_DATETIME, type Schema } from "shelving/schema";
+import { formatDateTime } from "shelving/util/format";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/DictionarySchema.test.ts
+++ b/modules/schema/DictionarySchema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { BOOLEAN, DICTIONARY, DictionarySchema, type ImmutableDictionary, NUMBER, type Schema, STRING } from "../index.js";
+import { BOOLEAN, DICTIONARY, DictionarySchema, NUMBER, type Schema, STRING } from "shelving/schema";
+import type { ImmutableDictionary } from "shelving/util/dictionary";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/EmailSchema.test.ts
+++ b/modules/schema/EmailSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { EMAIL, EmailSchema, NULLABLE_EMAIL } from "../index.js";
+import { EMAIL, EmailSchema, NULLABLE_EMAIL, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/EntitySchema.test.ts
+++ b/modules/schema/EntitySchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { ENTITY, EntitySchema, NULLABLE_ENTITY } from "../index.js";
+import { ENTITY, EntitySchema, NULLABLE_ENTITY, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/FileSchema.test.ts
+++ b/modules/schema/FileSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { FILE, FileSchema, NULLABLE_FILE } from "../index.js";
+import { FILE, FileSchema, NULLABLE_FILE, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/KeySchema.test.ts
+++ b/modules/schema/KeySchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { KEY, KeySchema, NULLABLE_KEY } from "../index.js";
+import { KEY, KeySchema, NULLABLE_KEY, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/NumberSchema.test.ts
+++ b/modules/schema/NumberSchema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { formatNumber, NULLABLE_NUMBER, NUMBER, NumberSchema, Schema } from "../index.js";
+import { NULLABLE_NUMBER, NUMBER, NumberSchema, Schema } from "shelving/schema";
+import { formatNumber } from "shelving/util/format";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/OptionalSchema.test.ts
+++ b/modules/schema/OptionalSchema.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from "bun:test";
-import { NumberSchema } from "./NumberSchema.js";
-import { OPTIONAL, OptionalSchema } from "./OptionalSchema.js";
-import { StringSchema } from "./StringSchema.js";
+import { NumberSchema, OPTIONAL, OptionalSchema, StringSchema } from "shelving/schema";
 
 test("TypeScript", () => {
 	// Test OptionalSchema type inference

--- a/modules/schema/PasswordSchema.test.ts
+++ b/modules/schema/PasswordSchema.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { PASSWORD, PasswordSchema } from "../index.js";
+import { PASSWORD, PasswordSchema } from "shelving/schema";
 
 test("constructor()", () => {
 	const schema1 = new PasswordSchema({});

--- a/modules/schema/PhoneSchema.test.ts
+++ b/modules/schema/PhoneSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { NULLABLE_PHONE, PHONE, PhoneSchema } from "../index.js";
+import { NULLABLE_PHONE, PHONE, PhoneSchema, type Schema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/StringSchema.test.ts
+++ b/modules/schema/StringSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { REQUIRED_STRING, STRING, StringSchema } from "../index.js";
+import { REQUIRED_STRING, type Schema, STRING, StringSchema } from "shelving/schema";
 
 // Vars.
 const longString =

--- a/modules/schema/TimeSchema.test.ts
+++ b/modules/schema/TimeSchema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { formatTime, TIME, TimeSchema } from "../index.js";
+import { TIME, TimeSchema } from "shelving/schema";
+import { formatTime } from "shelving/util/format";
 
 test("constructor()", () => {
 	const schema1 = new TimeSchema({});

--- a/modules/schema/URISchema.test.ts
+++ b/modules/schema/URISchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { NULLABLE_URI_SCHEMA, URI_SCHEMA, URISchema } from "../index.js";
+import { NULLABLE_URI_SCHEMA, type Schema, URI_SCHEMA, URISchema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/schema/URLSchema.test.ts
+++ b/modules/schema/URLSchema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Schema } from "../index.js";
-import { NULLABLE_URL_SCHEMA, URL_SCHEMA, URLSchema } from "../index.js";
+import { NULLABLE_URL_SCHEMA, type Schema, URL_SCHEMA, URLSchema } from "shelving/schema";
 
 // Tests.
 test("TypeScript", () => {

--- a/modules/sequence/DeferredSequence.test.ts
+++ b/modules/sequence/DeferredSequence.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
-import { runMicrotasks, runSequence } from "../index.js";
-import { DeferredSequence } from "./DeferredSequence.js";
+import { DeferredSequence } from "shelving/sequence";
+import { runMicrotasks } from "shelving/util/async";
+import { runSequence } from "shelving/util/sequence";
 
 test("Multiple `resolve()` and `reject()` calls", async () => {
 	const deferred = new DeferredSequence<number>();

--- a/modules/sequence/InspectSequence.test.ts
+++ b/modules/sequence/InspectSequence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { InspectSequence } from "../index.js";
+import { InspectSequence } from "shelving/sequence";
 
 // Build an `InspectSequence` wrapping a simple async generator source.
 async function* _numbers(): AsyncGenerator<number, string, undefined> {

--- a/modules/sequence/LazySequence.test.ts
+++ b/modules/sequence/LazySequence.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { DeferredSequence } from "../index.js";
-import { LazySequence } from "./LazySequence.js";
+import { DeferredSequence, LazySequence } from "shelving/sequence";
 
 describe("LazySequence", () => {
 	test("StartCallback is called", async () => {

--- a/modules/store/ArrayStore.test.ts
+++ b/modules/store/ArrayStore.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
-import type { ImmutableArray } from "../index.js";
-import { ArrayStore, runMicrotasks, runSequence } from "../index.js";
+import { ArrayStore } from "shelving/store";
+import type { ImmutableArray } from "shelving/util/array";
+import { runMicrotasks } from "shelving/util/async";
+import { runSequence } from "shelving/util/sequence";
 
 test("ArrayStore with initial value", async () => {
 	const store = new ArrayStore<number>([1, 2, 3]);

--- a/modules/store/BusyStore.test.ts
+++ b/modules/store/BusyStore.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { BusyStore, createDeferred, NONE, runMicrotasks } from "../index.js";
+import { BusyStore } from "shelving/store";
+import { createDeferred, runMicrotasks } from "shelving/util/async";
+import { NONE } from "shelving/util/constants";
 
 test("busy is false initially", () => {
 	const store = new BusyStore<number>(42);

--- a/modules/store/DataStore.test.ts
+++ b/modules/store/DataStore.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import { DataStore, OptionalDataStore, RequiredError, runMicrotasks, runSequence } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { DataStore, OptionalDataStore } from "shelving/store";
+import { runMicrotasks } from "shelving/util/async";
+import { runSequence } from "shelving/util/sequence";
 
 test("DataStore.prototype.data", async () => {
 	type T = { a: number };

--- a/modules/store/FetchStore.test.ts
+++ b/modules/store/FetchStore.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { createDeferred, type Deferred, FetchStore, NONE, runMicrotasks } from "../index.js";
+import { FetchStore } from "shelving/store";
+import { createDeferred, type Deferred, runMicrotasks } from "shelving/util/async";
+import { NONE } from "shelving/util/constants";
 import { EXPECT_PROMISELIKE } from "../test/util.js";
 
 // --- Basic fetch ---

--- a/modules/store/PayloadFetchStore.test.ts
+++ b/modules/store/PayloadFetchStore.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { NONE, PayloadFetchStore, runMicrotasks } from "../index.js";
+import { PayloadFetchStore } from "shelving/store";
+import { runMicrotasks } from "shelving/util/async";
+import { NONE } from "shelving/util/constants";
 
 // --- Initial state ---
 

--- a/modules/store/Store.test.ts
+++ b/modules/store/Store.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { createDeferred, NONE, runMicrotasks, runSequence, Store } from "../index.js";
+import { Store } from "shelving/store";
+import { createDeferred, runMicrotasks } from "shelving/util/async";
+import { NONE } from "shelving/util/constants";
+import { runSequence } from "shelving/util/sequence";
 import { EXPECT_PROMISELIKE } from "../test/util.js";
 
 test("No initial value", async () => {

--- a/modules/store/URLStore.test.ts
+++ b/modules/store/URLStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { RequiredError, URLStore } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { URLStore } from "shelving/store";
 
 describe("URLStore", () => {
 	test("constructor: creates store with URL string", () => {

--- a/modules/ui/docs/DocumentationPage.test.tsx
+++ b/modules/ui/docs/DocumentationPage.test.tsx
@@ -1,10 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { DocumentationElement } from "../../util/tree.js";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
-import { DocumentationPage } from "./DocumentationPage.js";
+import { createMeta, DocumentationPage, MetaContext } from "shelving/ui";
+import type { DocumentationElement } from "shelving/util/tree";
 
 /** Make a minimal `tree-documentation` child element of a given kind. */
 function doc(name: string, kind: string): DocumentationElement {

--- a/modules/ui/form/Field.test.tsx
+++ b/modules/ui/form/Field.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Field } from "./Field.js";
+import { Field } from "shelving/ui";
 
 describe("Field", () => {
 	test("does not render a message container when there is no message", () => {

--- a/modules/ui/input/SchemaInput.test.tsx
+++ b/modules/ui/input/SchemaInput.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { PASSTHROUGH, StringSchema } from "../../index.js";
-import { StringSchemaInput } from "../index.js";
+import { StringSchema } from "shelving/schema";
+import { StringSchemaInput } from "shelving/ui";
+import { PASSTHROUGH } from "shelving/util/function";
 
 describe("StringSchemaInput", () => {
 	test("formats the initial value to its clean sanitized value", () => {

--- a/modules/ui/misc/MetaContext.test.tsx
+++ b/modules/ui/misc/MetaContext.test.tsx
@@ -1,9 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { RequiredError } from "../../error/RequiredError.js";
-import { createMeta } from "../util/meta.js";
-import { MetaContext, requireMetaURL } from "./MetaContext.js";
+import { RequiredError } from "shelving/error";
+import { createMeta, MetaContext, requireMetaURL } from "shelving/ui";
 
 /** Render `requireMetaURL().path` from inside a component so its `use(MetaContext)` call is valid. */
 function Probe(): ReactNode {

--- a/modules/ui/router/Router.test.tsx
+++ b/modules/ui/router/Router.test.tsx
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
-import { Router } from "./Router.js";
-import type { RouteProps } from "./Routes.js";
+import { createMeta, MetaContext, type RouteProps, Router } from "shelving/ui";
 
 const ROUTES = {
 	"/": () => <main>Home</main>,

--- a/modules/ui/tree/TreeButton.test.tsx
+++ b/modules/ui/tree/TreeButton.test.tsx
@@ -1,11 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { DocumentationElement, TreeElement } from "../../util/tree.js";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
-import { TreeButton } from "./TreeButton.js";
-import { TreeProvider } from "./TreeContext.js";
+import { createMeta, MetaContext, TreeButton, TreeProvider } from "shelving/ui";
+import type { DocumentationElement, TreeElement } from "shelving/util/tree";
 
 /** Tree with a class member so both flat (`Store.get`) and canonical-path references resolve. */
 const get: DocumentationElement = {

--- a/modules/ui/tree/TreeContext.test.tsx
+++ b/modules/ui/tree/TreeContext.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { DocumentationElement, TreeElement } from "../../util/tree.js";
-import { flattenTree } from "../../util/tree.js";
-import { getTreeElement } from "./TreeContext.js";
+import { getTreeElement } from "shelving/ui";
+import { type DocumentationElement, flattenTree, type TreeElement } from "shelving/util/tree";
 
 /** Tree spanning a module, a class with a member, a standalone function, and a component. */
 const validate: DocumentationElement = {

--- a/modules/ui/tree/TreeMarkup.test.tsx
+++ b/modules/ui/tree/TreeMarkup.test.tsx
@@ -1,11 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { DocumentationElement, TreeElement } from "../../util/tree.js";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
-import { TreeProvider } from "./TreeContext.js";
-import { TreeMarkup } from "./TreeMarkup.js";
+import { createMeta, MetaContext, TreeMarkup, TreeProvider } from "shelving/ui";
+import type { DocumentationElement, TreeElement } from "shelving/util/tree";
 
 /** Tree with a single documented class so `Store` resolves to a canonical path. */
 const store: DocumentationElement = {

--- a/modules/ui/tree/TreeRouter.test.tsx
+++ b/modules/ui/tree/TreeRouter.test.tsx
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { TreeElement } from "../../util/tree.js";
-import { MetaContext } from "../misc/MetaContext.js";
-import { createMeta } from "../util/meta.js";
-import { TreeProvider } from "./TreeContext.js";
-import { TreeRouter } from "./TreeRouter.js";
+import { createMeta, MetaContext, TreeProvider, TreeRouter } from "shelving/ui";
+import type { TreeElement } from "shelving/util/tree";
 
 /** Minimal tree: root → `util` directory → `array` file. */
 const tree: TreeElement = {

--- a/modules/util/ansi.test.ts
+++ b/modules/util/ansi.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { ANSI_GREEN, ANSI_RESET, ANSI_SUCCESS, ansiWrap, SUCCESS } from "../index.js";
+import { ANSI_GREEN, ANSI_RESET, ANSI_SUCCESS, ansiWrap } from "shelving/util/ansi";
+import { SUCCESS } from "shelving/util/constants";
 
 // `ansiWrap` resolves colour support once at module load (`_USES_COLOR`), so within this process its behaviour is
 // fixed — every result is one of two deterministic forms regardless of the test runner's TTY/env state.

--- a/modules/util/array.test.ts
+++ b/modules/util/array.test.ts
@@ -1,30 +1,23 @@
 import { expect, test } from "bun:test";
+import { RequiredError } from "shelving/error";
 import {
 	addArrayItem,
 	addArrayItems,
 	assertArray,
 	deleteArrayItems,
-	filterArray,
 	getNext,
 	getPrev,
 	getUniqueArray,
 	interleaveArray,
 	isArray,
-	isArrayWith,
-	isEqual,
-	isEqualGreater,
-	isEqualLess,
-	isGreater,
-	isInArray,
-	isLess,
-	notEqual,
 	omitArrayItems,
-	RequiredError,
 	requireArray,
 	shuffleArray,
 	toggleArrayItems,
 	withArrayItems,
-} from "../index.js";
+} from "shelving/util/array";
+import { isArrayWith, isEqual, isEqualGreater, isEqualLess, isGreater, isInArray, isLess, notEqual } from "shelving/util/equal";
+import { filterArray } from "shelving/util/filter";
 
 test("toggleArrayItems()", () => {
 	const arr = [1, 2, 3];

--- a/modules/util/async.test.ts
+++ b/modules/util/async.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { awaitAbort, awaitValues, createDeferred, Errors as ShelvingAggregateError } from "../index.js";
+import { Errors as ShelvingAggregateError } from "shelving/error";
+import { awaitAbort, awaitValues, createDeferred } from "shelving/util/async";
 
 describe("awaitAbort()", () => {
 	test("rejects when signal is already aborted", async () => {
@@ -15,13 +16,13 @@ describe("awaitAbort()", () => {
 	});
 	test("races against getDelay — delay wins when signal never fires", async () => {
 		const controller = new AbortController();
-		const { getDelay } = await import("./async.js");
+		const { getDelay } = await import("shelving/util/async");
 		const result = await Promise.race([getDelay(10).then(() => "done"), awaitAbort(controller.signal).catch(() => "aborted")]);
 		expect(result).toBe("done");
 	});
 	test("races against getDelay — abort wins when signal fires first", async () => {
 		const controller = new AbortController();
-		const { getDelay } = await import("./async.js");
+		const { getDelay } = await import("shelving/util/async");
 		const race = Promise.race([getDelay(100).then(() => "done"), awaitAbort(controller.signal).catch(() => "aborted")]);
 		controller.abort();
 		expect(await race).toBe("aborted");

--- a/modules/util/base64.test.ts
+++ b/modules/util/base64.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ValueError } from "shelving/error";
 import {
 	decodeBase64Bytes,
 	decodeBase64String,
@@ -6,8 +7,7 @@ import {
 	decodeBase64URLString,
 	encodeBase64,
 	encodeBase64URL,
-	ValueError,
-} from "../index.js";
+} from "shelving/util/base64";
 
 describe("encodeBase64()", () => {
 	test("encode ASCII strings correctly", () => {

--- a/modules/util/buffer.test.ts
+++ b/modules/util/buffer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isBuffer, isBufferView, isTypedArray } from "../index.js";
+import { isBuffer, isBufferView, isTypedArray } from "shelving/util/buffer";
 
 test("isBuffer()", () => {
 	// Valid ArrayBuffer

--- a/modules/util/bytes.test.ts
+++ b/modules/util/bytes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { getBytes, RequiredError, requireBytes } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { getBytes, requireBytes } from "shelving/util/bytes";
 
 describe("getBytes()", () => {
 	test("returns Uint8Array from ArrayBuffer", () => {

--- a/modules/util/class.test.ts
+++ b/modules/util/class.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isConstructor } from "../index.js";
+import { isConstructor } from "shelving/util/class";
 
 test("isClass(): Works correctly", () => {
 	// Classes.

--- a/modules/util/color.test.ts
+++ b/modules/util/color.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { Color, getColor, RequiredError, requireColor } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { Color, getColor, requireColor } from "shelving/util/color";
 
 test("toColor(): colors", () => {
 	expect(getColor("#fff")).toBeInstanceOf(Color);

--- a/modules/util/crypto.test.ts
+++ b/modules/util/crypto.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { ValueError } from "../error/ValueError.js";
-import { hashPassword, verifyPassword } from "./crypto.js";
+import { ValueError } from "shelving/error";
+import { hashPassword, verifyPassword } from "shelving/util/crypto";
 
 const PASSWORD = "mysecretpassword";
 

--- a/modules/util/currency.test.ts
+++ b/modules/util/currency.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { CURRENCY_CODES, formatCurrency, getCurrencySymbol } from "../index.js";
+import { CURRENCY_CODES, getCurrencySymbol } from "shelving/util/currency";
+import { formatCurrency } from "shelving/util/format";
 
 test("TypeScript", () => {
 	const amount: string = formatCurrency(12.34, "GBP");

--- a/modules/util/data.test.ts
+++ b/modules/util/data.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import type { BranchData, Data, ImmutableDictionary, LeafData } from "../index.js";
-import { getDataProp } from "../index.js";
+import { type BranchData, type Data, getDataProp, type LeafData } from "shelving/util/data";
+import type { ImmutableDictionary } from "shelving/util/dictionary";
 
 type T = {
 	readonly a: {

--- a/modules/util/date.test.ts
+++ b/modules/util/date.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { PossibleDate } from "../index.js";
-import { getDate, getDateString, requireDateString } from "../index.js";
-import { requireTimeString } from "./date.js";
+import { getDate, getDateString, type PossibleDate, requireDateString, requireTimeString } from "shelving/util/date";
 
 describe("getDate()", () => {
 	test("getDate(): Parses valid possible dates to Date instances", () => {

--- a/modules/util/debug.test.ts
+++ b/modules/util/debug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { debug, debugFullRequest, debugFullResponse, debugHeaders } from "../index.js";
+import { debug, debugFullRequest, debugFullResponse, debugHeaders } from "shelving/util/debug";
 
 describe("debugHeaders()", () => {
 	test("formats headers correctly", () => {

--- a/modules/util/diff.test.ts
+++ b/modules/util/diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { type Data, deepDiff, deepDiffArray, deepDiffObject, SAME } from "../index.js";
+import type { Data } from "shelving/util/data";
+import { deepDiff, deepDiffArray, deepDiffObject, SAME } from "shelving/util/diff";
 
 const arrFlat: readonly unknown[] = [1, "b", true, false, null];
 const arrFlatSame: readonly unknown[] = [1, "b", true, false, null];

--- a/modules/util/duration.test.ts
+++ b/modules/util/duration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { DAY, HOUR, MINUTE, MONTH, SECOND, WEEK } from "./constants.js";
-import { getBestDurationUnit, getMillisecondsUntil } from "./duration.js";
+import { DAY, HOUR, MINUTE, MONTH, SECOND, WEEK } from "shelving/util/constants";
+import { getBestDurationUnit, getMillisecondsUntil } from "shelving/util/duration";
 
 test("getMillisecondsUntil()", () => {
 	expect(getMillisecondsUntil(10000000, 20000000)).toBe(-10000000);

--- a/modules/util/element.test.ts
+++ b/modules/util/element.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactElement, ReactNode } from "react";
-import type { Data, Element, Elements } from "../index.js";
-import { filterElements, getElementText, queryElements, walkElements } from "../index.js";
+import type { Data } from "shelving/util/data";
+import { type Element, type Elements, filterElements, getElementText, queryElements, walkElements } from "shelving/util/element";
 
 const P: Element = {
 	key: null,

--- a/modules/util/equal.test.ts
+++ b/modules/util/equal.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isArrayEqual, isArrayWith, isDeepEqual, isEqual, isObjectEqual, isObjectMatch, notArrayWith } from "../index.js";
+import { isArrayEqual, isArrayWith, isDeepEqual, isEqual, isObjectEqual, isObjectMatch, notArrayWith } from "shelving/util/equal";
 
 const arrFlat = [1, "b", true, false, null];
 const arrFlatSame = [1, "b", true, false, null];

--- a/modules/util/error.test.ts
+++ b/modules/util/error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { RequiredError } from "../error/RequiredError.js";
-import { getMessage, joinMessage, requireMessage, splitMessage } from "./error.js";
+import { RequiredError } from "shelving/error";
+import { getMessage, joinMessage, requireMessage, splitMessage } from "shelving/util/error";
 
 describe("getMessage()", () => {
 	test("returns string when input is string", () => {

--- a/modules/util/file.test.ts
+++ b/modules/util/file.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { RequiredError } from "../error/RequiredError.js";
-import { getFileExtension, requireFileExtension, splitFileExtension } from "./file.js";
+import { RequiredError } from "shelving/error";
+import { getFileExtension, requireFileExtension, splitFileExtension } from "shelving/util/file";
 
 test("getOptionalFileExtension()", () => {
 	expect(getFileExtension("abc.jpg")).toBe("jpg");

--- a/modules/util/format.test.ts
+++ b/modules/util/format.test.ts
@@ -1,17 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	DAY,
-	formatAgo,
-	formatDuration,
-	formatNumber,
-	formatPercent,
-	formatUnit,
-	formatUntil,
-	formatValue,
-	formatWhen,
-	HOUR,
-	YEAR,
-} from "../index.js";
+import { DAY, HOUR, YEAR } from "shelving/util/constants";
+import { formatAgo, formatDuration, formatUntil, formatWhen } from "shelving/util/duration";
+import { formatNumber, formatPercent, formatUnit, formatValue } from "shelving/util/format";
 
 describe("formatNumber()", () => {
 	test("Works correctly", () => {

--- a/modules/util/geo.test.ts
+++ b/modules/util/geo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { COUNTRIES, getCountry } from "../index.js";
+import { COUNTRIES, getCountry } from "shelving/util/geo";
 
 describe("getCountry()", () => {
 	test("Returns explicit country codes", () => {

--- a/modules/util/http.test.ts
+++ b/modules/util/http.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { RequestError } from "shelving/error";
 import {
 	createFormDataRequest,
 	createJSONRequest,
@@ -11,8 +12,7 @@ import {
 	parseResponseBody,
 	parseResponseFormData,
 	parseResponseJSON,
-	RequestError,
-} from "../index.js";
+} from "shelving/util/http";
 
 function mockRequest(body: string | null, contentType?: string, method = "POST"): Request {
 	return new Request("http://x.com/", {

--- a/modules/util/hydrate.test.ts
+++ b/modules/util/hydrate.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import type { Data } from "../index.js";
-import { dehydrate, hydrate } from "../index.js";
+import type { Data } from "shelving/util/data";
+import { dehydrate, hydrate } from "shelving/util/hydrate";
 
 class Message {
 	readonly message: string;

--- a/modules/util/iterate.test.ts
+++ b/modules/util/iterate.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { countItems, getChunks, getRange, interleaveItems, limitItems, mergeItems, reduceItems, requireArray } from "../index.js";
+import { requireArray } from "shelving/util/array";
+import { countItems, getChunks, getRange, interleaveItems, limitItems, mergeItems, reduceItems } from "shelving/util/iterate";
 
 test("getRange()", () => {
 	expect(requireArray(getRange(1, 4))).toEqual([1, 2, 3, 4]);

--- a/modules/util/jwt.test.ts
+++ b/modules/util/jwt.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	DAY,
-	encodeToken,
-	getRequestToken,
-	requireRequestToken,
-	setRequestToken,
-	UnauthorizedError,
-	ValueError,
-	verifyRequestToken,
-	verifyToken,
-} from "../index.js";
+import { UnauthorizedError, ValueError } from "shelving/error";
+import { DAY } from "shelving/util/constants";
+import { encodeToken, getRequestToken, requireRequestToken, setRequestToken, verifyRequestToken, verifyToken } from "shelving/util/jwt";
 
 const TOKEN_SECRET = "mytokensecretmytokensecretmytokensecretmytokensecretmytokensecretmytokensecret";
 const TOKEN_ISSUER = "mytokenissuer";

--- a/modules/util/link.test.ts
+++ b/modules/util/link.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { getLink, type ImmutableURI, RequiredError, requireLink, requireURL } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { getLink, requireLink } from "shelving/util/link";
+import type { ImmutableURI } from "shelving/util/uri";
+import { requireURL } from "shelving/util/url";
 
 const ROOT = requireURL("https://x.com/app/");
 const ROOT_NO_SLASH = requireURL("https://x.com/app");

--- a/modules/util/merge.test.ts
+++ b/modules/util/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { ImmutableArray } from "../index.js";
-import { deepMerge, mergeArray, mergeObject, shallowMerge } from "../index.js";
+import type { ImmutableArray } from "shelving/util/array";
+import { deepMerge, mergeArray, mergeObject, shallowMerge } from "shelving/util/merge";
 
 const arrFlat = [1, "b", true, false, null];
 const arrFlatSame = [1, "b", true, false, null];

--- a/modules/util/number.test.ts
+++ b/modules/util/number.test.ts
@@ -1,16 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	boundNumber,
-	getNumber,
-	getPercent,
-	getRange,
-	roundNumber,
-	roundStep,
-	sumNumbers,
-	truncateNumber,
-	ValueError,
-	wrapNumber,
-} from "../index.js";
+import { ValueError } from "shelving/error";
+import { getRange } from "shelving/util/iterate";
+import { boundNumber, getNumber, getPercent, roundNumber, roundStep, sumNumbers, truncateNumber, wrapNumber } from "shelving/util/number";
 
 test("roundNumber(): Works correctly", () => {
 	expect(roundNumber(123.456, 0)).toBe(123);

--- a/modules/util/object.test.ts
+++ b/modules/util/object.test.ts
@@ -1,16 +1,13 @@
 import { expect, test } from "bun:test";
-import type { ImmutableDictionary, MutableDictionary } from "../index.js";
 import {
 	deleteDictionaryItems,
-	getProp,
-	isObject,
-	omitProps,
-	pickProps,
+	type ImmutableDictionary,
+	type MutableDictionary,
 	setDictionaryItem,
 	setDictionaryItems,
 	withDictionaryItem,
-	withProps,
-} from "../index.js";
+} from "shelving/util/dictionary";
+import { getProp, isObject, omitProps, pickProps, withProps } from "shelving/util/object";
 
 const maplikeObj: ImmutableDictionary<number> = { a: 1, b: 2, c: 3, d: 4 };
 

--- a/modules/util/path.test.ts
+++ b/modules/util/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getPath, isAbsolutePath, isPathProud, matchPathPrefix } from "../index.js";
+import { getPath, isAbsolutePath, isPathProud, matchPathPrefix } from "shelving/util/path";
 
 test("isAbsolutePath()", () => {
 	// Absolute.

--- a/modules/util/query.test.ts
+++ b/modules/util/query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { ImmutableArray } from "../index.js";
-import { filterQueryItems, getIdentifiers, getQueryFilters, getQueryOrders, matchQueryItem, queryItems, sortQueryItems } from "../index.js";
+import type { ImmutableArray } from "shelving/util/array";
+import { getIdentifiers } from "shelving/util/item";
+import { filterQueryItems, getQueryFilters, getQueryOrders, matchQueryItem, queryItems, sortQueryItems } from "shelving/util/query";
 import type { BasicData } from "../test/index.js";
 import { basic1, basic2, basics, expectUnorderedItems } from "../test/index.js";
 import { expectOrderedItems } from "../test/util.js";

--- a/modules/util/random.test.ts
+++ b/modules/util/random.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { getRandom, getRandomCharacter, getRandomItem, getRandomKey } from "../index.js";
+import { getRandom, getRandomCharacter, getRandomItem, getRandomKey } from "shelving/util/random";
 
 test("getRandomCharacter()", () => {
 	expect(typeof getRandomCharacter("abc")).toBe("string");

--- a/modules/util/regexp.test.ts
+++ b/modules/util/regexp.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
+import { filterArray } from "shelving/util/filter";
 import {
 	createRegExpAll,
 	createRegExpAny,
-	filterArray,
 	getMatch,
 	getMatchGroups,
 	isMatch,
 	notMatch,
 	requireMatch,
 	requireMatchGroups,
-} from "../index.js";
+} from "shelving/util/regexp";
 
 test("getAllRegExp()", () => {
 	// No pattern (always true).

--- a/modules/util/sequence.test.ts
+++ b/modules/util/sequence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { MutableArray } from "../index.js";
-import { createDeferred, mergeSequences, repeatDelay, repeatUntil, runSequence } from "../index.js";
+import type { MutableArray } from "shelving/util/array";
+import { createDeferred } from "shelving/util/async";
+import { mergeSequences, repeatDelay, repeatUntil, runSequence } from "shelving/util/sequence";
 
 const DELAY = 50;
 

--- a/modules/util/serialise.test.ts
+++ b/modules/util/serialise.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { serialise } from "../index.js";
+import { serialise } from "shelving/util/serialise";
 
 describe("serialise()", () => {
 	test("Works correctly", () => {

--- a/modules/util/sort.test.ts
+++ b/modules/util/sort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { compareAscending, compareDescending, sortArray } from "../index.js";
+import { compareAscending, compareDescending, sortArray } from "shelving/util/sort";
 
 describe("ASC & DESC", () => {
 	test("Different types are sorted correctly", () => {

--- a/modules/util/string.test.ts
+++ b/modules/util/string.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { RequiredError, ValueError } from "shelving/error";
+import { NBSP, NNBSP, THINSP } from "shelving/util/constants";
 import {
 	assertStringLength,
 	getWords,
 	isStringBetween,
-	NBSP,
-	NNBSP,
-	RequiredError,
 	requireSlug,
 	requireStringLength,
 	sanitizeMultilineText,
@@ -13,9 +12,7 @@ import {
 	sanitizeWord,
 	simplifyString,
 	splitString,
-	THINSP,
-	ValueError,
-} from "../index.js";
+} from "shelving/util/string";
 
 test("assertStringLength()", () => {
 	// Assert string.

--- a/modules/util/template.test.ts
+++ b/modules/util/template.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { RequiredError, ValueError } from "shelving/error";
 import {
 	getPlaceholders,
 	matchPathTemplate,
 	matchPathTemplates,
 	matchTemplate,
 	matchTemplates,
-	RequiredError,
 	renderPathTemplate,
 	renderTemplate,
 	type TemplateMatches,
-	ValueError,
-} from "../index.js";
+} from "shelving/util/template";
 
 // Tests.
 describe("matchTemplate()", () => {

--- a/modules/util/transform.test.ts
+++ b/modules/util/transform.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { getUndefined, mapArray, mapProps, transformObject } from "../index.js";
+import { mapArray, mapProps, transformObject } from "shelving/util/transform";
+import { getUndefined } from "shelving/util/undefined";
 
 test("mapArray()", () => {
 	const arr = [1, 2, 3, 4];

--- a/modules/util/tree.test.ts
+++ b/modules/util/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { DocumentationElement, TreeElement } from "../index.js";
-import { flattenTree, searchTree, walkElements } from "../index.js";
+import { walkElements } from "shelving/util/element";
+import { type DocumentationElement, flattenTree, searchTree, type TreeElement } from "shelving/util/tree";
 
 /** First child of a tree element (children are an `Elements` iterable, not necessarily an array). */
 function firstChild(element: TreeElement | undefined): TreeElement | undefined {

--- a/modules/util/units.test.ts
+++ b/modules/util/units.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import {
-	ANGLE_UNITS,
-	AREA_UNITS,
-	DURATION_UNITS,
-	LENGTH_UNITS,
-	MASS_UNITS,
-	SPEED_UNITS,
-	TEMPERATURE_UNITS,
-	VOLUME_UNITS,
-} from "../index.js";
+import { DURATION_UNITS } from "shelving/util/duration";
+import { ANGLE_UNITS, AREA_UNITS, LENGTH_UNITS, MASS_UNITS, SPEED_UNITS, TEMPERATURE_UNITS, VOLUME_UNITS } from "shelving/util/units";
 
 describe("to()", () => {
 	test("to() works correctly with base", () => {

--- a/modules/util/update.test.ts
+++ b/modules/util/update.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
-import type { ImmutableArray, ImmutableDictionary, Updates } from "./index.js";
-import { getUpdates, updateData } from "./index.js";
+import type { ImmutableArray } from "shelving/util/array";
+import type { ImmutableDictionary } from "shelving/util/dictionary";
+import { getUpdates, type Updates, updateData } from "shelving/util/update";
 
 type T = {
 	a: {

--- a/modules/util/uri.test.ts
+++ b/modules/util/uri.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	getURIParam,
-	getURIParams,
-	ImmutableURL,
-	omitURIParam,
-	omitURIParams,
-	RequiredError,
-	requireURIParam,
-	withURIParam,
-	withURIParams,
-} from "../index.js";
+import { RequiredError } from "shelving/error";
+import { getURIParam, getURIParams, omitURIParam, omitURIParams, requireURIParam, withURIParam, withURIParams } from "shelving/util/uri";
+import { ImmutableURL } from "shelving/util/url";
 
 describe("getURIParams()", () => {
 	test("returns params from URL", () => {

--- a/modules/util/url.test.ts
+++ b/modules/util/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getBasedURI, getURL, isURL, isURLActive, isURLProud, matchURLPrefix, requireURL } from "../index.js";
+import { getBasedURI, getURL, isURL, isURLActive, isURLProud, matchURLPrefix, requireURL } from "shelving/util/url";
 
 describe("isURL()", () => {
 	test("returns true for URL instance", () => {

--- a/modules/util/uuid.test.ts
+++ b/modules/util/uuid.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { getUUID, RequiredError, randomUUID, requireUUID } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { getUUID, randomUUID, requireUUID } from "shelving/util/uuid";
 
 // filepath: /Users/dhoulb/Repos/shelving/modules/util/uuid.test.ts
 

--- a/modules/util/validate.test.ts
+++ b/modules/util/validate.test.ts
@@ -1,16 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	NUMBER,
-	OPTIONAL,
-	RequiredError,
-	requireValid,
-	STRING,
-	StringSchema,
-	validateArray,
-	validateData,
-	validateDictionary,
-	validateItems,
-} from "../index.js";
+import { RequiredError } from "shelving/error";
+import { NUMBER, OPTIONAL, STRING, StringSchema } from "shelving/schema";
+import { requireValid, validateArray, validateData, validateDictionary, validateItems } from "shelving/util/validate";
 
 const VALIDATORS = {
 	str: STRING,

--- a/modules/util/xml.test.ts
+++ b/modules/util/xml.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { escapeXML, getXML, RequiredError } from "../index.js";
+import { RequiredError } from "shelving/error";
+import { escapeXML, getXML } from "shelving/util/xml";
 
 describe("escapeXML()", () => {
 	test("escapes special XML characters", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
 		"noUncheckedIndexedAccess": true,
 		"skipLibCheck": true,
 		"target": "esnext",
-		"verbatimModuleSyntax": true
+		"verbatimModuleSyntax": true,
+		"paths": {
+			"shelving": ["./modules/index.ts"],
+			"shelving/util/*": ["./modules/util/*.ts"],
+			"shelving/*": ["./modules/*/index.ts"]
+		}
 	},
 	"include": ["./modules/**/*", "./docs/**/*", "./**/*.json"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Closes #229.

## What

Audits and rewrites **every colocated test file (131 files)** so it imports public tokens from the top-level `shelving/*` barrel instead of a relative source path (`../foo.js`). This makes each test also validate that the barrel actually re-exports the tokens it uses — which is the whole point of the convention in `AGENTS.md` that had drifted (93% of tests still imported relatively).

## How the rewrite routes each token

The rewrite is token-aware, not a blind find-replace:

- Every imported **name** is resolved to the package subpath that *owns* it by transitively walking each barrel's exports — `shelving/schema`, `shelving/db`, `shelving/util/<file>` (util is wildcard-exported per file), `shelving/markup`, `shelving/ui`, `shelving/firestore/<client|lite|server>`, etc.
- A single relative import that pulls tokens from several modules is **split across the correct barrels** (e.g. a `db` test importing a schema token and a util type now imports from `shelving/db`, `shelving/schema`, and `shelving/util/data` separately).
- **Internal module utilities** are distinguished from the top-level `util/` module — `modules/ui/util/*` / `modules/markup/util/*` tokens route to `shelving/ui` / `shelving/markup`, while `modules/util/*` tokens route to `shelving/util/<file>`.
- `import type` and inline `type` markers are **preserved**; aliases (`Errors as ShelvingAggregateError`) are preserved; three dynamic `await import("../x.js")` calls in tests were converted too.
- Fixtures under `modules/test` **stay relative** — they're test helpers, not public surface.

## Resolution wiring

`shelving/*` did not resolve to source in dev before this change (no test used it). Added `tsconfig.json` `paths` so both `tsgo` (typecheck) and Bun (`bun test`) resolve `shelving/*` → `modules/*`. `paths` don't affect emit, so the built `dist` tests keep the `shelving/*` specifiers and self-resolve them via the copied `package.json` `exports` at runtime.

## Enforcement

A Biome `noRestrictedImports` override on `**/*.test.ts` / `**/*.test.tsx` rejects relative source imports in test files going forward (fixtures under `modules/test` are exempt via a gitignore-style negation). This is the tightest fit since Biome is already in the toolchain.

## Files

- 131 `*.test.ts` / `*.test.tsx` across every module (util 47, schema 24, markup 12, api 11, ui 9, db 8, store 7, extract 7, sequence 3, error 2, cloudflare 1)
- `biome.json` — the enforcement rule
- `tsconfig.json` — `shelving/*` → source `paths`
- `AGENTS.md` — tightened wording (the old `shelving/util` example was inaccurate; util is wildcard-exported per file)

## Verification

- `bun run test:type` — passes (no barrel-export gaps surfaced; every routed token is genuinely re-exported)
- `bun run test:unit` — **1189 pass / 0 fail** across 131 files
- `bun run test:lint` — clean (enforcement rule confirmed to fire on a relative import and to exempt `modules/test` fixtures)
- `bun run build` — full build + `dist` test run (**1034 pass / 0 fail**) confirms `dist` self-resolution still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpgZeGqpjZXsMYFUVQtRkY)_