### PR TITLE
feat: support block styling variants on Row

### DIFF
--- a/modules/ui/block/Row.tsx
+++ b/modules/ui/block/Row.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { getBlockClass } from "../style/Block.js";
+import { type BlockVariants, getBlockClass } from "../style/Block.js";
 import { type FlexVariants, getFlexClass } from "../style/Flex.js";
 import { getClass } from "../util/css.js";
 import type { OptionalChildProps } from "../util/index.js";
@@ -10,7 +10,7 @@ import type { BlockElement } from "./Block.js";
  *
  * @see https://shelving.cc/ui/RowProps
  */
-export interface RowProps extends FlexVariants, OptionalChildProps {
+export interface RowProps extends BlockVariants, FlexVariants, OptionalChildProps {
 	/**
 	 * Element this `<Row>` renders as, e.g. "header" to output a "<header>"
 	 * @default "div"


### PR DESCRIPTION
RowProps now extends BlockVariants (indent, space, padding, typography,
width) to match ColumnProps. The Row implementation already called
getBlockClass(), so these props were applied at runtime but rejected by
the type signature.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NtFEJno5YsaVMAmZAU36eU