### PR TITLE
feat: add shadow variant to Card and trim shadow scale

### DIFF
--- a/modules/ui/block/Card.md
+++ b/modules/ui/block/Card.md
@@ -7,7 +7,8 @@ A boxed surface that groups a self-contained piece of content. Rendered as an `<
 - Set `href` or `onClick` to make the whole card navigable — a stretched, visually-hidden overlay `<a>` / `<button>` covers the card while the children render normally inside. Real interactive elements inside the card (inline links, buttons) stay clickable and keyboard-focusable.
 - `color=` and `status=` move the tint anchor for the card's scope, so the surface, border, text, and hover shade all re-derive together — and nested components (`<Tag>`, `<Preformatted>`, `<Button>`) inherit the same tint.
 - A card styles only the box. Lay out its contents with the usual block components (`<Subheading>`, `<Paragraph>`, `<Row>`, …).
-- Composes the standard styling variants: `color`, `status`, `padding`, `space`, `width`, plus typography.
+- Cards carry a `normal` drop shadow by default — set `shadow="none"` to flatten a given card, or `shadow="small"` / `shadow="large"` to adjust its elevation.
+- Composes the standard styling variants: `color`, `status`, `padding`, `space`, `width`, `shadow`, plus typography.
 
 ## Usage
 
@@ -43,6 +44,16 @@ import { Card, Subheading } from "shelving/ui";
 <Card color="purple" padding="large" space="none"><Subheading>Featured</Subheading></Card>
 ```
 
+### Shadow
+
+```tsx
+import { Card, Subheading } from "shelving/ui";
+
+// Flatten one card; raise another.
+<Card shadow="none"><Subheading>Flat</Subheading></Card>
+<Card shadow="large"><Subheading>Raised</Subheading></Card>
+```
+
 ## Styling
 
 `Card` paints from the [tint ladder](/ui/TINT_CLASS); override these hooks at `:root` (or any ancestor scope) to retheme. Apply `color=` / `status=` (on the card or an ancestor scope) to recolour everything at once — surface, border, text, and hover shade re-derive together; reach for a per-property hook for a single surgical change.
@@ -57,19 +68,20 @@ import { Card, Subheading } from "shelving/ui";
 | `--card-radius` | Corner radius | `var(--radius-normal)` (16px) |
 | `--card-padding` | Inner padding | `var(--space-normal)` (16px) |
 | `--card-space` | Outer block margin (top + bottom) | `var(--space-paragraph)` (16px) |
-| `--card-shadow` | Drop shadow | `none` |
+| `--card-shadow` | Drop shadow | `var(--shadow-normal)` |
 | `--card-transition` | Transition | `all var(--duration-fast)` (150ms) |
 | `--card-focus-border` | Focus outline | `var(--stroke-focus) solid var(--color-focus)` |
 
-**Global tokens it reads** — move these to retheme broadly rather than overriding ladder steps directly: the tint ladder `--tint-00` / `--tint-80` / `--tint-90` / `--tint-95`, plus `--space-normal`, `--space-paragraph`, `--radius-normal`, `--stroke-normal`, `--stroke-focus`, `--color-focus`, and `--duration-fast`.
+**Global tokens it reads** — move these to retheme broadly rather than overriding ladder steps directly: the tint ladder `--tint-00` / `--tint-80` / `--tint-90` / `--tint-95`, plus `--space-normal`, `--space-paragraph`, `--radius-normal`, `--shadow-normal`, `--stroke-normal`, `--stroke-focus`, `--color-focus`, and `--duration-fast`.
 
 ```css
-/* Theme: borderless cards with a soft shadow and tighter corners. */
+/* Theme: flat cards with tighter corners. */
 :root {
-  --card-border: none;
-  --card-shadow: var(--shadow-small);
+  --card-shadow: none;
   --card-radius: var(--radius-small);
 }
 ```
+
+The `--card-shadow` hook sets the app-wide default; the `shadow=` variant prop wins over it on a per-card basis.
 
 To recolour cards, apply `color=` / `status=` to the card (or a tinted ancestor scope) — e.g. `<Card color="purple">` — rather than a per-component tint hook.

--- a/modules/ui/block/Card.module.css
+++ b/modules/ui/block/Card.module.css
@@ -2,6 +2,7 @@
 @import url("../style/Color.module.css");
 @import url("../style/Duration.module.css");
 @import url("../style/Radius.module.css");
+@import url("../style/Shadow.module.css");
 @import url("../style/Space.module.css");
 @import url("../style/Stroke.module.css");
 @import url("../style/Tint.module.css");
@@ -30,7 +31,7 @@
 		/* Style */
 		background: var(--card-background, var(--tint-90));
 		color: var(--card-color, var(--tint-00));
-		box-shadow: var(--card-shadow, none);
+		box-shadow: var(--card-shadow, var(--shadow-normal));
 		transition: var(--card-transition, all var(--duration-fast));
 		outline: var(--card-focus-border, var(--stroke-focus) solid var(--color-focus));
 		outline-offset: calc(0px - var(--card-stroke, var(--stroke-normal)));

--- a/modules/ui/block/Card.tsx
+++ b/modules/ui/block/Card.tsx
@@ -1,17 +1,18 @@
 import type { ReactElement } from "react";
 import { Clickable, type ClickableProps } from "../button/Clickable.js";
 import { type BlockVariants, getBlockClass } from "../style/Block.js";
+import { getShadowClass, type ShadowVariants } from "../style/Shadow.js";
 import { getStatusClass, type StatusVariants } from "../style/Status.js";
 import { getClass, getModuleClass } from "../util/css.js";
 import type { BlockElement } from "./Block.js";
 import CARD_CSS from "./Card.module.css";
 
 /**
- * Props for `Card` — combines `ClickableProps` (for navigable cards) with colour, status, padding, space, typography, and width variants.
+ * Props for `Card` — combines `ClickableProps` (for navigable cards) with colour, status, padding, space, typography, width, and shadow variants.
  *
  * @see https://shelving.cc/ui/CardProps
  */
-export interface CardProps extends ClickableProps, StatusVariants, BlockVariants {
+export interface CardProps extends ClickableProps, StatusVariants, BlockVariants, ShadowVariants {
 	/**
 	 * Element this `<Card>` renders as, e.g. "header" to output a "<header>"
 	 * @default "article"
@@ -25,6 +26,7 @@ export interface CardProps extends ClickableProps, StatusVariants, BlockVariants
  * - When `href` or `onClick` is set the card becomes navigable: a stretched overlay `<a>` / `<button>` covers the entire card while the children render normally inside.
  * - Real interactive elements inside the card (e.g. inline `<a>` links) stay clickable thanks to `position: relative; z-index: 2` rules in the stylesheet.
  * - Accepts a `status` colour and raw `ColorProps` — the card styles the box; lay out its contents however the use case needs.
+ * - Carries a `normal` drop shadow by default — set `shadow="none"` to flatten a card, or `shadow="small"` / `shadow="large"` to adjust its elevation.
  *
  * @kind component
  * @see https://shelving.cc/ui/Card
@@ -39,6 +41,7 @@ export function Card({ as: Element = "article", children, href, onClick, title =
 				getModuleClass(CARD_CSS, "card"), //
 				getStatusClass(props),
 				getBlockClass(props),
+				getShadowClass(props),
 			)}
 		>
 			{overlay}

--- a/modules/ui/style/Shadow.module.css
+++ b/modules/ui/style/Shadow.module.css
@@ -6,13 +6,9 @@
 		--shadow-color: #0006;
 
 		/* Shadows — elevation drop-shadows. */
-		--shadow-xxsmall: 0 0.125rem 0.5rem -0.25rem var(--shadow-color);
-		--shadow-xsmall: 0 0.25rem 1rem -0.5rem var(--shadow-color);
 		--shadow-small: 0 0.375rem 1.5rem -0.75rem var(--shadow-color);
 		--shadow-normal: 0 0.5rem 2rem -1rem var(--shadow-color);
 		--shadow-large: 0 0.75rem 3rem -1.5rem var(--shadow-color);
-		--shadow-xlarge: 0 1rem 4rem -2rem var(--shadow-color);
-		--shadow-xxlarge: 0 1.5rem 6rem -3rem var(--shadow-color);
 	}
 }
 
@@ -20,14 +16,6 @@
 	/* Drop-shadow variants. */
 	.shadow-none {
 		box-shadow: none;
-	}
-
-	.shadow-xxsmall {
-		box-shadow: var(--shadow-xxsmall);
-	}
-
-	.shadow-xsmall {
-		box-shadow: var(--shadow-xsmall);
 	}
 
 	.shadow-small {
@@ -40,13 +28,5 @@
 
 	.shadow-large {
 		box-shadow: var(--shadow-large);
-	}
-
-	.shadow-xlarge {
-		box-shadow: var(--shadow-xlarge);
-	}
-
-	.shadow-xxlarge {
-		box-shadow: var(--shadow-xxlarge);
 	}
 }

--- a/modules/ui/style/Shadow.tsx
+++ b/modules/ui/style/Shadow.tsx
@@ -6,7 +6,7 @@ import SHADOW_CSS from "./Shadow.module.css";
  *
  * @see https://shelving.cc/ui/ShadowVariant
  */
-export type ShadowVariant = "none" | "xxsmall" | "xsmall" | "small" | "normal" | "large" | "xlarge" | "xxlarge";
+export type ShadowVariant = "none" | "small" | "normal" | "large";
 
 /**
  * Variant props for the drop shadow of an element, e.g. `shadow="large"`.

--- a/modules/ui/style/getShadowClass.md
+++ b/modules/ui/style/getShadowClass.md
@@ -8,10 +8,8 @@ The following `:root` variables are defined by this module and can be overridden
 
 | Variable | Default |
 |---|---|
-| `--shadow-xxsmall` | `0 0.125rem 0.5rem -0.25rem #0006` |
-| `--shadow-xsmall` | `0 0.25rem 1rem -0.5rem #0006` |
 | `--shadow-small` | `0 0.375rem 1.5rem -0.75rem #0006` |
 | `--shadow-normal` | `0 0.5rem 2rem -1rem #0006` |
 | `--shadow-large` | `0 0.75rem 3rem -1.5rem #0006` |
-| `--shadow-xlarge` | `0 1rem 4rem -2rem #0006` |
-| `--shadow-xxlarge` | `0 1.5rem 6rem -3rem #0006` |
+
+The `shadow=` variant prop accepts `"none"`, `"small"`, `"normal"`, or `"large"` — `"none"` removes a component's default shadow rather than mapping to a token.


### PR DESCRIPTION
Adds per-card shadow control and slims the drop-shadow scale down to three steps.

## Changes

- **Trim the shadow scale to `small` / `normal` / `large` (plus the `none` keyword).** `ShadowVariant`, the `--shadow-*` tokens in `Shadow.module.css`, and the `.shadow-*` variant classes all drop the `xxsmall` / `xsmall` / `xlarge` / `xxlarge` steps. Nothing else in the library consumed the removed sizes (`Popover` uses `--shadow-small`, `Modal` uses `--shadow-normal` — both kept), and the token values for the surviving steps are unchanged.
- **`Card` now composes `ShadowVariants`.** `CardProps` extends `ShadowVariants` and `Card` applies `getShadowClass(props)`, so `shadow="none"` flattens a given card and `shadow="small"` / `shadow="large"` adjust its elevation. The variant class lives in the `variants` cascade layer, so it beats both the component default and a themed `--card-shadow`.
- **Cards carry a `normal` drop shadow by default.** The component paints `box-shadow: var(--card-shadow, var(--shadow-normal))` (previously the fallback was `none`). The `--card-shadow` hook still sets the app-wide default; the `shadow=` prop wins per card.
- Docs updated in step: `Card.md` (Things to know, new Shadow usage example, Styling table, theme example), `getShadowClass.md` token table, and the `Card.tsx` docblocks.

**Breaking in practice** (kept within the v0 non-major flow): the four removed `--shadow-*` tokens and `ShadowVariant` values are gone, and cards now render with a default shadow unless a theme sets `--card-shadow` or a card sets `shadow="none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReK411cCAHJB4vfCWiguVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReK411cCAHJB4vfCWiguVC)_