### PR TITLE
fix(markup): harden parser against O(n²) backtracking and deep-nesting DoS

### DIFF
--- a/modules/markup/MarkupParser.ts
+++ b/modules/markup/MarkupParser.ts
@@ -50,6 +50,14 @@ export type MarkupOptions = {
 	 * Default context to use if one isn't set. Defaults to `"block"`
 	 */
 	readonly context?: string;
+
+	/**
+	 * Current nesting depth — used to cap self-recursive rules (e.g. blockquotes) so pathological input can't
+	 * overflow the stack. Internal: set automatically as rules recurse via `MarkupParser.nested()`; callers
+	 * normally leave it at the default `0`.
+	 * @default 0
+	 */
+	readonly depth?: number | undefined;
 };
 
 /**
@@ -106,7 +114,14 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	 */
 	readonly context: string;
 
-	constructor({ rules = MARKUP_RULES, rel, url, root, schemes = HTTP_SCHEMES, context = "block" }: MarkupOptions = {}) {
+	/**
+	 * Current nesting depth, incremented by `nested()` as self-recursive rules descend. Used to cap recursion so
+	 * pathological input (e.g. a long `>>>>…` blockquote) can't overflow the stack.
+	 * @see https://shelving.cc/markup/MarkupParser/depth
+	 */
+	readonly depth: number;
+
+	constructor({ rules = MARKUP_RULES, rel, url, root, schemes = HTTP_SCHEMES, context = "block", depth = 0 }: MarkupOptions = {}) {
 		this.rules = rules;
 		this.priorities = _getPriorities(rules);
 		this.rel = rel;
@@ -114,6 +129,27 @@ export class MarkupParser implements Parser<string, ReactNode> {
 		this.root = root;
 		this.schemes = schemes;
 		this.context = context;
+		this.depth = depth;
+	}
+
+	/**
+	 * Return a copy of this parser with `depth` incremented by one, sharing all other options.
+	 * - Self-recursive rules (e.g. blockquotes) parse their nested content through `nested()` so `depth` tracks how
+	 *   deep the recursion has gone, letting them stop before the call stack overflows.
+	 *
+	 * @returns A new `MarkupParser` identical to this one but one level deeper.
+	 * @see https://shelving.cc/markup/MarkupParser/nested
+	 */
+	nested(): MarkupParser {
+		return new MarkupParser({
+			rules: this.rules,
+			rel: this.rel,
+			url: this.url,
+			root: this.root,
+			schemes: this.schemes,
+			context: this.context,
+			depth: this.depth + 1,
+		});
 	}
 
 	/**

--- a/modules/markup/MarkupParser.ts
+++ b/modules/markup/MarkupParser.ts
@@ -119,6 +119,10 @@ export class MarkupParser implements Parser<string, ReactNode> {
 	/**
 	 * Parse a text string as Markdownish markup syntax and render it as a React node.
 	 * - Syntax is not defined by this code, but by the rules supplied to it.
+	 * - **Untrusted input:** parsing is linear for normal content, but a few rules can still degrade on adversarial
+	 *   input — long unbroken runs of backtick code fences, and deeply-nested `>` blockquotes (each leading `>`
+	 *   recurses one level, so a pathological line can overflow the stack). When `input` is user-generated, cap its
+	 *   length first; a sane maximum for your use case (for typical user content, tens of kilobytes) bounds worst-case work.
 	 *
 	 * @param input The string content possibly containing markup syntax, e.g. `"This is a *bold* string."`.
 	 * @param context The context to render in (defaults to this parser's `context`, i.e. `"block"` unless overridden).

--- a/modules/markup/README.md
+++ b/modules/markup/README.md
@@ -42,6 +42,18 @@ import { MARKUP_PARSER } from "shelving/markup";
 const node = MARKUP_PARSER.parse(content);
 ```
 
+### Input length (untrusted content)
+
+`parse()` is linear in the length of normal content, but a few rules can still degrade on deliberately adversarial input — notably long unbroken runs of backtick code fences, and deeply-nested `>` blockquotes (each leading `>` recurses one level, so a pathological line can overflow the stack).
+
+When the source comes from users, **cap its length before parsing**. A sane maximum for your use case — for typical user-generated content, tens of kilobytes — keeps worst-case work bounded:
+
+```ts
+const MAX_MARKUP_LENGTH = 100_000;
+if (source.length > MAX_MARKUP_LENGTH) throw new Error("Content too long");
+const node = MARKUP_PARSER.parse(source);
+```
+
 ### Options
 
 `MarkupParser` is constructed with `MarkupOptions`:

--- a/modules/markup/rule/blockquote.test.ts
+++ b/modules/markup/rule/blockquote.test.ts
@@ -66,3 +66,21 @@ test("BLOCKQUOTE_RULE", () => {
 		},
 	]);
 });
+
+// Recursively count `<blockquote>` elements in a rendered node tree.
+function countBlockquotes(node: unknown): number {
+	if (Array.isArray(node)) return node.reduce((sum: number, child) => sum + countBlockquotes(child), 0);
+	if (!node || typeof node !== "object") return 0;
+	const { type, props } = node as { type?: unknown; props?: { children?: unknown } };
+	return (type === "blockquote" ? 1 : 0) + countBlockquotes(props?.children);
+}
+
+test("BLOCKQUOTE_RULE caps nesting depth at 10 levels", () => {
+	// Shallow nesting is unaffected.
+	expect(countBlockquotes(PARSER.parse(`${">".repeat(3)} x`))).toBe(3);
+	// Deep nesting stops at exactly 10 levels instead of recursing once per `>`.
+	expect(countBlockquotes(PARSER.parse(`${">".repeat(10)} x`))).toBe(10);
+	expect(countBlockquotes(PARSER.parse(`${">".repeat(50)} x`))).toBe(10);
+	// Pathological input must not overflow the call stack.
+	expect(() => PARSER.parse(">".repeat(50000))).not.toThrow();
+});

--- a/modules/markup/rule/blockquote.tsx
+++ b/modules/markup/rule/blockquote.tsx
@@ -4,11 +4,15 @@ import { BLOCK_CONTENT_REGEXP, createBlockRegExp } from "../util/regexp.js";
 const PREFIX = ">";
 const INDENT = new RegExp(`^${PREFIX}`, "gm");
 
+/** Maximum blockquote nesting depth. Each `>` level recurses once, so an unbounded `>>>>…` line would overflow the stack; beyond this the remaining source is left as plain text. */
+const MAX_DEPTH = 10;
+
 /**
  * Blockquote block.
  * - `>` quote character followed by zero or more spaces.
  * - No spaces can appear before the `>` quote character.
  * - Quote block is only broken by `\n\n` two newline characters.
+ * - Nesting is capped at `MAX_DEPTH` (10) levels; deeper `>` prefixes are rendered as plain text rather than recursed, so pathological input can't overflow the stack.
  *
  * @example new MarkupParser({ rules: [BLOCKQUOTE_RULE] }).parse("> Quoted text")
  * @see https://shelving.cc/markup/BLOCKQUOTE_RULE
@@ -17,6 +21,12 @@ export const BLOCKQUOTE_RULE = createMarkupRule<{
 	quote: string;
 }>(
 	createBlockRegExp(`(?<quote>${PREFIX}${BLOCK_CONTENT_REGEXP})`),
-	(key, { quote }, parser) => <blockquote key={key}>{parser.parse(quote.replace(INDENT, ""), "block")}</blockquote>,
+	(key, { quote }, parser) => {
+		const inner = quote.replace(INDENT, "");
+		// This blockquote is level `depth + 1`; once it reaches the cap, render the (still `>`-prefixed) remainder as
+		// plain text instead of recursing, so nesting stops at exactly MAX_DEPTH levels and can't overflow the stack.
+		if (parser.depth + 1 >= MAX_DEPTH) return <blockquote key={key}>{inner}</blockquote>;
+		return <blockquote key={key}>{parser.nested().parse(inner, "block")}</blockquote>;
+	},
 	["block", "list"],
 );

--- a/modules/markup/rule/code.tsx
+++ b/modules/markup/rule/code.tsx
@@ -18,7 +18,8 @@ import { BLOCK_CONTENT_REGEXP } from "../util/regexp.js";
 export const CODE_RULE = createMarkupRule<{
 	code: string;
 }>(
-	getRegExp(`(?<fence>\`+)(?<code>${BLOCK_CONTENT_REGEXP})\\k<fence>`),
+	// Fence length is bounded (`{1,64}`) so a long run of backticks can't force O(n²) backtracking against the closing backreference.
+	getRegExp(`(?<fence>\`{1,64})(?<code>${BLOCK_CONTENT_REGEXP})\\k<fence>`),
 	(key, { code }) => <code key={key}>{code}</code>,
 	["inline", "list", "link"],
 	10,

--- a/modules/markup/rule/inline.tsx
+++ b/modules/markup/rule/inline.tsx
@@ -25,7 +25,9 @@ export const INLINE_RULE = createMarkupRule<{
 	text: string;
 }>(
 	createWordRegExp(
-		`(?<wrap>(?<char>[${Object.keys(INLINE_CHARS).join("")}])+)(?<text>(?!\\k<char>)\\S(?:[\\s\\S]*?(?!\\k<char>)\\S)?)\\k<wrap>`,
+		// Marker run is bounded (`{1,8}`) and the inner span is bounded (`{0,2000}?`) so a long run of
+		// unclosed markers can't force O(n²) backtracking — real emphasis never approaches these limits.
+		`(?<wrap>(?<char>[${Object.keys(INLINE_CHARS).join("")}]){1,8})(?<text>(?!\\k<char>)\\S(?:[\\s\\S]{0,2000}?(?!\\k<char>)\\S)?)\\k<wrap>`,
 	),
 	(key, { char, text }, parser) => {
 		const Inline = INLINE_CHARS[char];

--- a/modules/markup/rule/link.tsx
+++ b/modules/markup/rule/link.tsx
@@ -47,7 +47,8 @@ export const LINK_RULE = createMarkupRule<LinkData>(
  * @see https://shelving.cc/markup/AUTOLINK_RULE
  */
 export const AUTOLINK_RULE = createMarkupRule<LinkData>(
-	getRegExp(/(?<href>[a-z]{3,}?:\S+)(?: +(?:\((?<title>[^)\n]*?)\)))?/), //
+	// Scheme length is bounded (`{3,64}?`) so a long run of letters with no `:` can't force O(n²) backtracking.
+	getRegExp(/(?<href>[a-z]{3,64}?:\S+)(?: +(?:\((?<title>[^)\n]*?)\)))?/), //
 	_renderLink,
 	["inline", "list"],
 );

--- a/modules/markup/rule/separator.tsx
+++ b/modules/markup/rule/separator.tsx
@@ -12,7 +12,8 @@ import { createLineRegExp } from "../util/regexp.js";
  * @see https://shelving.cc/markup/SEPARATOR_RULE
  */
 export const SEPARATOR_RULE = createMarkupRule(
-	createLineRegExp("([-*•+_=])(?: *\\1){2,}"), //
+	// Inter-character whitespace is bounded (`{0,2000}`) so a long run of spaces can't force O(n²) backtracking.
+	createLineRegExp("([-*•+_=])(?: {0,2000}\\1){2,}"), //
 	key => <hr key={key} />,
 	["block"],
 );

--- a/modules/markup/rule/table.tsx
+++ b/modules/markup/rule/table.tsx
@@ -3,7 +3,7 @@ import { createMarkupRule } from "../MarkupRule.js";
 import { createBlockRegExp, LINE_SPACE_REGEXP } from "../util/regexp.js";
 
 // Constants.
-const _SPACE = `${LINE_SPACE_REGEXP}*`; // Run of line whitespace (never crosses a newline).
+const _SPACE = `${LINE_SPACE_REGEXP}{0,2000}`; // Run of line whitespace (never crosses a newline); bounded so a long whitespace line can't force O(n²) backtracking in the delimiter row.
 const _CELL = `${_SPACE}:?-+:?${_SPACE}`; // Delimiter-row cell: one or more dashes with optional `:` alignment markers.
 const _DELIMITER_SOURCE = `${_SPACE}\\|?(?:${_CELL}\\|)+(?:${_CELL})?${_SPACE}`; // Delimiter row: pipe-separated dash cells.
 const _DELIMITER = new RegExp(`^${_DELIMITER_SOURCE}$`, "u"); // Tests whether a single line is a delimiter row.

--- a/modules/markup/util/regexp.ts
+++ b/modules/markup/util/regexp.ts
@@ -17,13 +17,13 @@ export const BLOCK_SPACE_REGEXP = "\\s"; // Block whitespace (run of any whitesp
  * Regular expression source matching the start of a block — the start of the string, or one linebreak.
  * @see https://shelving.cc/markup/BLOCK_START_REGEXP
  */
-export const BLOCK_START_REGEXP = "(?:\\s*\\n|^)"; // Start of block (start of string, or one linebreak).
+export const BLOCK_START_REGEXP = "(?:\\s{0,2000}\\n|^)"; // Start of block (start of string, or one linebreak). Whitespace is bounded so a long whitespace run can't force O(n²) backtracking at every offset.
 
 /**
  * Regular expression source matching the end of a block — the end of the string, or two linebreaks, with trailing whitespace trimmed.
  * @see https://shelving.cc/markup/BLOCK_END_REGEXP
  */
-export const BLOCK_END_REGEXP = "\\s*(?:$|\\n\\s*\\n)"; // End of block (end of string, or two linebreaks, trimmed whitespace).
+export const BLOCK_END_REGEXP = "\\s{0,2000}(?:$|\\n\\s{0,2000}\\n)"; // End of block (end of string, or two linebreaks, trimmed whitespace). Whitespace runs bounded to avoid O(n²) backtracking.
 
 /**
  * Regular expression source matching line content — the shortest run of any character except newline.
@@ -47,7 +47,7 @@ export const LINE_START_REGEXP = BLOCK_START_REGEXP; // Start of line (start of 
  * Regular expression source matching the end of a line — the end of the string, or one linebreak, with trailing whitespace trimmed.
  * @see https://shelving.cc/markup/LINE_END_REGEXP
  */
-export const LINE_END_REGEXP = `${LINE_SPACE_REGEXP}*(?:\\s*\\n|$)`; // End of line (end of string, or one linebreak, trimmed whitespace).
+export const LINE_END_REGEXP = `${LINE_SPACE_REGEXP}{0,2000}(?:\\s{0,2000}\\n|$)`; // End of line (end of string, or one linebreak, trimmed whitespace). Whitespace runs bounded to avoid O(n²) backtracking.
 
 /**
  * Regular expression source matching word content — at least one letter or number character.

--- a/modules/ui/misc/Markup.md
+++ b/modules/ui/misc/Markup.md
@@ -7,6 +7,7 @@ Parses a markup string and renders the resulting React nodes inline. Defaults to
 - `url` and `root` default to the current `<Meta>` context, so link rules resolve site-absolute and relative hrefs correctly. Override any `MarkupOptions` prop (`rules`, `rel`, `url`, `root`, `schemes`) directly on `<Markup>` for a custom rule set or base URL.
 - Renders `null` when `children` is empty.
 - Wrap in `<Prose>` to give the produced `<p>` / `<ul>` / `<pre>` / etc. the standard prose typography.
+- When `children` comes from users, cap its length before rendering: parsing is linear for normal content, but a few rules can degrade on adversarial input (long backtick runs, deeply-nested `>` blockquotes). A sane maximum for your use case — tens of kilobytes for typical user content — keeps worst-case work bounded.
 
 ## Usage
 

--- a/modules/ui/misc/Markup.tsx
+++ b/modules/ui/misc/Markup.tsx
@@ -17,6 +17,7 @@ export interface MarkupProps extends Partial<MarkupOptions> {
  * - Defaults to `MARKUP_OPTIONS` (full block + inline rule set). Pass `rules`, `rel`, `url`, `root`, or `schemes` as props to override.
  * - `url`/`root` default to the current `<Meta>` context so link rules resolve site-absolute and relative hrefs.
  * - Renders inside whatever ancestor element the caller provides — wrap in `<Prose>` to get the standard prose typography for the produced `<p>` / `<ul>` / `<pre>` / etc.
+ * - **Untrusted input:** when `children` comes from users, cap its length before rendering — parsing is linear for normal content but a few rules can degrade on adversarial input (a sane maximum for your use case, typically tens of kilobytes, bounds worst-case work). See `MarkupParser.parse()`.
  *
  * @param children The source markup string to parse and render (renders `null` when empty).
  * @returns The parsed markup as React nodes, or `null` when `children` is empty.

--- a/modules/ui/tree/TreeMarkup.md
+++ b/modules/ui/tree/TreeMarkup.md
@@ -7,7 +7,7 @@ Renders a markup string just like `<Markup>`, but auto-links every inline code s
 - Defaults to `TREE_MARKUP_RULES` — the full default rule set with the inline-code rule swapped for `TREE_CODE_RULE`, which renders each span through `TreeLink`.
 - Resolution is exact-match against the tree map: a hit (`` `BooleanSchema` ``, `` `Store.get` ``) links; a miss (`` `bun run fix` ``, `` `string` ``) falls back to a plain code token, so unknown spans never produce a broken link.
 - Falls back to plain code spans outside a `<TreeProvider>`, so it's safe to use anywhere — it simply stops linking.
-- Inherits everything else from `<Markup>`: `url` / `root` default to the current `<Meta>` context, and any `MarkupOptions` prop (`rules`, `rel`, `url`, `root`, `schemes`) can be overridden directly.
+- Inherits everything else from `<Markup>`: `url` / `root` default to the current `<Meta>` context, and any `MarkupOptions` prop (`rules`, `rel`, `url`, `root`, `schemes`) can be overridden directly. That includes the input-length guidance — cap untrusted `children` length before rendering.
 - Wrap in `<Prose>` to give the produced `<p>` / `<ul>` / `<pre>` / etc. the standard prose typography.
 
 ## Usage

--- a/modules/ui/tree/TreeMarkup.tsx
+++ b/modules/ui/tree/TreeMarkup.tsx
@@ -30,6 +30,7 @@ export const TREE_MARKUP_RULES: MarkupRules = MARKUP_RULES.map(rule => (rule ===
  * - Like `<Markup>` but defaults to `TREE_MARKUP_RULES`, so each backtick span resolves through `TreeLink` against the surrounding `<TreeProvider>` — a known token links to its canonical page, an unknown one stays plain code.
  * - The standard way to render documentation-site content (READMEs, docblocks, per-symbol pages); plain `<Markup>` stays the choice for general user content that shouldn't cross-link.
  * - Falls back to plain code spans outside a `<TreeProvider>`, so it's safe to use anywhere. Pass any `MarkupOptions` prop (including `rules`) to override.
+ * - Inherits `<Markup>`'s input-length guidance: when `children` is untrusted, cap its length before rendering (see `MarkupParser.parse()`).
  *
  * @param children The source markup string to parse and render (renders `null` when empty).
  * @returns The parsed markup as React nodes, or `null` when `children` is empty.


### PR DESCRIPTION
## Issue

`MarkupParser` renders untrusted user content. Some parsing could degrade super-linearly on adversarial input (stalling the render/SSR thread), and blockquotes could recurse unboundedly and overflow the stack — a denial of service. Specific trigger inputs and measurements are intentionally omitted.

Closes #240.

## Fixes

1. **Bounded regex quantifiers** — several markup rules and the shared block/line boundaries now use bounded quantifiers, with limits far above any real content, so parsing stays linear on hostile input.
2. **Blockquote depth cap** — a `depth` counter on `MarkupParser` (via a new `nested()` helper) caps nesting at `MAX_DEPTH = 10`, consistent with the router's redirect-depth cap; beyond the cap the remainder renders as plain text.
3. **Docs** — recommend capping untrusted input length on the main render surface (`MarkupParser.parse`, markup README) and the markup components (`<Markup>`, `<TreeMarkup>`).

## Testing

All markup + UI tests pass, and `bun run test:type` is clean.

## Accepted limitation

One rule retains a minor residual parser-scan cost; reworking it would touch the deliberately hard-won parser core, so we're accepting it (mitigated by the input-length guidance). Can be revisited as a fresh issue if needed.