### PR TITLE
fix(schema): enforce StringSchema max length before running match

### DIFF
--- a/modules/schema/CurrencyCodeSchema.test.ts
+++ b/modules/schema/CurrencyCodeSchema.test.ts
@@ -49,7 +49,7 @@ describe("validate()", () => {
 
 	test("Invalid currency codes are invalid", () => {
 		expect(() => schema.validate("US")).toThrow("Invalid currency");
-		expect(() => schema.validate("USDT")).toThrow("Invalid currency");
+		expect(() => schema.validate("USDT")).toThrow("Maximum 3 characters"); // Over-length is now caught by `max` before the pattern runs.
 		expect(() => schema.validate("ZZZ")).toThrow("Unknown currency code");
 	});
 

--- a/modules/schema/StringSchema.ts
+++ b/modules/schema/StringSchema.ts
@@ -89,9 +89,12 @@ export class StringSchema extends Schema<string> {
 		const str = typeof value === "number" ? value.toString() : value;
 		if (typeof str !== "string") throw value ? `Must be ${this.one}` : "Required";
 		const sane = this.sanitize(str);
+		// Enforce `max` before running `match`, so an over-length string is rejected without ever being handed to
+		// the (potentially expensive) regex — a length cap can't shield the pattern otherwise. `min` stays after
+		// `match` to preserve the existing "Invalid" precedence for short-but-malformed values.
+		if (sane.length > this.max) throw `Maximum ${this.max} characters`;
 		if (this.match && !this.match.test(sane)) throw str.length ? `Invalid ${this.one}` : "Required";
 		if (sane.length < this.min) throw str.length ? `Minimum ${this.min} characters` : "Required";
-		if (sane.length > this.max) throw `Maximum ${this.max} characters`;
 		return sane;
 	}
 


### PR DESCRIPTION
## Issue

`StringSchema.validate` tested the `match` regex **before** enforcing `max`:

```ts
const sane = this.sanitize(str);
if (this.match && !this.match.test(sane)) throw …;   // runs on full-length input
if (sane.length < this.min) throw …;
if (sane.length > this.max) throw …;
```

So the length cap did not shield the `match` regex from oversized input. Harmless today — every built-in `match` pattern is anchored with bounded quantifiers and runs linearly — but any consumer supplying a custom `match:` with super-linear behaviour would be exploitable regardless of `max`. This is defense-in-depth.

Fixes #246.

## Fix

Move the `max` check **ahead of** `match`, so an over-length string is rejected without ever being handed to the pattern. `min` stays **after** `match`, deliberately, to preserve the existing "Invalid" precedence for short-but-malformed values (moving `min` up changed messages for values that sanitise to empty).

Final order: `max` → `match` → `min`.

## ⚠️ Behaviour change (please review)

An over-`max` value that would *also* fail `match` now reports **"Maximum N characters"** instead of **"Invalid …"**, because the pattern no longer runs for it. This is unavoidable — shielding the regex from oversized input means oversized input is rejected by length first.

One existing test relied on the old ordering and is updated:

- `CurrencyCodeSchema` (`max: 3`): `validate("USDT")` now throws `"Maximum 3 characters"` instead of `"Invalid currency"`. `"US"` (too short) and `"ZZZ"` (unknown code) are unchanged.

If you'd prefer to keep "Invalid …" messaging for over-length values, the alternative is to not reorder and accept that the regex runs on oversized input — happy to close this if the tradeoff isn't worth it for a latent issue.

## Testing

`bun test modules/schema` — 319 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQzwYXbcEjpqmjNeAxaE1P)_