### PR TITLE
fix(util): prevent prototype injection in validateDictionary

### DIFF
--- a/modules/util/validate.test.ts
+++ b/modules/util/validate.test.ts
@@ -133,4 +133,12 @@ describe("validateDictionary()", () => {
 			expect(err).toBe("b: Must be number");
 		}
 	});
+	test("a `__proto__` key does not pollute the prototype or the returned object", () => {
+		// JSON.parse creates an own `"__proto__"` data key (not a setter call), so this reaches the loop with a hostile key.
+		const dict: Record<string, unknown> = JSON.parse('{"__proto__": "5", "b": "1"}');
+		const out = validateDictionary(dict, NUMBER); // coercion → `changed`, so the accumulator is returned
+		expect(Object.getPrototypeOf(out)).toBe(null); // accumulator is null-prototype, not attacker-controlled
+		expect(Object.keys(out)).toEqual(["__proto__", "b"]); // `__proto__` stays an enumerable own entry (counts stay correct)
+		expect(({} as Record<string, unknown>).b).toBe(undefined); // Object.prototype untouched
+	});
 });

--- a/modules/util/validate.ts
+++ b/modules/util/validate.ts
@@ -163,7 +163,10 @@ export function validateArray<T>(unsafeArray: PossibleArray<unknown>, validator:
  */
 export function validateDictionary<T>(unsafeDictionary: PossibleDictionary<unknown>, validator: Validator<T>): ImmutableDictionary<T> {
 	let changed = false;
-	const safeDictionary: MutableDictionary<T> = {};
+	// Null-prototype accumulator: an untrusted `"__proto__"` key (or `"constructor"`) then becomes an inert own
+	// property instead of invoking the inherited `__proto__` setter, so a crafted `{ "__proto__": … }` input can't
+	// reassign the returned dictionary's prototype, and the entry stays enumerable so `min`/`max` counts are correct.
+	const safeDictionary: MutableDictionary<T> = { __proto__: null } as MutableDictionary<T>;
 	const messages: MutableArray<string> = [];
 	for (const [key, unsafeValue] of getDictionaryItems(unsafeDictionary)) {
 		try {


### PR DESCRIPTION
## Issue

`validateDictionary` (`modules/util/validate.ts`) built its result with a plain `{}` accumulator and assigned validated entries with an **untrusted key**:

```ts
const safeDictionary: MutableDictionary<T> = {};
for (const [key, unsafeValue] of getDictionaryItems(unsafeDictionary)) {
    const safeValue = validator.validate(unsafeValue);
    safeDictionary[key] = safeValue;   // key from untrusted input → __proto__ setter
```

`DictionarySchema.validate` is a public validator for external data and routes through this. A crafted `{ "__proto__": <object> }` (where the `items` schema yields an object) invoked the inherited `__proto__` setter and **reassigned the returned dictionary's prototype** — local prototype injection: the "validated" object then answers missing-key lookups with attacker-controlled values. Because `__proto__` was then non-enumerable, `Object.keys(dict).length` also undercounted, slipping past `DictionarySchema`'s `min`/`max` checks. (No global `Object.prototype` pollution — the impact is scoped to the returned object.)

Fixes #242.

## Fix

Accumulate into a **null-prototype** object — `{ __proto__: null }`, the same idiom the codebase already uses for `EMPTY_DICTIONARY`. On a null-prototype object there is no inherited `__proto__` setter, so a `__proto__` (or `constructor`) key becomes an inert **own** property:

- The returned dictionary's prototype can no longer be attacker-controlled.
- `Object.prototype` is never touched.
- The key stays an enumerable own entry, so `min`/`max` counts remain correct.

## Testing

Added a regression test asserting the accumulator is null-prototype, `__proto__` stays an enumerable own key, and `Object.prototype` is untouched. `bun test modules/util/validate.test.ts modules/schema` — all pass (336 across schema + validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQzwYXbcEjpqmjNeAxaE1P)_