### PR TITLE
fix(api): percent-encode/decode path placeholder values (renderPathTemplate ↔ matchPathTemplate)

### DIFF
--- a/modules/ui/router/Router.tsx
+++ b/modules/ui/router/Router.tsx
@@ -2,7 +2,8 @@ import type { ReactElement } from "react";
 import { NotFoundError } from "../../error/RequestError.js";
 import { UnexpectedError } from "../../error/UnexpectedError.js";
 import { getProps } from "../../util/index.js";
-import { matchPathTemplate, renderPathTemplate } from "../../util/template.js";
+import type { AbsolutePath } from "../../util/path.js";
+import { matchPathTemplate, renderTemplate } from "../../util/template.js";
 import { MetaContext, type MetaURL, requireMetaURL } from "../misc/MetaContext.js";
 import type { PossibleMeta } from "../util/meta.js";
 import type { Routes } from "./Routes.js";
@@ -61,7 +62,8 @@ function _matchRoute(
 		// String value is a redirect; re-run matching with the new path. Guard against infinite redirect loops by limiting depth.
 		if (typeof Route === "string") {
 			if (depth > 10) throw new UnexpectedError("Infinite redirect loop", { received: route, expected: path, caller: _matchRoute });
-			return _matchRoute(routes, fallback, meta, renderPathTemplate(Route, placeholders), depth + 1);
+			// Redirect targets re-use raw matched params (which may already be percent-encoded), so render without re-encoding.
+			return _matchRoute(routes, fallback, meta, renderTemplate(Route, placeholders) as AbsolutePath, depth + 1);
 		}
 
 		// React element — render as-is.

--- a/modules/ui/router/Router.tsx
+++ b/modules/ui/router/Router.tsx
@@ -2,8 +2,7 @@ import type { ReactElement } from "react";
 import { NotFoundError } from "../../error/RequestError.js";
 import { UnexpectedError } from "../../error/UnexpectedError.js";
 import { getProps } from "../../util/index.js";
-import type { AbsolutePath } from "../../util/path.js";
-import { matchPathTemplate, renderTemplate } from "../../util/template.js";
+import { matchPathTemplate, renderPathTemplate } from "../../util/template.js";
 import { MetaContext, type MetaURL, requireMetaURL } from "../misc/MetaContext.js";
 import type { PossibleMeta } from "../util/meta.js";
 import type { Routes } from "./Routes.js";
@@ -62,8 +61,8 @@ function _matchRoute(
 		// String value is a redirect; re-run matching with the new path. Guard against infinite redirect loops by limiting depth.
 		if (typeof Route === "string") {
 			if (depth > 10) throw new UnexpectedError("Infinite redirect loop", { received: route, expected: path, caller: _matchRoute });
-			// Redirect targets re-use raw matched params (which may already be percent-encoded), so render without re-encoding.
-			return _matchRoute(routes, fallback, meta, renderTemplate(Route, placeholders) as AbsolutePath, depth + 1);
+			// `placeholders` are already decoded by `matchPathTemplate`, so re-encode them into the redirect path with `renderPathTemplate` — the symmetric partner of the match above.
+			return _matchRoute(routes, fallback, meta, renderPathTemplate(Route, placeholders), depth + 1);
 		}
 
 		// React element — render as-is.

--- a/modules/util/template.test.ts
+++ b/modules/util/template.test.ts
@@ -104,6 +104,16 @@ describe("matchPathTemplate()", () => {
 		expect(matchPathTemplate("/files/{...path}", "/files/")).toEqual({ path: "" });
 		expect(matchPathTemplate("/files/**", "/files")).toEqual({ "0": "" });
 	});
+	test("Percent-decodes matched values (inverse of renderPathTemplate)", () => {
+		expect(matchPathTemplate("/users/{id}", "/users/a%2Fb")).toEqual({ id: "a/b" });
+		expect(matchPathTemplate("/users/{id}", "/users/caf%C3%A9")).toEqual({ id: "café" });
+		// Catchall decodes each segment but keeps the `/` separators.
+		expect(matchPathTemplate("/files/{...path}", "/files/a%20b/c")).toEqual({ path: "a b/c" });
+	});
+	test("Rejects malformed percent-encoding as a non-match", () => {
+		expect<TemplateMatches | undefined>(matchPathTemplate("/users/{id}", "/users/%zz")).toBe(undefined);
+		expect<TemplateMatches | undefined>(matchPathTemplate("/users/{id}", "/users/%")).toBe(undefined);
+	});
 });
 
 describe("getPlaceholders()", () => {
@@ -176,9 +186,24 @@ describe("renderTemplate()", () => {
 });
 
 describe("renderPathTemplate()", () => {
-	test("Behaviour matches renderTemplate (paired sibling for matchPathTemplate)", () => {
+	test("Plain values render unchanged", () => {
 		expect(renderPathTemplate("/users/{id}", { id: "123" })).toBe("/users/123");
 		expect(renderPathTemplate("/files/{...path}", { path: "a/b/c" })).toBe("/files/a/b/c");
+	});
+	test("Percent-encodes values so they stay within their path segment", () => {
+		expect(renderPathTemplate("/users/{id}", { id: "a/b" })).toBe("/users/a%2Fb");
+		expect(renderPathTemplate("/users/{id}", { id: "x?a=1#f" })).toBe("/users/x%3Fa%3D1%23f");
+		expect(renderPathTemplate("/users/{id}", { id: "café" })).toBe("/users/caf%C3%A9");
+		// Catchall keeps `/` separators, encoding each segment independently.
+		expect(renderPathTemplate("/files/{...path}", { path: "a b/c" })).toBe("/files/a%20b/c");
+	});
+	test("Round-trips losslessly with matchPathTemplate", () => {
+		for (const value of ["Dave", "a/b", "x?a=1#f", "café münchen", "50%"]) {
+			const path = renderPathTemplate("/users/{id}", { id: value });
+			expect(matchPathTemplate("/users/{id}", path)).toEqual({ id: value });
+		}
+		const path = renderPathTemplate("/files/{...path}", { path: "a b/c/d.txt" });
+		expect(matchPathTemplate("/files/{...path}", path)).toEqual({ path: "a b/c/d.txt" });
 	});
 });
 

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -265,16 +265,47 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 }
 
 /**
- * Render a path-shaped template. Behaviourally identical to `renderTemplate()` — substitution doesn't need separator awareness — but provided as a sibling to `matchPathTemplate()` so callers can pair them.
+ * Render a path-shaped template, percent-encoding each substituted value so it stays within its path segment.
+ *
+ * Unlike `renderTemplate()`, each placeholder value is run through `encodeURIComponent()` before substitution.
+ * This stops a value that contains `/`, `?`, `#`, `%`, or control characters from escaping its segment and
+ * altering the resolved URL — i.e. path traversal to a different endpoint, or query/fragment injection — when
+ * the result is resolved against a base URL (e.g. by `ClientAPIProvider`). Catchall placeholders (`**`,
+ * `{...path}`, …) legitimately span segments, so each `/`-separated part is encoded but the separators are kept.
+ *
+ * Note: because `encodeURIComponent()` does not encode `.`, a value that is exactly `.` or `..` still renders as
+ * `.`/`..`; callers that treat a placeholder as a trusted single segment should validate against those.
  *
  * @param template The path-shaped template including placeholders, e.g. `/users/{name}`.
  * @param values An object containing values (functions are called, everything else converted to string), or a function or string to use for all placeholders.
  * @param caller Function to attribute a thrown error to (defaults to `renderPathTemplate` itself).
- * @returns The rendered path, e.g. `/users/Dave`.
+ * @returns The rendered path with each value percent-encoded, e.g. `/users/Dave`.
  * @throws {RequiredError} If a placeholder in the template string is not specified in values.
- * @example renderPathTemplate("/users/{name}", { name: "Dave" }) // "/users/Dave"
+ * @example renderPathTemplate("/users/{name}", { name: "a/b" }) // "/users/a%2Fb"
  * @see https://shelving.cc/util/template/renderPathTemplate
  */
 export function renderPathTemplate(template: AbsolutePath, values: TemplateValues, caller: AnyCaller = renderPathTemplate): AbsolutePath {
-	return renderTemplate(template, values, caller) as AbsolutePath;
+	const chunks = _splitTemplateCached(template, caller);
+	if (!chunks.length) return template;
+	let output: string = template;
+	for (const { name, placeholder, catchall } of chunks) {
+		const value = _getTemplateValue(values, name, caller);
+		const encoded = catchall ? value.split("/").map(encodeURIComponent).join("/") : encodeURIComponent(value);
+		// Use a replacer function so `$` sequences in the (already-encoded) value are never treated as special replacement patterns.
+		output = output.replace(placeholder, () => encoded);
+	}
+	return output as AbsolutePath;
+}
+
+/** Resolve the string value for a single template placeholder from `TemplateValues` (mirrors `renderTemplate()`'s per-name resolution). */
+function _getTemplateValue(values: TemplateValues, name: string, caller: AnyCaller): string {
+	const value = isFunction(values)
+		? values(name)
+		: isData(values)
+			? getString(getDataProp(values, name))
+			: isArray(values)
+				? getString(values[Number(name)])
+				: getString(values);
+	if (value === undefined) throw new RequiredError(`Template placeholder "${name}" not found`, { received: values, name, caller });
+	return value;
 }

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -129,18 +129,20 @@ function _getPlaceholder({ name }: TemplateChunk): string {
  * @see https://shelving.cc/util/template/matchTemplate
  */
 export function matchTemplate(template: string, target: string, caller: AnyCaller = matchTemplate): TemplateMatches | undefined {
-	return _matchTemplate(template, target, "", caller);
+	return _matchTemplate(template, target, "", false, caller);
 }
 
 /**
  * Match a path-shaped template against a target path.
  * - Like `matchTemplate()`, but with `/` segment semantics: non-catchall placeholders cannot span path segments; catchall placeholders can.
  * - A trailing catchall (e.g. `/files/{...path}`) also matches when the trailing separator is absent (e.g. `/files`), with the catchall value as `""`.
+ * - Matched values are **percent-decoded** (the inverse of `renderPathTemplate()`'s encoding), so a round trip is lossless: `matchPathTemplate(t, renderPathTemplate(t, values))` returns the original values. Catchall values keep their `/` separators (each segment is decoded).
+ * - Returns `undefined` if `target` is not validly percent-encoded (e.g. a bare `%` or `%zz`), treating a malformed path as a non-match.
  *
  * @param template The path-shaped template string, e.g. `/users/{name}`.
  * @param target The path containing values, e.g. `/users/Dave`.
  * @param caller Function to attribute a thrown error to (defaults to `matchPathTemplate` itself).
- * @returns An object containing values (e.g. `{ name: "Dave" }`), or `undefined` if no match.
+ * @returns An object containing decoded values (e.g. `{ name: "Dave" }`), or `undefined` if no match.
  * @throws {ValueError} If two template placeholders are not separated by at least one character.
  * @example matchPathTemplate("/users/{name}", "/users/Dave") // { name: "Dave" }
  * @see https://shelving.cc/util/template/matchPathTemplate
@@ -150,10 +152,29 @@ export function matchPathTemplate(
 	target: AbsolutePath,
 	caller: AnyCaller = matchPathTemplate,
 ): TemplateMatches | undefined {
-	return _matchTemplate(template, target, "/", caller);
+	return _matchTemplate(template, target, "/", true, caller);
 }
 
-function _matchTemplate(template: string, target: string, separator: string, caller: AnyCaller): TemplateMatches | undefined {
+/**
+ * Decode a matched path value — the inverse of `renderPathTemplate()`'s `encodeURIComponent`.
+ * - Catchall values keep their `/` separators (each segment is decoded independently, mirroring the per-segment encode).
+ * - Returns `undefined` for malformed percent-encoding (e.g. a bare `%` or `%zz`), so the caller can reject the whole match.
+ */
+function _decodePathValue(value: string, catchall: boolean): string | undefined {
+	try {
+		return catchall ? value.split("/").map(decodeURIComponent).join("/") : decodeURIComponent(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function _matchTemplate(
+	template: string,
+	target: string,
+	separator: string,
+	decode: boolean,
+	caller: AnyCaller,
+): TemplateMatches | undefined {
 	// Get separators and placeholders from template.
 	const chunks = _splitTemplateCached(template, caller);
 	const firstChunk = chunks[0];
@@ -187,7 +208,16 @@ function _matchTemplate(template: string, target: string, separator: string, cal
 			if (!value.length) return undefined; // Empty values only allowed for catchall placeholders.
 			if (separator && value.includes(separator)) return undefined; // Non-catchall placeholders can't span separators (when one is configured).
 		}
-		values[name] = value;
+		// In path mode, percent-decode the (still-encoded) value so it round-trips with `renderPathTemplate()`; a
+		// malformed encoding rejects the whole match. The separator check above runs on the encoded value first,
+		// so an encoded `%2F` can't smuggle a separator into a non-catchall segment.
+		if (decode) {
+			const decoded = _decodePathValue(value, catchall);
+			if (decoded === undefined) return undefined;
+			values[name] = decoded;
+		} else {
+			values[name] = value;
+		}
 		startIndex = stopIndex + post.length;
 	}
 	if (startIndex < target.length) return undefined; // Target doesn't match template because last chunk post didn't reach the end.


### PR DESCRIPTION
## Issue

Payload values substituted into endpoint paths were injected **raw** and then resolved into the request URL (`ClientAPIProvider.renderURL`), so a value containing `/`, `..`, `?`, or `#` could alter the request target — path traversal to a different endpoint, or query/fragment injection. `encodeURIComponent` appeared nowhere in the codebase.

Fixes #241.

## Fix — symmetric encode on render, decode on match

### 1. `renderPathTemplate` percent-encodes (outbound)

`renderTemplate` is left unchanged. `renderPathTemplate` now runs each substituted value through `encodeURIComponent()`:
- non-catchall placeholders → the whole value is encoded (so `/`, `?`, `#`, `%`, control chars can't escape the segment);
- catchall placeholders (`**`, `{...path}`) → each `/`-separated part is encoded, separators kept;
- substitution uses a replacer function, so `$` sequences in a value are never treated as special replacement patterns.

### 2. `matchPathTemplate` percent-decodes (inbound)

`renderPathTemplate` encoding without a matching decode would be a lopsided round trip: the server's `Endpoint.match` (via `matchPathTemplate`) returned raw, still-encoded params — so a handler received `id = "a%2Fb"` instead of `"a/b"`, and inconsistently with query params (which `URLSearchParams` already decodes). `matchPathTemplate` now percent-decodes each matched value (per-segment for catchall, mirroring the encode), so **`matchPathTemplate(t, renderPathTemplate(t, v))` round-trips losslessly**. Malformed encoding (`%zz`, bare `%`) is treated as a non-match (returns `undefined`) rather than throwing.

`matchTemplate` (the no-separator variant) stays **raw** — its partner `renderTemplate` is raw, and `MergingExtractor` matches non-URL doc-token keys with it.

| Render | Match |
|---|---|
| `renderTemplate` (raw) | `matchTemplate` (raw) |
| `renderPathTemplate` (encode) | `matchPathTemplate` (decode) |

### 3. Router

`renderPathTemplate` previously just delegated to `renderTemplate`. It's used by `Router` to expand redirect targets from matched params; now that `matchPathTemplate` decodes, `Router` re-uses `renderPathTemplate` (the symmetric encode partner) for those redirects — replacing the temporary `renderTemplate` cast from an earlier revision. Route params handed to components are now decoded too.

## Behaviour

```
renderPathTemplate("/users/{id}", { id: "../../admin" })     // "/users/..%2F..%2Fadmin"  (no traversal)
renderPathTemplate("/users/{id}", { id: "x?admin=1#f" })     // "/users/x%3Fadmin%3D1%23f"
matchPathTemplate("/users/{id}",  "/users/a%2Fb")            // { id: "a/b" }
matchPathTemplate("/users/{id}",  "/users/%zz")              // undefined (malformed → no match)
renderPathTemplate("/files/{...p}", { p: "a b/c" })          // "/files/a%20b/c"  (catchall keeps separators)
```

### Known limitation

`encodeURIComponent()` does not encode `.`, so a value that is exactly `.` or `..` still renders as `.`/`..`; callers treating a placeholder as a trusted single segment should validate against those. A literal un-encoded `%` in an inbound path (technically malformed) now fails to match instead of matching raw — reasonable for a URL-path matcher.

## Testing

`bun test modules/util/template.test.ts modules/api modules/ui/router` — 89 pass / 0 fail (added encoding, decoding, round-trip, and malformed-input tests). `bun run test:type` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)