### PR TITLE
fix: cap PBKDF2 iteration count in verifyPassword/hashPassword

### DIFF
--- a/modules/util/crypto.ts
+++ b/modules/util/crypto.ts
@@ -5,6 +5,7 @@ import { type Bytes, requireBytes } from "./bytes.js";
 // Constants.
 const ALGORITHM = { name: "PBKDF2", hash: "SHA-512" };
 const ITERATIONS = 500000;
+const MAX_ITERATIONS = 10000000; // Upper bound on iterations accepted from a stored hash — guards against a malicious hash forcing an arbitrarily expensive derivation (DoS). Comfortably above the 500k default.
 const SALT_LENGTH = 16; // 16 bytes = 128 bits
 const HASH_LENGTH = 64; // 64 bytes = 512 bits
 const PASSWORD_LENGTH = 6;
@@ -46,7 +47,8 @@ export async function hashPassword(password: string, iterations = ITERATIONS): P
 			received: password.length,
 			caller: hashPassword,
 		});
-	if (iterations < 1) throw new ValueError("Iterations must be number greater than 0", { received: iterations, caller: hashPassword });
+	if (iterations < 1 || iterations > MAX_ITERATIONS)
+		throw new ValueError(`Iterations must be between 1 and ${MAX_ITERATIONS}`, { received: iterations, caller: hashPassword });
 
 	// Hash the password.
 	const key = await _getKey(password);
@@ -76,7 +78,7 @@ export async function verifyPassword(password: string, hash: string): Promise<bo
 
 	// Check iterations.
 	const iterations = Number.parseInt(i, 10);
-	if (!Number.isFinite(iterations) || iterations < 1) return false;
+	if (!Number.isFinite(iterations) || iterations < 1 || iterations > MAX_ITERATIONS) return false;
 
 	// Derive the hash.
 	const key = await _getKey(password);


### PR DESCRIPTION
## Issue

`verifyPassword` (`modules/util/crypto.ts`) parses the PBKDF2 iteration count out of the stored `salt$iterations$hash` string and enforces only a **lower** bound (`≥ 1`), with no upper bound:

```ts
const iterations = Number.parseInt(i, 10);
if (!Number.isFinite(iterations) || iterations < 1) return false;   // no upper cap
…
await crypto.subtle.deriveBits({ ...ALGORITHM, salt, iterations }, key, bits);
```

If a hash string ever originates from an untrusted source, a value like `999999999999` forces an arbitrarily expensive key derivation — a CPU denial of service. The rest of the module is solid (PBKDF2-SHA512, 500k default iterations, random 16-byte salt, constant-time compare); this is purely about trusting the embedded iteration count.

Fixes #244.

## Fix

Add a `MAX_ITERATIONS` cap (`10_000_000`, comfortably above the 500k default) and enforce it in both entry points:

- `verifyPassword` — returns `false` for an out-of-range count (still never throws, per its contract).
- `hashPassword` — throws `ValueError` (matching its existing lower-bound behaviour).

## Testing

`bun test modules/util/crypto.test.ts` — 6 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQzwYXbcEjpqmjNeAxaE1P)_