### PR TITLE
Add indeterminate state to Progress component

### DIFF
--- a/modules/ui/block/Prose.md
+++ b/modules/ui/block/Prose.md
@@ -4,7 +4,7 @@ A wrapper that applies cohesive longform typography to a subtree of mixed HTML c
 
 **Things to know:**
 
-- `Prose` applies the "prose" variant of *every* block and inline component as a single compound class, so raw `<p>`, `<ul>`, `<h2>`, `<code>`, `<a>`, etc. are styled to match their component counterparts (`<Paragraph>`, `<List>`, `<Heading>`, `<Code>`, `<Link>`, …).
+- `Prose` applies the "prose" variant of *every* block and inline component as a single compound class, so raw `<p>`, `<ul>`, `<h2>`, `<code>`, `<a>`, `<progress>`, etc. are styled to match their component counterparts (`<Paragraph>`, `<List>`, `<Heading>`, `<Code>`, `<Link>`, `<Progress>`, …).
 - This is the bridge for markup: wrap `shelving/markup` output (or anything that emits raw HTML) in `<Prose>` and it just works — no per-element component wrapping needed.
 - It only sets up typography and its own outer margin; it paints no colour and adds no box of its own.
 

--- a/modules/ui/block/Prose.tsx
+++ b/modules/ui/block/Prose.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import PROGRESS_CSS from "../form/Progress.module.css";
 import CODE_CSS from "../inline/Code.module.css";
 import DELETED_CSS from "../inline/Deleted.module.css";
 import EMPHASIS_CSS from "../inline/Emphasis.module.css";
@@ -50,6 +51,7 @@ const PROSE_STYLES = getClass(
 	getModuleClass(LINK_CSS, "prose"),
 	getModuleClass(MARK_CSS, "prose"),
 	getModuleClass(PREFORMATTED_CSS, "prose"),
+	getModuleClass(PROGRESS_CSS, "prose"),
 	getModuleClass(SMALL_CSS, "prose"),
 	getModuleClass(STRONG_CSS, "prose"),
 	getModuleClass(SUBSCRIPT_CSS, "prose"),

--- a/modules/ui/form/Progress.md
+++ b/modules/ui/form/Progress.md
@@ -7,6 +7,7 @@ A continuous horizontal progress bar for the completion of a task. Rendered as a
 - Use `Progress` for **task completion** — a value heading toward "done" (an upload, a multi-step form, a load). For a static reading within a range that can move up and down (disk usage, a score), a gauge is the right model, not a progress bar.
 - `value` is filled within the `min`–`max` range (defaults `0`–`100`), matching `getPercent()` and `formatPercent()`. `<progress>` has no `min` attribute, so the range is normalised to `value - min` / `max - min` before it reaches the element.
 - The browser clamps `value` to the `0`–`max` range, so an out-of-range `value` renders an empty or full bar rather than overspilling. A non-positive range (`min === max`) falls back to an empty bar rather than the indeterminate state.
+- Pass `indeterminate` for an ongoing task whose duration isn't known — `value` is dropped so the element is natively indeterminate (no `aria-valuenow`), and a band of fill colour flows across the track on a loop. `color=` / `status=` still recolour it. The animation respects `prefers-reduced-motion` (it holds a centred band instead of looping).
 - `aria-valuetext` carries the formatted percentage, so assistive tech announces e.g. "75%".
 - Paints from the [tint ladder](/ui/TINT_CLASS): `color=` and `status=` move the tint anchor for the bar, so the fill (and track) re-derive together — `status="success"` gives a green bar, `color="purple"` a purple one. Without either, the bar takes the ambient tint (`--tint-50`, gray by default).
 
@@ -40,6 +41,18 @@ import { Progress } from "shelving/ui";
 <Progress value={60} color="purple" />
 ```
 
+### Indeterminate
+
+```tsx
+import { Progress } from "shelving/ui";
+
+// Looping flow animation for a task of unknown duration.
+<Progress value={0} indeterminate />
+
+// The flowing band still picks up status/colour.
+<Progress value={0} indeterminate status="success" />
+```
+
 ## Styling
 
 `Progress` paints a track (the element / `::-webkit-progress-bar`) and a fill (`::-webkit-progress-value` / `::-moz-progress-bar`) from the [tint ladder](/ui/TINT_CLASS). Apply `color=` / `status=` (on the bar or a tinted ancestor scope) to recolour the fill and track together — reach for a per-property hook only for a single surgical change. Override these hooks at `:root` (or any ancestor scope) to retheme.
@@ -50,6 +63,7 @@ import { Progress } from "shelving/ui";
 | `--progress-radius` | Corner radius | `999px` (pill) |
 | `--progress-background` | Track fill | `var(--tint-90)` |
 | `--progress-color` | Fill colour | `var(--tint-50)` |
+| `--progress-duration` | Indeterminate flow-loop duration | `1.5s` |
 
 **Global tokens it reads** — move these to retheme broadly rather than overriding the hooks directly: the tint-ladder steps `--tint-50` (fill) and `--tint-90` (track), plus `--duration-fast` (the fill's grow transition). To recolour a bar, prefer `color=` / `status=` (or a tinted ancestor scope) over the per-component hooks.
 

--- a/modules/ui/form/Progress.md
+++ b/modules/ui/form/Progress.md
@@ -7,7 +7,7 @@ A continuous horizontal progress bar for the completion of a task. Rendered as a
 - Use `Progress` for **task completion** — a value heading toward "done" (an upload, a multi-step form, a load). For a static reading within a range that can move up and down (disk usage, a score), a gauge is the right model, not a progress bar.
 - `value` is filled within the `min`–`max` range (defaults `0`–`100`), matching `getPercent()` and `formatPercent()`. `<progress>` has no `min` attribute, so the range is normalised to `value - min` / `max - min` before it reaches the element.
 - The browser clamps `value` to the `0`–`max` range, so an out-of-range `value` renders an empty or full bar rather than overspilling. A non-positive range (`min === max`) falls back to an empty bar rather than the indeterminate state.
-- Pass `indeterminate` for an ongoing task whose duration isn't known — `value` is dropped so the element is natively indeterminate (no `aria-valuenow`), and a band of fill colour flows across the track on a loop. `color=` / `status=` still recolour it. The animation respects `prefers-reduced-motion` (it holds a centred band instead of looping).
+- Omit `value` (or pass `null`/`undefined`) for an ongoing task whose duration isn't known — exactly like a native `<progress>`, dropping the attribute switches the element into the `:indeterminate` state (no `aria-valuenow`), and a block of fill colour flows across the track on a loop. `color=` / `status=` still recolour it. The animation respects `prefers-reduced-motion` (it holds a centred block instead of looping).
 - `aria-valuetext` carries the formatted percentage, so assistive tech announces e.g. "75%".
 - Paints from the [tint ladder](/ui/TINT_CLASS): `color=` and `status=` move the tint anchor for the bar, so the fill (and track) re-derive together — `status="success"` gives a green bar, `color="purple"` a purple one. Without either, the bar takes the ambient tint (`--tint-50`, gray by default).
 
@@ -46,11 +46,11 @@ import { Progress } from "shelving/ui";
 ```tsx
 import { Progress } from "shelving/ui";
 
-// Looping flow animation for a task of unknown duration.
-<Progress value={0} indeterminate />
+// No `value` → looping flow animation for a task of unknown duration.
+<Progress />
 
-// The flowing band still picks up status/colour.
-<Progress value={0} indeterminate status="success" />
+// The flowing block still picks up status/colour.
+<Progress status="success" />
 ```
 
 ## Styling

--- a/modules/ui/form/Progress.module.css
+++ b/modules/ui/form/Progress.module.css
@@ -5,7 +5,8 @@
 
 @layer components {
 	/* Continuous progress bar — a native `<progress>` styled as a single track that fills horizontally. */
-	.progress {
+	.progress,
+	.prose progress {
 		/* Strip the native rendering so the track/fill can be painted from tokens. */
 		appearance: none;
 		display: block;
@@ -21,22 +22,26 @@
 	}
 
 	/* Track (WebKit/Blink) — Firefox has no track pseudo-element. */
-	.progress::-webkit-progress-bar {
+	.progress::-webkit-progress-bar,
+	.prose progress::-webkit-progress-bar {
 		background: var(--progress-background, var(--tint-90));
 	}
 
 	/* Fill — WebKit/Blink and Firefox expose the fill under different pseudo-elements, so both repeat the same paint. Painted from the tint ladder, so `color=` / `status=` recolour it. */
-	.progress::-webkit-progress-value {
+	.progress::-webkit-progress-value,
+	.prose progress::-webkit-progress-value {
 		background: var(--progress-color, var(--tint-50));
 		transition: inline-size var(--duration-fast);
 	}
 
-	.progress::-moz-progress-bar {
+	.progress::-moz-progress-bar,
+	.prose progress::-moz-progress-bar {
 		background: var(--progress-color, var(--tint-50));
 	}
 
-	/* Indeterminate — no `value`, so a band of fill colour flows left-to-right across the track on a loop for a task of unknown duration. */
-	.progress.indeterminate {
+	/* Indeterminate — a native `<progress>` with no `value`, so a solid block of fill colour slides across the track on a loop for a task of unknown duration. */
+	.progress:indeterminate,
+	.prose progress:indeterminate {
 		/* Track underneath, plus a solid block of fill colour that slides across the element itself — hard edges, no blended fade. */
 		background-color: var(--progress-background, var(--tint-90));
 		background-image: linear-gradient(90deg, var(--progress-color, var(--tint-50)), var(--progress-color, var(--tint-50)));
@@ -45,19 +50,23 @@
 		animation: progress-flow var(--progress-duration, 1.5s) linear infinite;
 	}
 
-	/* The native track/fill pseudo-elements would paint over the flowing band, so make them transparent and let the element's own background show through. */
-	.progress.indeterminate::-webkit-progress-bar,
-	.progress.indeterminate::-webkit-progress-value {
+	/* The native track/fill pseudo-elements would paint over the sliding block, so make them transparent and let the element's own background show through. */
+	.progress:indeterminate::-webkit-progress-bar,
+	.progress:indeterminate::-webkit-progress-value,
+	.prose progress:indeterminate::-webkit-progress-bar,
+	.prose progress:indeterminate::-webkit-progress-value {
 		background: transparent;
 	}
 
-	.progress.indeterminate::-moz-progress-bar {
+	.progress:indeterminate::-moz-progress-bar,
+	.prose progress:indeterminate::-moz-progress-bar {
 		background: transparent;
 	}
 
-	/* Honour reduced-motion: hold the band centred rather than looping. */
+	/* Honour reduced-motion: hold the block centred rather than looping. */
 	@media (prefers-reduced-motion: reduce) {
-		.progress.indeterminate {
+		.progress:indeterminate,
+		.prose progress:indeterminate {
 			animation: none;
 			background-position: 50% 0;
 		}

--- a/modules/ui/form/Progress.module.css
+++ b/modules/ui/form/Progress.module.css
@@ -42,7 +42,7 @@
 		background-image: linear-gradient(90deg, var(--progress-color, var(--tint-50)), var(--progress-color, var(--tint-50)));
 		background-repeat: no-repeat;
 		background-size: 40% 100%;
-		animation: progress-flow var(--progress-duration, 1.5s) ease-in-out infinite;
+		animation: progress-flow var(--progress-duration, 1.5s) linear infinite;
 	}
 
 	/* The native track/fill pseudo-elements would paint over the flowing band, so make them transparent and let the element's own background show through. */
@@ -64,13 +64,13 @@
 	}
 }
 
-/* Slide the fill band from just off the left edge to just off the right edge. */
+/* Conveyor the block fully off the left edge, across, and fully off the right — then it loops back round unseen. `-70%`/`170%` fully clear a `40%`-wide block, and `linear` timing keeps a constant speed with no ease-out stall at the ends. */
 @keyframes progress-flow {
 	from {
-		background-position: -50% 0;
+		background-position: -70% 0;
 	}
 
 	to {
-		background-position: 150% 0;
+		background-position: 170% 0;
 	}
 }

--- a/modules/ui/form/Progress.module.css
+++ b/modules/ui/form/Progress.module.css
@@ -34,4 +34,43 @@
 	.progress::-moz-progress-bar {
 		background: var(--progress-color, var(--tint-50));
 	}
+
+	/* Indeterminate — no `value`, so a band of fill colour flows left-to-right across the track on a loop for a task of unknown duration. */
+	.progress.indeterminate {
+		/* Track underneath, plus a flowing band of fill colour painted as a moving gradient across the element itself. */
+		background-color: var(--progress-background, var(--tint-90));
+		background-image: linear-gradient(90deg, transparent, var(--progress-color, var(--tint-50)), transparent);
+		background-repeat: no-repeat;
+		background-size: 40% 100%;
+		animation: progress-flow var(--progress-duration, 1.5s) ease-in-out infinite;
+	}
+
+	/* The native track/fill pseudo-elements would paint over the flowing band, so make them transparent and let the element's own background show through. */
+	.progress.indeterminate::-webkit-progress-bar,
+	.progress.indeterminate::-webkit-progress-value {
+		background: transparent;
+	}
+
+	.progress.indeterminate::-moz-progress-bar {
+		background: transparent;
+	}
+
+	/* Honour reduced-motion: hold the band centred rather than looping. */
+	@media (prefers-reduced-motion: reduce) {
+		.progress.indeterminate {
+			animation: none;
+			background-position: 50% 0;
+		}
+	}
+}
+
+/* Slide the fill band from just off the left edge to just off the right edge. */
+@keyframes progress-flow {
+	from {
+		background-position: -50% 0;
+	}
+
+	to {
+		background-position: 150% 0;
+	}
 }

--- a/modules/ui/form/Progress.module.css
+++ b/modules/ui/form/Progress.module.css
@@ -37,9 +37,9 @@
 
 	/* Indeterminate — no `value`, so a band of fill colour flows left-to-right across the track on a loop for a task of unknown duration. */
 	.progress.indeterminate {
-		/* Track underneath, plus a flowing band of fill colour painted as a moving gradient across the element itself. */
+		/* Track underneath, plus a solid block of fill colour that slides across the element itself — hard edges, no blended fade. */
 		background-color: var(--progress-background, var(--tint-90));
-		background-image: linear-gradient(90deg, transparent, var(--progress-color, var(--tint-50)), transparent);
+		background-image: linear-gradient(90deg, var(--progress-color, var(--tint-50)), var(--progress-color, var(--tint-50)));
 		background-repeat: no-repeat;
 		background-size: 40% 100%;
 		animation: progress-flow var(--progress-duration, 1.5s) ease-in-out infinite;

--- a/modules/ui/form/Progress.tsx
+++ b/modules/ui/form/Progress.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { formatPercent } from "../../util/format.js";
+import { type Nullish, notNullish } from "../../util/null.js";
 import { type ColorVariants, getColorClass } from "../style/Color.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
 import { getClass, getModuleClass } from "../util/css.js";
@@ -11,11 +12,10 @@ import styles from "./Progress.module.css";
  * @see https://shelving.cc/ui/ProgressProps
  */
 export interface ProgressProps extends ColorVariants, StatusVariants {
-	value: number;
+	/** Position within the `min`–`max` range, or `null`/`undefined`/omitted for an indeterminate bar. */
+	value?: Nullish<number>;
 	min?: number;
 	max?: number;
-	/** Ignore `value` and show a looping flow animation for an ongoing task whose duration isn't known. */
-	indeterminate?: boolean | undefined;
 }
 
 /**
@@ -23,32 +23,31 @@ export interface ProgressProps extends ColorVariants, StatusVariants {
  * - Renders a native `<progress>` element, so `role="progressbar"` and the value/max semantics come from the browser.
  * - `<progress>` has no `min` attribute (its implicit minimum is `0`), so the range is normalised to `value - min` / `max - min` before it's handed to the element.
  * - The browser clamps `value` to the `0`–`max` range, so an out-of-range `value` shows an empty or full bar rather than overspilling.
- * - Pass `indeterminate` to drop `value` entirely — the element becomes natively indeterminate (no `aria-valuenow`) and a band of fill colour flows across the track on a loop.
+ * - Omit `value` (or pass `null`/`undefined`) to drop the attribute entirely — exactly as a native `<progress>` does, the element becomes `:indeterminate` (no `aria-valuenow`) and a block of fill colour flows across the track on a loop.
  * - Paints from the tint ladder, so `color=` / `status=` recolour the fill (and track) by moving the tint anchor.
  *
  * @returns A progress bar element.
  * @kind component
  * @example <Progress value={3} max={4} />
  * @example <Progress value={90} status="success" />
- * @example <Progress value={0} indeterminate />
+ * @example <Progress />
  * @see https://shelving.cc/ui/Progress
  */
-export function Progress({ value, min = 0, max = 100, indeterminate = false, ...props }: ProgressProps): ReactElement {
+export function Progress({ value, min = 0, max = 100, ...props }: ProgressProps): ReactElement {
 	// `<progress>` has no `min`, so shift the range to a `0`-based one. A non-positive span would make `<progress>` indeterminate, so fall back to an empty determinate bar.
 	const span = max - min;
-	const fill = span > 0 ? value - min : 0;
 
 	return (
 		<progress
 			className={getClass(
-				getModuleClass(styles, "progress", { indeterminate }), //
+				getModuleClass(styles, "progress"), //
 				getColorClass(props),
 				getStatusClass(props),
 			)}
-			// Indeterminate omits `value` (and its announced text) so the element is natively indeterminate and the flowing `.indeterminate` animation takes over.
-			value={indeterminate ? undefined : fill}
+			// A nullish `value` drops the attribute (and its announced text) so the element is natively `:indeterminate` and the flowing animation styled off that pseudo-class takes over.
+			value={notNullish(value) ? (span > 0 ? value - min : 0) : undefined}
 			max={span > 0 ? span : 1}
-			aria-valuetext={indeterminate ? undefined : formatPercent(value - min, max - min)}
+			aria-valuetext={notNullish(value) ? formatPercent(value - min, max - min) : undefined}
 		/>
 	);
 }

--- a/modules/ui/form/Progress.tsx
+++ b/modules/ui/form/Progress.tsx
@@ -14,6 +14,8 @@ export interface ProgressProps extends ColorVariants, StatusVariants {
 	value: number;
 	min?: number;
 	max?: number;
+	/** Ignore `value` and show a looping flow animation for an ongoing task whose duration isn't known. */
+	indeterminate?: boolean | undefined;
 }
 
 /**
@@ -21,28 +23,32 @@ export interface ProgressProps extends ColorVariants, StatusVariants {
  * - Renders a native `<progress>` element, so `role="progressbar"` and the value/max semantics come from the browser.
  * - `<progress>` has no `min` attribute (its implicit minimum is `0`), so the range is normalised to `value - min` / `max - min` before it's handed to the element.
  * - The browser clamps `value` to the `0`–`max` range, so an out-of-range `value` shows an empty or full bar rather than overspilling.
+ * - Pass `indeterminate` to drop `value` entirely — the element becomes natively indeterminate (no `aria-valuenow`) and a band of fill colour flows across the track on a loop.
  * - Paints from the tint ladder, so `color=` / `status=` recolour the fill (and track) by moving the tint anchor.
  *
  * @returns A progress bar element.
  * @kind component
  * @example <Progress value={3} max={4} />
  * @example <Progress value={90} status="success" />
+ * @example <Progress value={0} indeterminate />
  * @see https://shelving.cc/ui/Progress
  */
-export function Progress({ value, min = 0, max = 100, ...props }: ProgressProps): ReactElement {
+export function Progress({ value, min = 0, max = 100, indeterminate = false, ...props }: ProgressProps): ReactElement {
 	// `<progress>` has no `min`, so shift the range to a `0`-based one. A non-positive span would make `<progress>` indeterminate, so fall back to an empty determinate bar.
 	const span = max - min;
+	const fill = span > 0 ? value - min : 0;
 
 	return (
 		<progress
 			className={getClass(
-				getModuleClass(styles, "progress"), //
+				getModuleClass(styles, "progress", { indeterminate }), //
 				getColorClass(props),
 				getStatusClass(props),
 			)}
-			value={span > 0 ? value - min : 0}
+			// Indeterminate omits `value` (and its announced text) so the element is natively indeterminate and the flowing `.indeterminate` animation takes over.
+			value={indeterminate ? undefined : fill}
 			max={span > 0 ? span : 1}
-			aria-valuetext={formatPercent(value - min, max - min)}
+			aria-valuetext={indeterminate ? undefined : formatPercent(value - min, max - min)}
 		/>
 	);
 }


### PR DESCRIPTION
Adds support for an indeterminate state to the `Progress` component for displaying ongoing tasks with unknown duration.

## Summary
The Progress component now supports an `indeterminate` prop that displays a looping animation instead of a determinate fill. When enabled, the component shows a band of color flowing across the track continuously, with the animation respecting `prefers-reduced-motion` by holding a centered band instead.

## Key Changes
- **Component API**: Added `indeterminate` boolean prop to `ProgressProps` that omits the `value` attribute and `aria-valuetext` to make the element natively indeterminate
- **Styling**: Implemented indeterminate animation using CSS `background-position` keyframes that flow a 40%-wide fill band across the track over a configurable duration (default 1.5s)
- **Accessibility**: Respects `prefers-reduced-motion` by replacing the looping animation with a static centered band
- **Theming**: Indeterminate state still respects `color=` and `status=` props for consistent styling, and introduces `--progress-duration` CSS variable for animation timing
- **Documentation**: Updated component docs with indeterminate usage examples and CSS variable reference

## Implementation Details
- The indeterminate animation uses `background-image` with `linear-gradient` and `background-position` keyframes to create the flowing effect, avoiding pseudo-element conflicts
- Native progress pseudo-elements (`::-webkit-progress-bar`, `::-webkit-progress-value`, `::-moz-progress-bar`) are made transparent in indeterminate mode to let the element's background show through
- The keyframe animation moves the background from `-70%` to `170%` to fully clear a 40%-wide block off both edges before looping

https://claude.ai/code/session_01C6ik6wx4DvWJJBEYmTkmnq