### PR TITLE
fix(util): harden object-accumulation sites against local prototype injection

### DIFF
--- a/modules/util/dictionary.md
+++ b/modules/util/dictionary.md
@@ -5,6 +5,7 @@ Typed helpers for working with `{ [key: string]: T }` objects — called *dictio
 - `ImmutableDictionary<T>` and `MutableDictionary<T>` are the two variants; all immutable helpers return the same reference when nothing changed.
 - `requireDictionary()` converts an iterable of `[key, value]` pairs into a plain object — useful when you receive entries from a `Map` or other iterable source.
 - `EMPTY_DICTIONARY` is a prototype-null singleton; use it as a safe empty default.
+- `setDictionaryItem()` / `setDictionaryItems()` trust their keys by contract: a runtime-untrusted key like `__proto__` would mutate the target's prototype, so validate or filter untrusted keys first (or use a null-prototype target).
 
 ## Usage
 

--- a/modules/util/dictionary.ts
+++ b/modules/util/dictionary.ts
@@ -204,6 +204,7 @@ export const pickDictionaryItems: <T>(dict: ImmutableDictionary<T>, ...keys: str
 
 /**
  * Set a single named item on a dictionary object (by reference) and return its value.
+ * - The key is trusted by contract: a runtime-untrusted key like `"__proto__"` would mutate the target's prototype, so validate or filter untrusted keys before calling (or use a null-prototype target).
  *
  * @param dict The dictionary to set the item on (modified by reference).
  * @param key The key of the item to set.
@@ -215,6 +216,7 @@ export const setDictionaryItem: <T>(dict: MutableDictionary<T>, key: string, val
 
 /**
  * Set several named items on a dictionary object (by reference).
+ * - Keys are trusted by contract: a runtime-untrusted key like `"__proto__"` would mutate the target's prototype, so validate or filter untrusted keys before calling (or use a null-prototype target).
  *
  * @param dict The dictionary to set the items on (modified by reference).
  * @param entries The items to set, as a dictionary or iterable set of key/value entry tuples.

--- a/modules/util/diff.md
+++ b/modules/util/diff.md
@@ -6,6 +6,7 @@ Compute the minimal transformation needed to turn one value into another. Used i
 - Objects are compared recursively. Keys present in `left` but absent from `right` appear in the diff as `undefined` (indicating deletion).
 - Scalar values that differ always return `right` directly — they cannot be partially diffed.
 - Objects with different constructors are never merged; `right` is returned as-is.
+- Diff objects are built with a `null` prototype, so an untrusted `__proto__` key in `right` becomes an inert own property instead of injecting a prototype.
 
 ## Usage
 

--- a/modules/util/diff.test.ts
+++ b/modules/util/diff.test.ts
@@ -164,4 +164,13 @@ describe("deepDiffObject()", () => {
 		expect(deepDiffObject(objDeep, objDeepMissing)).toEqual({ obj2: { b: undefined } });
 		expect(deepDiffObject(objDeepMissing, objDeep)).toEqual({ obj2: { b: "b" } });
 	});
+	test("deepDiffObject(): a `__proto__` key does not inject a prototype", () => {
+		// JSON.parse creates an own `"__proto__"` data key (not a setter call), so this reaches the loop with a hostile key.
+		const right: Data = JSON.parse('{"__proto__": { "polluted": true }, "b": 2}');
+		const diff = deepDiffObject({ a: 1 }, right);
+		expect(diff).not.toBe(SAME);
+		expect(Object.getPrototypeOf(diff)).toBe(null); // Hostile prototype was not injected.
+		expect(Object.keys(diff)).toEqual(["__proto__", "b", "a"]); // `__proto__` stays an enumerable own entry.
+		expect(({} as { polluted?: boolean }).polluted).toBeUndefined(); // Global `Object.prototype` untouched.
+	});
 });

--- a/modules/util/diff.ts
+++ b/modules/util/diff.ts
@@ -61,6 +61,7 @@ export function deepDiffArray<R extends ImmutableArray>(left: ImmutableArray, ri
  * @returns Object containing the missing/updated properties that `left` needs to become `right`.
  * - If the two values are deeply equal the `SAME` constant is returned.
  * - If `left` isn't an object then the result can't be diffed so entire `right` is returned.
+ * - Diff object has a `null` prototype, so an untrusted `"__proto__"` key in `right` becomes an inert own property instead of injecting a prototype.
  * @see https://shelving.cc/util/diff/deepDiffObject
  */
 export function deepDiffObject<R extends ImmutableObject>(left: ImmutableObject, right: R): R | DeepPartial<R> | typeof SAME;
@@ -73,7 +74,10 @@ export function deepDiffObject(left: ImmutableObject, right: ImmutableObject): I
 	// If left is empty, entire right is returned.
 	if (!leftKeys.length) return rightKeys.length ? right : SAME;
 
-	const diff: MutableObject = {};
+	// Null-prototype accumulator: an untrusted `"__proto__"` key in `right` then becomes an inert own property
+	// instead of invoking the inherited `__proto__` setter, so a crafted `{ "__proto__": … }` input can't reassign
+	// the diff object's prototype.
+	const diff: MutableObject = Object.create(null);
 	let changed = false;
 
 	for (const k of rightKeys) {

--- a/modules/util/merge.md
+++ b/modules/util/merge.md
@@ -8,6 +8,7 @@ Immutably merge two values — objects, arrays, or primitives. All merge functio
 - `mergeObject()` treats an explicit `undefined` value in `right` as a deletion of that key from the merged result.
 - `exactMerge()` simply returns `right` — the building block for shallow merges of object properties.
 - Same-reference shortcut: if `left === right`, the function returns immediately without allocating.
+- Merged objects are built with a `null` prototype, so an untrusted `__proto__` key in `right` becomes an inert own property instead of injecting a prototype.
 
 ## Usage
 

--- a/modules/util/merge.test.ts
+++ b/modules/util/merge.test.ts
@@ -187,4 +187,14 @@ describe("mergeObject()", () => {
 		expect(mergeObject(objDeepMissing, objDeep, deepMerge)).toEqual(objDeep);
 		expect(mergeObject({ deep: { a: 1 } }, { deep: { b: 2 } }, deepMerge)).toEqual({ deep: { a: 1, b: 2 } });
 	});
+	test("mergeObject(): a `__proto__` key does not inject a prototype", () => {
+		// JSON.parse creates an own `"__proto__"` data key (not a setter call), so this reaches the loop with a hostile key.
+		const right: Record<string, unknown> = JSON.parse('{"__proto__": { "polluted": true }, "b": 2}');
+		const merged = mergeObject({ a: 1 }, right);
+		expect(Object.getPrototypeOf(merged)).toBe(null); // Hostile prototype was not injected.
+		expect(Object.keys(merged)).toEqual(["a", "__proto__", "b"]); // `__proto__` stays an enumerable own entry.
+		expect(({} as { polluted?: boolean }).polluted).toBeUndefined(); // Global `Object.prototype` untouched.
+		// Same via `deepMerge()`, which recurses into `mergeObject()`.
+		expect(Object.getPrototypeOf(deepMerge({ a: 1 }, right))).toBe(null);
+	});
 });

--- a/modules/util/merge.ts
+++ b/modules/util/merge.ts
@@ -97,6 +97,7 @@ export function mergeArray(left: ImmutableArray, right: ImmutableArray): Immutab
  * - Only works on enumerable own keys (as returned by `Object.keys()`).
  * - Always returns a new object (or the `left` object if no changes were made).
  * - Resulting object is `cleaned`, i.e. properties in `left` or `right` that are `undefined` will be removed from the merged object.
+ * - Merged object has a `null` prototype, so an untrusted `"__proto__"` key in `right` becomes an inert own property instead of injecting a prototype.
  *
  * @param left The left object to merge into.
  * @param right The right object whose props replace or merge with `left`.
@@ -119,7 +120,10 @@ export function mergeObject(left: ImmutableObject, right: ImmutableObject, recur
 	if (!rightEntries.length) return left;
 
 	const leftKeys = Object.keys(left);
-	const merged: MutableObject = { ...left };
+	// Null-prototype accumulator: an untrusted `"__proto__"` key in `right` then becomes an inert own property
+	// instead of invoking the inherited `__proto__` setter, so a crafted `{ "__proto__": … }` input can't reassign
+	// the merged object's prototype.
+	const merged: MutableObject = Object.assign(Object.create(null), left);
 	let changed = false;
 
 	for (const [k, r] of rightEntries) {

--- a/modules/util/object.md
+++ b/modules/util/object.md
@@ -8,6 +8,7 @@ Core immutable helpers for reading and updating plain objects, plus utility type
 - Same-reference shortcut: if the new value is `===` to the existing value, the original object is returned without allocating.
 - `omitProp()` is an alias for `omitProps()` with a single key — they are the same function.
 - `deleteProp()` / `deleteProps()` and `setProp()` / `setProps()` mutate by reference; use the `with*` / `omit*` variants for immutable operations.
+- `setProp()` / `setProps()` trust their keys by contract: a runtime-untrusted key like `__proto__` would mutate the target's prototype, so validate or filter untrusted keys first (or use a null-prototype target).
 - `isObject()` returns `true` for any non-null object including arrays and class instances. Use `isPlainObject()` when you need only `{}` shaped objects.
 
 ## Usage

--- a/modules/util/object.ts
+++ b/modules/util/object.ts
@@ -312,6 +312,7 @@ function _hasKey<T extends ImmutableObject>(this: Key<T>[], [key]: readonly [Key
 
 /**
  * Set a single named prop on an object (by reference) and return its value.
+ * - The key is trusted by contract: a runtime-untrusted key like `"__proto__"` would mutate the target's prototype, so validate or filter untrusted keys before calling (or use a null-prototype target).
  *
  * @param obj The object to set the prop on (modified by reference).
  * @param key The key of the prop to set.
@@ -326,6 +327,7 @@ export function setProp<T extends MutableObject, K extends Key<T>>(obj: T, key: 
 
 /**
  * Set several named props on an object (by reference).
+ * - Keys are trusted by contract: a runtime-untrusted key like `"__proto__"` would mutate the target's prototype, so validate or filter untrusted keys before calling (or use a null-prototype target).
  *
  * @param obj The object to set the props on (modified by reference).
  * @param entries The props to set, as an object or iterable set of key/value entry tuples.

--- a/modules/util/uri.md
+++ b/modules/util/uri.md
@@ -7,7 +7,7 @@ These helpers work with any valid URI — including non-hierarchical ones like `
 - `ImmutableURI` is a re-export of the native `URL` constructor with a tighter TypeScript interface. At runtime it _is_ `URL`; the type just restricts properties to narrower literal types.
 - `getURI()` only accepts **complete** URIs (with protocol). Relative inputs always return `undefined`. Use `getBasedURI()` from `url.ts` to resolve a path against a base.
 - `withURIParam()` / `withURIParams()` return the **same URI instance** when the params would not change.
-- `getURIParams()` converts `URLSearchParams`, a URI string, a URL object, or a plain dictionary — all to the same `{ key: string }` shape.
+- `getURIParams()` converts `URLSearchParams`, a URI string, a URL object, or a plain dictionary — all to the same `{ key: string }` shape. The returned dictionary has a `null` prototype, so an untrusted `__proto__` param becomes an inert own entry.
 - `omitURIParam` is an alias for `omitURIParams()` with a single key.
 
 ## Usage

--- a/modules/util/uri.test.ts
+++ b/modules/util/uri.test.ts
@@ -8,6 +8,14 @@ describe("getURIParams()", () => {
 		expect(getURIParams("https://a.com/?a=1&b=2")).toEqual({ a: "1", b: "2" });
 		expect(getURIParams(new ImmutableURL("https://a.com/?a=1&b=2"))).toEqual({ a: "1", b: "2" });
 	});
+	test("a `__proto__` param does not inject a prototype", () => {
+		const params = getURIParams("https://a.com/?__proto__=a&b=2");
+		expect(Object.getPrototypeOf(params)).toBe(null); // No prototype to inject through.
+		expect(Object.entries(params)).toEqual([
+			["__proto__", "a"], // `__proto__` stays an enumerable own entry (not silently dropped).
+			["b", "2"],
+		]);
+	});
 });
 describe("getURIParam()", () => {
 	test("gets param from URL", () => {

--- a/modules/util/uri.ts
+++ b/modules/util/uri.ts
@@ -251,6 +251,7 @@ function* getURIEntries(params: PossibleURIParams, caller: AnyCaller = getURIPar
 /**
  * Get a set of params for a URI as a dictionary.
  * - Any params with `undefined` value will be ignored.
+ * - Returned dictionary has a `null` prototype, so an untrusted `__proto__` param becomes an inert own entry (instead of being silently dropped by the inherited `__proto__` setter).
  *
  * @param params Possible URI params to convert.
  * @param caller Function to attribute a thrown error to (defaults to `getURIParams` itself).
@@ -260,7 +261,9 @@ function* getURIEntries(params: PossibleURIParams, caller: AnyCaller = getURIPar
  * @see https://shelving.cc/util/uri/getURIParams
  */
 export function getURIParams(params: PossibleURIParams, caller: AnyCaller = getURIParams): URIParams {
-	const output: MutableDictionary<string> = {};
+	// Null-prototype accumulator: param keys are runtime-untrusted, so an untrusted `"__proto__"` key becomes an
+	// inert own entry instead of invoking the inherited `__proto__` setter (which would silently drop the param).
+	const output: MutableDictionary<string> = Object.create(null);
 	for (const [key, str] of getURIEntries(params, caller)) output[key] = str;
 	return output;
 }

--- a/modules/util/validate.ts
+++ b/modules/util/validate.ts
@@ -166,7 +166,7 @@ export function validateDictionary<T>(unsafeDictionary: PossibleDictionary<unkno
 	// Null-prototype accumulator: an untrusted `"__proto__"` key (or `"constructor"`) then becomes an inert own
 	// property instead of invoking the inherited `__proto__` setter, so a crafted `{ "__proto__": … }` input can't
 	// reassign the returned dictionary's prototype, and the entry stays enumerable so `min`/`max` counts are correct.
-	const safeDictionary: MutableDictionary<T> = { __proto__: null } as MutableDictionary<T>;
+	const safeDictionary: MutableDictionary<T> = Object.create(null);
 	const messages: MutableArray<string> = [];
 	for (const [key, unsafeValue] of getDictionaryItems(unsafeDictionary)) {
 		try {


### PR DESCRIPTION
Closes #254

Sweep of every site that writes to an object with a runtime-untrusted key, following the `validateDictionary` fix from #242/#250. The concern is *local* prototype injection: a crafted `"__proto__"` key invoking the inherited setter and reassigning the result object's prototype (plus enumerability/count surprises). No global `Object.prototype` pollution existed or exists.

## Changes per candidate

### (a) Null-prototype accumulator

- **`mergeObject()`** (`modules/util/merge.ts`) — the issue's strongest candidate. The merged object is now built with `Object.assign(Object.create(null), left)`, so an untrusted `"__proto__"` key in `right` becomes an inert own property instead of reassigning the merged object's prototype. Covers object merges via `shallowMerge()` / `deepMerge()` too. (Note `Object.assign` onto a null-prototype target is itself safe — there is no inherited setter to hit.)
- **`deepDiffObject()`** (`modules/util/diff.ts`) — **found in the sweep, not listed in the issue**: `diff[k] = d` iterates `Object.keys(right)` where `right` is arbitrary runtime data (this feeds the update/sync layers), so a `"__proto__"` key in `right` could reassign the diff object's prototype. Same null-prototype accumulator fix.
- **`getURIParams()`** (`modules/util/uri.ts`) — listed as "likely safe" since values are always strings (the setter no-ops), but the no-op also meant a `?__proto__=x` param was **silently dropped** from the output. The null-prototype output dictionary is both defense-in-depth and fixes that: the param is now preserved as an inert own entry.

As with `validateDictionary`, the null prototype only applies to the *newly built* result; the unchanged-input fast paths still return the original reference.

### (c) Trusted-by-contract, documented

- **`setProp()` / `setProps()`** (`modules/util/object.ts`) and **`setDictionaryItem()` / `setDictionaryItems()`** (`modules/util/dictionary.ts`) — these mutate a caller-provided target by reference, so a null-prototype accumulator isn't applicable, and silently skipping keys would violate the "set" contract. Their docblocks (and the `object.md` / `dictionary.md` pages) now state that keys are trusted by contract and untrusted keys must be validated/filtered first (or a null-prototype target used).

### Reviewed and left as-is

- **`matchTemplate()`** (`template.ts`) and **`transformObject()`** (`transform.ts`) — keys come from developer-defined templates / transform maps, not runtime data.
- `validateData()` (`validate.ts:215`) — iterates developer-defined schema keys, as already noted in the issue.

## Also included: the #253 type fix

`validateDictionary`'s accumulator is now constructed with `Object.create(null)` instead of `{ __proto__: null } as MutableDictionary<T>` — the identical one-line change as #253, included here because `tsgo --noEmit` (so `test:type` and CI) is red on `main` without it. Identical changes merge cleanly whichever PR lands first. All new accumulators use `Object.create(null)` per the issue's guidance.

I did **not** add the suggested `mutableDictionary()` shared helper — only two of the four hardened sites are dictionaries, and per `AGENTS.md` new shared primitives warrant discussion first. Happy to add one as a follow-up if wanted.

## Tests

New regression tests (all using `JSON.parse` to create a genuine own `"__proto__"` data key) for `mergeObject()` + `deepMerge()`, `deepDiffObject()`, and `getURIParams()`: prototype is not injected, the key stays an enumerable own entry, and global `Object.prototype` is untouched.

## Verification

- `bun run test:lint` → clean
- `bun run test:type` → clean (was **red on `main`** with the TS2352 error #253 describes)
- `bun run test:unit` → 1194 pass (up from 1191; 3 new tests)
- `bun run fix` → no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UWyn1F8R1BQcBY1jrVEaV

---
_Generated by [Claude Code](https://claude.ai/code/session_018UWyn1F8R1BQcBY1jrVEaV)_