### PR TITLE
fix(util): use Object.create(null) for validateDictionary accumulator (unbreak tsgo)

### DIFF
--- a/modules/util/validate.ts
+++ b/modules/util/validate.ts
@@ -166,7 +166,7 @@ export function validateDictionary<T>(unsafeDictionary: PossibleDictionary<unkno
 	// Null-prototype accumulator: an untrusted `"__proto__"` key (or `"constructor"`) then becomes an inert own
 	// property instead of invoking the inherited `__proto__` setter, so a crafted `{ "__proto__": … }` input can't
 	// reassign the returned dictionary's prototype, and the entry stays enumerable so `min`/`max` counts are correct.
-	const safeDictionary: MutableDictionary<T> = { __proto__: null } as MutableDictionary<T>;
+	const safeDictionary: MutableDictionary<T> = Object.create(null);
 	const messages: MutableArray<string> = [];
 	for (const [key, unsafeValue] of getDictionaryItems(unsafeDictionary)) {
 		try {


### PR DESCRIPTION
## Problem — main does not type-check

The null-prototype accumulator merged in #250 used:

```ts
const safeDictionary: MutableDictionary<T> = { __proto__: null } as MutableDictionary<T>;
```

which fails `tsgo --noEmit` on `main` (so `test:type` and `build` are red):

```
modules/util/validate.ts(169,47): error TS2352: Conversion of type '{ __proto__: null; }' to type
'MutableDictionary<T>' may be a mistake because neither type sufficiently overlaps with the other.
  Property '__proto__' is incompatible with index signature.
    Type 'null' is not comparable to type 'T'.
```

TypeScript still does **not** treat `__proto__:` in an object literal as the prototype-setter for typing purposes (a longstanding limitation) — it types the literal as having a real `__proto__: null` property, which is incompatible with `MutableDictionary<T>`'s `[key: string]: T` index signature. (`EMPTY_DICTIONARY` gets away with `{ __proto__: null }` only because its type, `{ [K in never]: never }`, has no index signature to violate.)

Unit tests passed, so this slipped through — the type error only surfaces under `tsgo`, which is what I should have run on the branch before it merged. My mistake.

## Fix

Use `Object.create(null)`, which returns a genuine null-prototype object typed `any`, so it assigns to `MutableDictionary<T>` with no cast:

```ts
const safeDictionary: MutableDictionary<T> = Object.create(null);
```

Runtime behaviour and the #242 security fix are identical — this only changes how the null-prototype object is constructed so it type-checks.

## Verification

- `bun run test:type` → clean ✅ (was failing on `main`)
- `bun test modules/util/validate.test.ts` → 18 pass ✅ (incl. the `__proto__` regression test from #250)
- Confirmed `bun test ./modules` (1191 pass) and `biome check` were already green on `main`; only `test:type` was red.

I also type-checked the two still-open branches (#248/#240, #249/#241) with this fix applied — both are clean, so they won't reintroduce the break once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQzwYXbcEjpqmjNeAxaE1P)_