### PR TITLE
ci: make docs preview teardown resilient to push races

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -106,14 +106,31 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -d "pr-${PR_NUMBER}" ]; then
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # The `docs` branch has many concurrent writers (every PR preview and every `main` deploy),
+          # so a plain `git push` races and fails non-fast-forward — which is exactly how stale `pr-*`
+          # previews pile up: the removal commit is built but never lands. Re-sync to the latest `docs`
+          # tip and retry the removal until the push succeeds (or the preview is already gone).
+          for attempt in 1 2 3 4 5; do
+            git fetch --quiet origin docs
+            git reset --hard --quiet FETCH_HEAD
+            if [ ! -d "pr-${PR_NUMBER}" ]; then
+              echo "Preview pr-${PR_NUMBER} already removed; nothing to do."
+              exit 0
+            fi
             rm -rf "pr-${PR_NUMBER}"
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore: remove docs preview for PR #${PR_NUMBER}"
-            git push
-          fi
+            git commit --quiet -m "chore: remove docs preview for PR #${PR_NUMBER}"
+            if git push origin HEAD:docs; then
+              echo "Removed pr-${PR_NUMBER} preview (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push raced with another deploy on attempt ${attempt}; re-syncing and retrying."
+            sleep $((attempt * 3))
+          done
+          echo "::error::Failed to remove pr-${PR_NUMBER} preview after 5 attempts."
+          exit 1
       # GitHub never deletes deployment records on its own, so the `docs-preview` deployments this
       # PR created would linger forever pointing at a now-removed preview. Mark them inactive (you
       # can't delete an active deployment) then delete them.


### PR DESCRIPTION
## Problem

The `docs` branch is written by many concurrent jobs — every PR preview deploy and every `main` deploy pushes to it. The **teardown** step (run when a PR closes) removed the PR's `pr-<n>/` directory with a bare `git push`, with no rebase or retry. When that push collided with a concurrent deploy it failed **non-fast-forward** and silently left the preview behind.

Over time these orphaned previews accumulated — **27** had built up (for PRs #91–#228, all long closed). Each is a full copy of the docs site, so the published site grew large enough that GitHub's managed *pages build and deployment* started failing at `syncing_files` ("Deployment failed, try again later"). That blocked **all** new deploys, including the root site — which is why [PR #231's preview](https://shelving.cc/pr-231/) 404'd.

(The 27 stale directories have already been pruned from the `docs` branch directly; this PR fixes the recurring cause.)

## Fix

Wrap the teardown removal in a **re-sync-and-retry loop**. On each attempt it fetches the latest `docs` tip, re-applies the directory removal on top, and pushes — retrying up to five times with backoff when the push races. It's also idempotent (exits cleanly if the preview is already gone) and now **fails loudly** after five tries instead of silently leaving a stale preview.

```yaml
for attempt in 1 2 3 4 5; do
  git fetch --quiet origin docs
  git reset --hard --quiet FETCH_HEAD
  if [ ! -d "pr-${PR_NUMBER}" ]; then exit 0; fi
  rm -rf "pr-${PR_NUMBER}"
  git add -A
  git commit --quiet -m "chore: remove docs preview for PR #${PR_NUMBER}"
  if git push origin HEAD:docs; then exit 0; fi
  sleep $((attempt * 3))
done
```

The deploy jobs are unchanged — `peaceiris/actions-gh-pages` already retries internally, which is why deploys survived the same race while teardown didn't.

## Verification

`docs.yaml` parses as valid YAML. Behaviour will be confirmed the next time a PR closes (the teardown should land its push even under contention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwDRPumwzeA9TKBsMX7UNE)_