### PR TITLE
fix(util): insert renderTemplate values literally (escape $ replacement patterns)

### DIFF
--- a/modules/util/template.test.ts
+++ b/modules/util/template.test.ts
@@ -183,6 +183,17 @@ describe("renderTemplate()", () => {
 		expect(() => renderTemplate("/*/", [])).toThrow(RequiredError);
 		expect(() => renderTemplate("/*/*", ["A"])).toThrow(RequiredError);
 	});
+	test("`$` sequences in values are inserted literally, not as replacement patterns", () => {
+		// `$&`, `$'`, `` $` ``, `$1`, `$$` must not be interpreted by String.prototype.replace.
+		expect(renderTemplate("a{x}b", { x: "$&" })).toBe("a$&b");
+		expect(renderTemplate("a{x}b", { x: "$`" })).toBe("a$`b");
+		expect(renderTemplate("a{x}b", { x: "$'" })).toBe("a$'b");
+		expect(renderTemplate("a{x}b", { x: "$1$2" })).toBe("a$1$2b");
+		expect(renderTemplate("a{x}b", { x: "p$$q" })).toBe("ap$$qb");
+		// Also via function and string value sources.
+		expect(renderTemplate("a{x}b", () => "$&")).toBe("a$&b");
+		expect(renderTemplate(":x", "$&")).toBe("$&");
+	});
 });
 
 describe("renderPathTemplate()", () => {

--- a/modules/util/template.ts
+++ b/modules/util/template.ts
@@ -272,26 +272,36 @@ export function renderTemplate(template: string, values: TemplateValues, caller:
 	if (!chunks.length) return template;
 	let output = template;
 	if (isFunction(values)) {
-		for (const { name, placeholder } of chunks) output = output.replace(placeholder, values(name));
+		for (const { name, placeholder } of chunks) output = output.replace(placeholder, _escapeReplacement(values(name)));
 	} else if (isData(values)) {
 		for (const { name, placeholder } of chunks) {
 			const v = getString(getDataProp(values, name));
 			if (v === undefined)
 				throw new RequiredError(`Template placeholder "${name}" not found in object`, { received: values, name, caller });
-			output = output.replace(placeholder, v);
+			output = output.replace(placeholder, _escapeReplacement(v));
 		}
 	} else if (isArray(values)) {
 		for (const { name, placeholder } of chunks) {
 			const v = getString(values[Number(name)]);
 			if (v === undefined) throw new RequiredError(`Template placeholder "${name}" not found in array`, { received: values, name, caller });
-			output = output.replace(placeholder, v);
+			output = output.replace(placeholder, _escapeReplacement(v));
 		}
 	} else {
 		const v = getString(values);
 		if (v === undefined) throw new RequiredError(`Template value must be string`, { received: values, caller });
-		for (const { placeholder } of chunks) output = output.replace(placeholder, v);
+		for (const { placeholder } of chunks) output = output.replace(placeholder, _escapeReplacement(v));
 	}
 	return output;
+}
+
+/**
+ * Escape `$` in a `String.prototype.replace()` replacement value so it's inserted literally.
+ * - Without this, `$&`, `$'`, `` $` ``, `$1`, `$$` in a (often user-supplied) value are interpreted as replacement
+ *   patterns and pull surrounding template text into the value's slot.
+ * - Cheap: only rewrites when a `$` is actually present, so the common case is a single scan with no allocation.
+ */
+function _escapeReplacement(value: string): string {
+	return value.includes("$") ? value.replaceAll("$", "$$$$") : value;
 }
 
 /**


### PR DESCRIPTION
## Issue

`renderTemplate` filled placeholders with `output.replace(placeholder, value)`. When the replacement is a **string**, JavaScript interprets `$`-sequences in it — `$&`, `` $` ``, `$'`, `$1`, `$$` — as replacement patterns, so a (often user-supplied) value containing them rendered incorrectly and could pull surrounding template text into its own slot:

```
renderTemplate("Hello {name}!", { name: "$&" })   // was "Hello {name}!"  (placeholder reappears)
renderTemplate("Hello {name}!", { name: "$'" })   // was "Hello !!"        (trailing text leaked in)
```

Fixes #243.

## Fix (Option A — escape, no per-replacement closure)

Escape `$` in the replacement value so it's inserted literally, but only when a `$` is actually present:

```ts
function _escapeReplacement(value: string): string {
	return value.includes("$") ? value.replaceAll("$", "$$$$") : value;
}
```

- **Common case** (no `$`): a single `includes` scan — **no allocation, no closure**.
- Only when a `$` is present do we pay one `replaceAll`.
- Applied to every value source (function / data / array / string).

Chosen over the replacer-function form (`output.replace(ph, () => v)`) to avoid allocating a closure per replacement in what can be a hot path. `renderPathTemplate` is unaffected — its values are `encodeURIComponent`-encoded, so they never contain a `$`.

## Behaviour

```
renderTemplate("Hello {name}!", { name: "$&" })   // "Hello $&!"
renderTemplate("Hello {name}!", { name: "$'" })   // "Hello $'!"
renderTemplate("Hello {name}!", { name: "a$$b" }) // "Hello a$$b!"
renderTemplate("Hello {name}!", { name: "Dave" }) // "Hello Dave!"  (unchanged)
```

Identical output for any value without a `$`.

## Testing

`bun test modules/util/template.test.ts modules/extract modules/ui/router modules/api` — 198 pass / 0 fail (added `$`-literal tests across value sources). `bun run test:type` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQzwYXbcEjpqmjNeAxaE1P)_