### PR TITLE
chore: type-check and build with classic tsc instead of tsgo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,11 +11,10 @@
         "@types/bun": "^1.3.14",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@typescript/native-preview": "^7.0.0-dev.20260627.2",
         "firebase": "^12.15.0",
         "react": "^19.3.0-canary-fef12a01-20260413",
         "react-dom": "^19.3.0-canary-fef12a01-20260413",
-        "typescript": "^5.9.3",
+        "typescript": "6.0.3",
       },
       "peerDependencies": {
         "@google-cloud/firestore": ">=7.0.0",
@@ -178,22 +177,6 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
-
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260627.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260627.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260627.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260627.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260627.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260627.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260627.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260627.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-kJlusQpaCY5IxejXa5jcVUXu6IfLtIuK2+CWKvaFD3lqNhvt4OR3+1KOxAleaxHdvEc4fWMr0mrF7MIAmDXoAg=="],
-
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260627.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-om8UapcrjCyQ7Vsn0eb6kEB/scwo2/Np95cOyCiIIjUWObsDKL/DSpkYX3Z1cxo1L8WY48UM5edR2bzzarBxBg=="],
-
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260627.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-40IOEo0tMS8lNLK/iVhjPcZsgXY7Erijqe5b2HLN9eufoPaGFUfNpFQ8JYHI/xgEF6/JdgGAQp6j4s8E8oamew=="],
-
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260627.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1wIpqbi6Y8plCc4dH1Qw12fBu5Uk1qAdEC1fnpybkztXG90ErTG8XeccQ/SeCAl2X65PnhUU+rvzNVwqfvGyGg=="],
-
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260627.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-66G5zoTYUi358zkza1kAoUgAXs4Ek0eA69TyPDU350fH6wgepeEkCuD5kel4iTPuIbJE40WZABcbBsQJsRCbJQ=="],
-
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260627.2", "", { "os": "linux", "cpu": "x64" }, "sha512-0v1xRUgREzDAaNjaKtHuX5jEHVmY/MC5YR/rvSTNSYbqtg3vnUvafimRpyInXwMq399a9K6SwW2omIOfYeNJmQ=="],
-
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260627.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kXsG81vUZxV4gjKfJP/Nx3mJISG9ijzQmXamDbDgPzndzpmD0g+RyzEF+s6RH5AzFAc3nuGcg3LQWY2QThl67w=="],
-
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260627.2", "", { "os": "win32", "cpu": "x64" }, "sha512-+V3qtCz+L1d6xN1mFFHohzDnpHlPCLlOfZS11FE7Kjz/qfMViBjQwCAAtTlBT+GfZKj41nsQ5ybRqo2DVC1sMg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -365,7 +348,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
 		"@types/bun": "^1.3.14",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"@typescript/native-preview": "^7.0.0-dev.20260627.2",
 		"firebase": "^12.15.0",
 		"react": "^19.3.0-canary-fef12a01-20260413",
 		"react-dom": "^19.3.0-canary-fef12a01-20260413",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"peerDependencies": {
 		"@google-cloud/firestore": ">=7.0.0",
@@ -67,7 +66,7 @@
 	"scripts": {
 		"test": "bun run --parallel test:*",
 		"test:lint": "biome check .",
-		"test:type": "tsgo --noEmit",
+		"test:type": "tsc --noEmit",
 		"test:unit": "bun test ./modules --concurrent --only-failures",
 		"fix": "bun run --sequential fix:*",
 		"fix:0:lint": "biome check --write .",
@@ -76,7 +75,7 @@
 		"build": "bun run --sequential build:*",
 		"build:0:setup": "rm -rf ./dist && mkdir -p ./dist",
 		"build:1:copy": "cp package.json dist/package.json && cp LICENSE.md dist/LICENSE.md && cp README.md dist/README.md && cp .npmignore dist/.npmignore && cp -r modules/ui dist/ui",
-		"build:2:emit": "tsgo -p tsconfig.build.json",
+		"build:2:emit": "tsc -p tsconfig.build.json",
 		"build:3:syntax": "bun run ./dist/index.js",
 		"build:4:unit": "bun test ./dist/**/*.test.js --concurrent --only-failures --bail"
 	},

--- a/shelving.code-workspace
+++ b/shelving.code-workspace
@@ -5,6 +5,6 @@
 		}
 	],
 	"settings": {
-		"typescript.native-preview.tsdk": "/Users/dhoulb/Repos/shelving/node_modules/@typescript/native-preview"
+		"typescript.tsdk": "node_modules/typescript/lib"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"noImplicitOverride": true,
 		"noUncheckedIndexedAccess": true,
 		"skipLibCheck": true,
+		"strict": true,
 		"target": "esnext",
 		"verbatimModuleSyntax": true,
 		"paths": {


### PR DESCRIPTION
## What

Replaces the `@typescript/native-preview` (`tsgo`) compiler with the classic `tsc` from the `typescript` package for both type-checking (`test:type`) and declaration emit (`build:2:emit`).

## Why

We looked at adopting `typescript@rc` (`7.0.1-rc`, the native compiler graduating to the canonical package name) and dropping the dual-package setup. It doesn't work as a drop-in: the RC exposes only the `./unstable/*` API and has **no classic default export**, so it can't stand in for the `typescript` package that [`modules/extract/TypescriptExtractor.ts`](modules/extract/TypescriptExtractor.ts) imports (`import ts from "typescript"`) to build the docs site. Since we must keep a classic `typescript` for that compiler API anyway, the simplest setup is to use that same package's `tsc` for the CLI too — one TypeScript dependency instead of two.

## Changes

- **Remove `@typescript/native-preview`**; `test:type` and `build:2:emit` now call `tsc`.
- **Bump `typescript` `5.9.3` → `6.0.3`.** `tsgo` shipped a newer `lib.d.ts` than 5.9; the code relies on types 5.9 lacks (`Intl.DurationFormat`, iterable `FileList`/`Headers`). 6.0's lib includes them — 5.9.3 produced 23 lib-mismatch errors, 6.0.3 produces none.
- **Add `"strict": true` to `tsconfig.json`.** Classic `tsc` rejects `exactOptionalPropertyTypes` without `strictNullChecks` (`TS5052`); `tsgo` accepted it silently. This matches the "strict mode" AGENTS.md already documents, and the code passes full strict with **zero** errors (no null-safety fixes needed — `tsgo` was effectively running strict).
- Point the VS Code workspace `typescript.tsdk` at `node_modules/typescript/lib`.

## Verification

- `bun run test:type` — 0 errors
- `bun run build` — emit + syntax check + **1034** dist tests pass
- `bun test modules/extract` — **108** pass (extractor on the 6.0.3 compiler API)
- `bun run docs:build` — **1895** pages rendered end-to-end
- `bun run test` — lint clean, type clean, **1190** unit tests pass

## Note for reviewer

This trades `tsgo`'s speed for a single, stable, non-preview toolchain. If keeping the native compiler's speed matters more, the alternative is to stay on `@typescript/native-preview` (bumped to its latest nightly) alongside the classic `typescript` — happy to go that way instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)