### PR TITLE
feat: support TypeScript 7 in the extractor and toolchain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,12 @@
         "@types/bun": "^1.3.14",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@typescript/native-preview": "^7.0.0-dev.20260706.1",
         "firebase": "^12.15.0",
         "react": "^19.3.0-canary-fef12a01-20260413",
         "react-dom": "^19.3.0-canary-fef12a01-20260413",
         "stylelint": "^17.14.0",
         "stylelint-config-standard": "^40.0.0",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
       },
       "peerDependencies": {
         "@google-cloud/firestore": ">=7.0.0",
@@ -211,21 +210,45 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260706.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260706.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260706.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260706.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260706.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260706.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260706.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260706.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-lm3nzcj+cbml0Pt+0QyOpdhZES9WRj0Fv/fds2GaKSf9wXe8694gy6Fa5D65lRcP6q4HHivlrNqJo8rR5Klzww=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260706.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-l9UTIdxt99UUJ7pe/xWWwjoxr9EnG+Sc2k6FUchQrSK0sFZOlx76+hQm6DvuzWOr+1JEpVP/LGmnx7+qk8Yr3Q=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260706.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-2/ivq1yeOrhNnN+aQhCLtGeqZ90R5v9OaoON4tG0zEJZLy+jIZGnRK6+gbI8lBhKuIVY2pjpHPJxN1VCaBmxGA=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260706.1", "", { "os": "linux", "cpu": "arm" }, "sha512-E2n8tnUcXwY4vRmyEpS8CfpJbK7y5coPtKtqDFtGZHbvWLPoiIP6OhHF5fIPCNMziBclz+5MR86OzxK1jt93YQ=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260706.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-eokiB0dLt8uUeWH2BbwhQZLrGay5quzptTsFs8kh/nFdSF4gYLoBwmpJn/o5YYrQU89T7Mvi4tKPkgo0TCnwIw=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260706.1", "", { "os": "linux", "cpu": "x64" }, "sha512-JwrLUanCkVq+vbSjcc+qMqQN909Jhiy1s671q5vaYmBMLIzlhNSkvWqmHk+8XLt100zcgJDGgv+kHRazDlpPUQ=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260706.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-z75g24yUxktDSnP41t5Y3lV8BbraGyFuRvxhpd5GwXxT/qKQ3bHHcmdTTDSLkn+SRD8fAnnbFqb274UIC4OcCA=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260706.1", "", { "os": "win32", "cpu": "x64" }, "sha512-kWP0dMeCvTN5E4X4lQ7dELxyarnfapY1R9KPwHZdN7mcY67uPYSFTvBHD1+V3Q4dTQHQVIaHDUNOfU6McBo1wA=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -559,7 +582,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/modules/extract/FileExtractor.ts
+++ b/modules/extract/FileExtractor.ts
@@ -35,7 +35,7 @@ export class FileExtractor extends Extractor<BunFile, TreeElement> {
 		const [base = filename] = splitFileExtension(filename);
 
 		const text = await file.text();
-		const props: TreeElementProps = { ...this.extractProps(base, text), source };
+		const props: TreeElementProps = { ...(await this.extractProps(base, text)), source };
 		return {
 			type: "tree-element",
 			key: filename,
@@ -47,15 +47,18 @@ export class FileExtractor extends Extractor<BunFile, TreeElement> {
 	 * Build the file element props from the extracted content.
 	 * - `name` is the basename without extension (e.g. `"array"`) — display-ready, used by menus, cards, and URL paths.
 	 * - Override to parse `text` into richer elements (content/children/description) and to set
-	 *   `title` if a confident title is available.
+	 *   `title` if a confident title is available. Overrides may be async (e.g. `TypescriptExtractor` parses via the native compiler server) — `extract()` awaits the result either way.
 	 *
 	 * @param name The basename of the file without extension (e.g. `"array"`).
 	 * @param content The raw text content of the file.
-	 * @returns The element props, always including a `name`; the base implementation stores `content` verbatim.
+	 * @returns The element props (or a promise resolving to them), always including a `name`; the base implementation stores `content` verbatim.
 	 * @example extractProps("notes", "Some text") // { name: "notes", content: "Some text" }
 	 * @see https://shelving.cc/extract/FileExtractor/extractProps
 	 */
-	extractProps(name: string, content: string): Partial<TreeElementProps> & { name: string } {
+	extractProps(
+		name: string,
+		content: string,
+	): (Partial<TreeElementProps> & { name: string }) | Promise<Partial<TreeElementProps> & { name: string }> {
 		return { name, content };
 	}
 }

--- a/modules/extract/TypescriptExtractor.ts
+++ b/modules/extract/TypescriptExtractor.ts
@@ -1,5 +1,48 @@
-import ts from "typescript";
+import {
+	type ClassDeclaration,
+	type ConstructorDeclaration,
+	getTextOfJSDocComment,
+	isArrayBindingPattern,
+	isBindingElement,
+	isClassDeclaration,
+	isConstructorDeclaration,
+	isEnumDeclaration,
+	isFunctionDeclaration,
+	isGetAccessorDeclaration,
+	isIdentifier,
+	isInterfaceDeclaration,
+	isJSDoc,
+	isJSDocParameterTag,
+	isJSDocReturnTag,
+	isJSDocSeeTag,
+	isJSDocThrowsTag,
+	isJSDocTypeExpression,
+	isMethodDeclaration,
+	isMethodSignatureDeclaration,
+	isObjectBindingPattern,
+	isPropertyDeclaration,
+	isPropertySignatureDeclaration,
+	isSetAccessorDeclaration,
+	isTypeAliasDeclaration,
+	isTypeLiteralNode,
+	isTypeReferenceNode,
+	isVariableStatement,
+	type Modifier,
+	type ModifierLike,
+	type Node,
+	type NodeArray,
+	type ParameterDeclaration,
+	type SourceFile,
+	type Statement,
+	SyntaxKind,
+	type TypeElement,
+	type TypeNode,
+} from "typescript/unstable/ast";
+import { API } from "typescript/unstable/async";
+import type { FileSystem } from "typescript/unstable/fs";
+import { ValueError } from "../error/ValueError.js";
 import type { ImmutableArray } from "../util/array.js";
+import { BLACKHOLE } from "../util/function.js";
 import type {
 	DocumentationElement,
 	DocumentationElementProps,
@@ -14,7 +57,8 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
 
 /**
  * File extractor that parses a TypeScript source file into a tree element.
- * - Uses the TypeScript compiler API to parse the AST.
+ * - Uses the native TypeScript compiler's API (`typescript/unstable/async` — TypeScript 7+) to parse the AST.
+ * - Parsing runs on a shared native compiler server, spawned on demand into a virtual filesystem and closed again after a short idle — callers never manage its lifecycle.
  * - Extracts exported, public, non-`_`-prefixed declarations as `tree-documentation` children.
  * - Overloaded declarations sharing a name are merged into a single `tree-documentation` with multiple `signatures`. When a function (or constructor) is overloaded, the implementation declaration (the "base definition") is dropped entirely — only the overload signatures are documented.
  * - A `@param name {Type}` (or `@returns {Type}`) whose `{Type}` is given is canonical: it supersedes the inferred type from the base definition and any overloads. Multiple `@param name` tags for one parameter each emit a row, letting a single parameter be documented as several typed variants.
@@ -30,26 +74,26 @@ import { extractMarkdownProps } from "./MarkupExtractor.js";
  * - Keys are the raw declared `name` (case-preserving) so case-distinct exports like `Collection` and `COLLECTION` stay separate.
  * - The file element itself has no `title` — a TS source file has no confident title source; renderers fall back to `name`.
  *
- * @example const element = new TypescriptExtractor().extractProps("string.ts", sourceText);
+ * @example const element = await new TypescriptExtractor().extractProps("string.ts", sourceText);
  *
  * @see https://shelving.cc/extract/TypescriptExtractor
  */
 export class TypescriptExtractor extends FileExtractor {
 	/** Parses the TypeScript source into one `tree-documentation` child per exported public declaration. */
-	override extractProps(name: string, text: string): Partial<TreeElementProps> & { name: string } {
-		const source = ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);
+	override async extractProps(name: string, text: string): Promise<Partial<TreeElementProps> & { name: string }> {
+		const source = await _parseSourceFile(text);
 
 		// Names with one or more overload signatures (bodyless function declarations). When a function is overloaded, the
 		// implementation declaration (the one with a body — the "base definition") is dropped entirely; only the overloads are documented.
 		const overloaded = new Set<string>();
 		for (const statement of source.statements)
-			if (ts.isFunctionDeclaration(statement) && !statement.body && statement.name) overloaded.add(statement.name.text);
+			if (isFunctionDeclaration(statement) && !statement.body && statement.name) overloaded.add(statement.name.text);
 
 		// Collect elements by key, merging overloads (same name) by appending signatures.
 		const byKey = new Map<string, DocumentationElement>();
 		for (const statement of source.statements) {
 			// Skip the implementation of an overloaded function — overloads supersede the base definition.
-			if (ts.isFunctionDeclaration(statement) && statement.body && statement.name && overloaded.has(statement.name.text)) continue;
+			if (isFunctionDeclaration(statement) && statement.body && statement.name && overloaded.has(statement.name.text)) continue;
 			const element = _extractStatement(statement, source);
 			if (!element) continue;
 			const existing = byKey.get(element.key);
@@ -60,6 +104,122 @@ export class TypescriptExtractor extends FileExtractor {
 		// `description` / `content`: file-level prose lives in the sibling README / `.md`, which the merge step folds onto this element.
 		return { name, children: Array.from(byKey.values()) };
 	}
+}
+
+// Constants.
+const _DIR = "/shelving-typescript-extractor";
+const _TSCONFIG_PATH = `${_DIR}/tsconfig.json`;
+const _TSCONFIG_JSON = JSON.stringify({ compilerOptions: { noEmit: true }, include: ["**/*.ts"] });
+const _IDLE_CLOSE_MS = 500;
+
+/** Shared native compiler server plus the virtual files it can see. */
+interface _Server {
+	readonly api: API;
+	readonly files: Map<string, string>;
+}
+
+let _server: _Server | undefined;
+let _queue: Promise<unknown> = Promise.resolve();
+let _timer: ReturnType<typeof setTimeout> | undefined;
+let _count = 0;
+let _previous: string | undefined;
+
+/** Is a path inside the virtual directory the compiler server is rooted in? */
+function _isVirtual(path: string): boolean {
+	return path === _DIR || path.startsWith(`${_DIR}/`);
+}
+
+/** Get the shared compiler server, spawning it on demand with a virtual filesystem rooted at `_DIR`. */
+function _getServer(): _Server {
+	if (_server) return _server;
+	const files = new Map<string, string>([[_TSCONFIG_PATH, _TSCONFIG_JSON]]);
+	// Paths outside the virtual directory return `undefined` so the server falls back to the real filesystem (e.g. bundled libs).
+	const fs: FileSystem = {
+		fileExists: f => (_isVirtual(f) ? files.has(f) : undefined),
+		readFile: f => (_isVirtual(f) ? (files.get(f) ?? null) : undefined),
+		directoryExists: d => (d === _DIR ? true : _isVirtual(d) ? false : undefined),
+		getAccessibleEntries: d =>
+			d === _DIR
+				? { files: Array.from(files.keys(), f => f.slice(_DIR.length + 1)), directories: [] }
+				: _isVirtual(d)
+					? { files: [], directories: [] }
+					: undefined,
+		realpath: p => (_isVirtual(p) ? p : undefined),
+	};
+	_server = { api: new API({ cwd: _DIR, fs }), files };
+	return _server;
+}
+
+/** Close the shared compiler server after a short idle, so the process can exit without callers managing the lifecycle. */
+function _scheduleClose(): void {
+	if (_timer) clearTimeout(_timer);
+	_timer = setTimeout(() => {
+		const server = _server;
+		_server = undefined;
+		_previous = undefined;
+		_timer = undefined;
+		try {
+			server?.api.close();
+		} catch {
+			// Closing can reject in-flight bookkeeping requests — harmless on shutdown.
+		}
+	}, _IDLE_CLOSE_MS);
+}
+
+/**
+ * Parse TypeScript source text into a `SourceFile` via the shared native compiler server.
+ * - Each call writes the text as a fresh virtual file, snapshots the project, and materialises the file's AST.
+ * - Calls are serialised through a queue so concurrent extractions don't interleave snapshot updates.
+ *
+ * @throws `ValueError` If the server fails to produce a source file for the text.
+ */
+function _parseSourceFile(text: string): Promise<SourceFile> {
+	const task = async (): Promise<SourceFile> => {
+		if (_timer) clearTimeout(_timer);
+		const { api, files } = _getServer();
+		const path = `${_DIR}/${_count++}.ts`;
+		files.set(path, text);
+		// Drop the previous parse's file so the virtual project stays a single file (keeps snapshots cheap).
+		const deleted = _previous;
+		if (deleted) files.delete(deleted);
+		_previous = path;
+		const snapshot = await api.updateSnapshot({
+			openProjects: [_TSCONFIG_PATH],
+			fileChanges: { created: [path], ...(deleted ? { deleted: [deleted] } : {}) },
+		});
+		try {
+			const source = await snapshot.getProject(_TSCONFIG_PATH)?.program.getSourceFile(path);
+			if (!source) throw new ValueError("Unable to parse TypeScript source", { received: text });
+			return source;
+		} finally {
+			snapshot.dispose();
+			_scheduleClose();
+		}
+	};
+	const result = _queue.then(task, task);
+	_queue = result.catch(BLACKHOLE);
+	return result;
+}
+
+/** Read a node's modifiers (excluding decorators), or `undefined` when it has none. */
+function _getModifiers(node: Node): readonly Modifier[] | undefined {
+	const modifiers = (node as Node & { modifiers?: NodeArray<ModifierLike> }).modifiers;
+	const filtered = modifiers?.filter((m): m is Modifier => m.kind !== SyntaxKind.Decorator);
+	return filtered?.length ? filtered : undefined;
+}
+
+/** Get a member's declared identifier name, or `undefined` for computed / private / missing names. */
+function _getMemberName(member: Node): string | undefined {
+	// Class/type member bases don't surface `name` structurally — read it off the node and narrow.
+	const { name } = member as Node & { name?: Node | undefined };
+	return name && isIdentifier(name) ? name.text : undefined;
+}
+
+/** Get the text of a JSDoc tag's `{Type}` expression — unwraps a `JSDocTypeExpression` to its inner type. */
+function _getJSDocTypeText(typeExpression: TypeNode | undefined, source: SourceFile): string | undefined {
+	if (!typeExpression) return;
+	const type = isJSDocTypeExpression(typeExpression) ? typeExpression.type : typeExpression;
+	return type.getText(source);
 }
 
 /** Merge a newly-extracted overload into the existing documentation element with the same key. */
@@ -108,7 +268,7 @@ function _concatUnique<T>(
 }
 
 /** Extract an element from a top-level statement, or return undefined if it should be skipped. */
-function _extractStatement(statement: ts.Statement, source: ts.SourceFile): DocumentationElement | undefined {
+function _extractStatement(statement: Statement, source: SourceFile): DocumentationElement | undefined {
 	// Skip non-exported statements.
 	if (!_isExported(statement)) return;
 
@@ -162,18 +322,18 @@ function _extractStatement(statement: ts.Statement, source: ts.SourceFile): Docu
 
 /** Extract the `extends` (single base type) and `implements` (interface list) heritage from a class or interface declaration, as full type text including any generic arguments (e.g. `AbstractStore<string>`, `Omit<StringSchemaOptions, "value">`). */
 function _getHeritage(
-	statement: ts.Statement,
-	source: ts.SourceFile,
+	statement: Statement,
+	source: SourceFile,
 ): { extends: string | undefined; implements: ImmutableArray<string> | undefined } | undefined {
-	if (!ts.isClassDeclaration(statement) && !ts.isInterfaceDeclaration(statement)) return;
+	if (!isClassDeclaration(statement) && !isInterfaceDeclaration(statement)) return;
 	let extendsName: string | undefined;
 	const implementsNames: string[] = [];
 	for (const clause of statement.heritageClauses ?? []) {
 		// Full text — keep generic arguments (`Foo<T>`) and wrappers (`Omit<…>`) intact; render-time lookup trims them to the bare name to resolve a link.
 		const names = clause.types.map(t => t.getText(source));
 		// `extends` keeps the first base type; an interface extending several still surfaces its primary base.
-		if (clause.token === ts.SyntaxKind.ExtendsKeyword) extendsName ??= names[0];
-		else if (clause.token === ts.SyntaxKind.ImplementsKeyword) implementsNames.push(...names);
+		if (clause.token === SyntaxKind.ExtendsKeyword) extendsName ??= names[0];
+		else if (clause.token === SyntaxKind.ImplementsKeyword) implementsNames.push(...names);
 	}
 	if (!extendsName && !implementsNames.length) return;
 	return { extends: extendsName, implements: implementsNames.length ? implementsNames : undefined };
@@ -185,13 +345,13 @@ function _getHeritage(
  * - Primitive keyword types (`string`, `number`, …) aren't type references so they're naturally excluded; the alias's own generic parameters are filtered out explicitly.
  * - Order-preserving and de-duplicated. Unresolved names (builtins like `Record`, externals) simply stay as plain text at render time.
  */
-function _getReferencedTypes(statement: ts.Statement, source: ts.SourceFile): ImmutableArray<string> | undefined {
-	if (!ts.isTypeAliasDeclaration(statement)) return;
+function _getReferencedTypes(statement: Statement, source: SourceFile): ImmutableArray<string> | undefined {
+	if (!isTypeAliasDeclaration(statement)) return;
 	const generics = new Set(statement.typeParameters?.map(t => t.name.text) ?? []);
 	const names: string[] = [];
 	const seen = new Set<string>();
-	const visit = (node: ts.Node): void => {
-		if (ts.isTypeReferenceNode(node)) {
+	const visit = (node: Node): void => {
+		if (isTypeReferenceNode(node)) {
 			const name = node.typeName.getText(source);
 			if (!generics.has(name) && !seen.has(name)) {
 				seen.add(name);
@@ -211,41 +371,42 @@ function _getReferencedTypes(statement: ts.Statement, source: ts.SourceFile): Im
  * - Skips private/protected, `_`-prefixed, `override`, and `declare` members. Optionality comes from a `?` token; defaults from a class-field initializer or a member's `@default` JSDoc; descriptions from each member's own JSDoc.
  * - Getters/setters fold into a single entry per name (the getter's type wins for a get/set pair).
  */
-function _getProperties(statement: ts.Statement, source: ts.SourceFile): ImmutableArray<DocumentationParam> | undefined {
+function _getProperties(statement: Statement, source: SourceFile): ImmutableArray<DocumentationParam> | undefined {
 	const members =
-		ts.isInterfaceDeclaration(statement) || ts.isClassDeclaration(statement)
+		isInterfaceDeclaration(statement) || isClassDeclaration(statement)
 			? statement.members
-			: ts.isTypeAliasDeclaration(statement) && ts.isTypeLiteralNode(statement.type)
+			: isTypeAliasDeclaration(statement) && isTypeLiteralNode(statement.type)
 				? statement.type.members
 				: undefined;
 	if (!members) return;
 	const properties: DocumentationParam[] = [];
 	for (const member of members) {
-		const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+		const name = _getMemberName(member);
 		if (!name || name.startsWith("_")) continue;
-		const modifiers = ts.canHaveModifiers(member) ? ts.getModifiers(member) : undefined;
+		const modifiers = _getModifiers(member);
 		// Skip private/protected (not public API), `override` (documented on the base class), and `declare` (ambient re-declarations).
-		if (modifiers?.some(m => m.kind === ts.SyntaxKind.PrivateKeyword || m.kind === ts.SyntaxKind.ProtectedKeyword)) continue;
-		if (modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword || m.kind === ts.SyntaxKind.DeclareKeyword)) continue;
+		if (modifiers?.some(m => m.kind === SyntaxKind.PrivateKeyword || m.kind === SyntaxKind.ProtectedKeyword)) continue;
+		if (modifiers?.some(m => m.kind === SyntaxKind.OverrideKeyword || m.kind === SyntaxKind.DeclareKeyword)) continue;
 		const jsDoc = _getJSDoc(member, source);
-		if (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) {
+		if (isPropertySignatureDeclaration(member) || isPropertyDeclaration(member)) {
 			// A class field's initializer is its default; otherwise fall back to an explicit `@default` tag.
-			const def = (ts.isPropertyDeclaration(member) ? member.initializer?.getText(source) : undefined) ?? jsDoc?.default;
+			const def = (isPropertyDeclaration(member) ? member.initializer?.getText(source) : undefined) ?? jsDoc?.default;
 			properties.push({
 				name,
 				type: member.type?.getText(source),
 				description: jsDoc?.description,
-				optional: !!member.questionToken,
+				// Optionality is a `?` postfix token (the postfix slot also carries `!` definite-assignment, which isn't optionality).
+				optional: member.postfixToken?.kind === SyntaxKind.QuestionToken,
 				default: def,
-				readonly: modifiers?.some(m => m.kind === ts.SyntaxKind.ReadonlyKeyword) || undefined,
+				readonly: modifiers?.some(m => m.kind === SyntaxKind.ReadonlyKeyword) || undefined,
 			});
-		} else if (ts.isGetAccessor(member) || ts.isSetAccessor(member)) {
-			const type = ts.isGetAccessor(member) ? member.type?.getText(source) : member.parameters[0]?.type?.getText(source);
+		} else if (isGetAccessorDeclaration(member) || isSetAccessorDeclaration(member)) {
+			const type = isGetAccessorDeclaration(member) ? member.type?.getText(source) : member.parameters[0]?.type?.getText(source);
 			const index = properties.findIndex(p => p.name === name);
 			const found = index >= 0 ? properties[index] : undefined;
 			// Fold a get/set pair into one entry: the getter's declared type wins, and the matching setter clears read-only.
 			if (found) {
-				properties[index] = { ...found, type: ts.isGetAccessor(member) && type ? type : found.type, readonly: undefined };
+				properties[index] = { ...found, type: isGetAccessorDeclaration(member) && type ? type : found.type, readonly: undefined };
 			} else {
 				// A lone getter is read-only until a setter is seen; a lone setter is writable.
 				properties.push({
@@ -254,7 +415,7 @@ function _getProperties(statement: ts.Statement, source: ts.SourceFile): Immutab
 					description: jsDoc?.description,
 					optional: false,
 					default: jsDoc?.default,
-					readonly: ts.isGetAccessor(member) || undefined,
+					readonly: isGetAccessorDeclaration(member) || undefined,
 				});
 			}
 		}
@@ -274,80 +435,79 @@ function _buildJSDocContent(description: string | undefined, unhandled: string |
 }
 
 /** Check if a statement has an `export` modifier. */
-function _isExported(statement: ts.Statement): boolean {
-	const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
-	return !!modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword);
+function _isExported(statement: Statement): boolean {
+	return !!_getModifiers(statement)?.some(m => m.kind === SyntaxKind.ExportKeyword);
 }
 
 /** Get the declared name of a statement. */
-function _getStatementName(statement: ts.Statement): string | undefined {
+function _getStatementName(statement: Statement): string | undefined {
 	if (
-		ts.isFunctionDeclaration(statement) ||
-		ts.isClassDeclaration(statement) ||
-		ts.isInterfaceDeclaration(statement) ||
-		ts.isTypeAliasDeclaration(statement) ||
-		ts.isEnumDeclaration(statement)
+		isFunctionDeclaration(statement) ||
+		isClassDeclaration(statement) ||
+		isInterfaceDeclaration(statement) ||
+		isTypeAliasDeclaration(statement) ||
+		isEnumDeclaration(statement)
 	) {
 		return statement.name?.text;
 	}
-	if (ts.isVariableStatement(statement)) {
+	if (isVariableStatement(statement)) {
 		const declaration = statement.declarationList.declarations[0];
-		if (declaration && ts.isIdentifier(declaration.name)) return declaration.name.text;
+		if (declaration && isIdentifier(declaration.name)) return declaration.name.text;
 	}
 }
 
 /** Map a statement to its documentation kind. */
-function _getKind(statement: ts.Statement): string | undefined {
-	if (ts.isFunctionDeclaration(statement)) return "function";
-	if (ts.isClassDeclaration(statement)) return "class";
-	if (ts.isInterfaceDeclaration(statement)) return "interface";
-	if (ts.isTypeAliasDeclaration(statement)) return "type";
-	if (ts.isVariableStatement(statement)) return "constant";
+function _getKind(statement: Statement): string | undefined {
+	if (isFunctionDeclaration(statement)) return "function";
+	if (isClassDeclaration(statement)) return "class";
+	if (isInterfaceDeclaration(statement)) return "interface";
+	if (isTypeAliasDeclaration(statement)) return "type";
+	if (isVariableStatement(statement)) return "constant";
 }
 
 /** Get the text signature(s) of a statement — complete, name-prefixed declarations usable as headings. */
-function _getSignatures(statement: ts.Statement, source: ts.SourceFile, name: string): readonly string[] | undefined {
-	if (ts.isFunctionDeclaration(statement)) {
+function _getSignatures(statement: Statement, source: SourceFile, name: string): readonly string[] | undefined {
+	if (isFunctionDeclaration(statement)) {
 		const params = statement.parameters.map(p => p.getText(source)).join(", ");
 		const ret = statement.type ? statement.type.getText(source) : "void";
 		return [`${name}(${params}): ${ret}`];
 	}
-	if (ts.isClassDeclaration(statement)) {
+	if (isClassDeclaration(statement)) {
 		// Synthesise `new ClassName<…>(…)` constructor signatures so a class page reads like a function's.
 		return _getConstructorSignatures(statement, source, name);
 	}
-	if (ts.isInterfaceDeclaration(statement)) {
+	if (isInterfaceDeclaration(statement)) {
 		// Emit a pretty-printed `{ member; member }` block — the same shape a `type` object body produces, distinguished only by the `kind` badge.
 		return [_formatObjectSignature(statement.members, source)];
 	}
-	if (ts.isTypeAliasDeclaration(statement)) {
+	if (isTypeAliasDeclaration(statement)) {
 		// Pretty-print object-literal aliases multi-line like an interface; emit other bodies (`string | null`, mapped types, …) verbatim. The alias name is already the page title.
-		if (ts.isTypeLiteralNode(statement.type)) return [_formatObjectSignature(statement.type.members, source)];
+		if (isTypeLiteralNode(statement.type)) return [_formatObjectSignature(statement.type.members, source)];
 		return [statement.type.getText(source)];
 	}
-	if (ts.isVariableStatement(statement)) {
+	if (isVariableStatement(statement)) {
 		const declaration = statement.declarationList.declarations[0];
 		if (declaration?.type) return [`${name}: ${declaration.type.getText(source)}`];
 	}
 }
 
 /** Pretty-print object-type members as a multi-line `{ … }` block — one member per tab-indented line ending in `;` — or `{}` when empty. */
-function _formatObjectSignature(members: readonly ts.TypeElement[], source: ts.SourceFile): string {
+function _formatObjectSignature(members: readonly TypeElement[], source: SourceFile): string {
 	if (!members.length) return "{}";
 	const lines = members.map(m => `\t${m.getText(source).replace(/;\s*$/, "").trim()};`);
 	return `{\n${lines.join("\n")}\n}`;
 }
 
 /** Render a class's generic parameter names as `<P, R>` (names only, no constraints), or `""` when non-generic. */
-function _getTypeParamNames(statement: ts.ClassDeclaration, source: ts.SourceFile): string {
+function _getTypeParamNames(statement: ClassDeclaration, source: SourceFile): string {
 	const { typeParameters } = statement;
 	if (!typeParameters?.length) return "";
 	return `<${typeParameters.map(t => t.name.getText(source)).join(", ")}>`;
 }
 
 /** Get a class's constructor declarations in source order — when overloaded, only the overload signatures (the implementation, i.e. the base definition, is dropped). */
-function _getConstructors(statement: ts.ClassDeclaration): readonly ts.ConstructorDeclaration[] {
-	const constructors = statement.members.filter(ts.isConstructorDeclaration);
+function _getConstructors(statement: ClassDeclaration): readonly ConstructorDeclaration[] {
+	const constructors = statement.members.filter(isConstructorDeclaration);
 	// When overload signatures exist, drop the implementation constructor (the one with a body) — overloads supersede the base definition.
 	return constructors.some(c => !c.body) ? constructors.filter(c => !c.body) : constructors;
 }
@@ -358,7 +518,7 @@ function _getConstructors(statement: ts.ClassDeclaration): readonly ts.Construct
  * - Multiple constructor overloads each become a signature, same as function overloads.
  * - A class with no explicit constructor yields a single degenerate `new ClassName()` signature.
  */
-function _getConstructorSignatures(statement: ts.ClassDeclaration, source: ts.SourceFile, name: string): readonly string[] {
+function _getConstructorSignatures(statement: ClassDeclaration, source: SourceFile, name: string): readonly string[] {
 	const generics = _getTypeParamNames(statement, source);
 	const constructors = _getConstructors(statement);
 	if (!constructors.length) return [`new ${name}${generics}()`];
@@ -367,12 +527,12 @@ function _getConstructorSignatures(statement: ts.ClassDeclaration, source: ts.So
 
 /** Extract parameters from a function or class declaration, enriched with JSDoc `@param` descriptions. */
 function _getParams(
-	statement: ts.Statement,
-	source: ts.SourceFile,
+	statement: Statement,
+	source: SourceFile,
 	jsDocParams: readonly DocumentationParam[] | undefined,
 ): readonly DocumentationParam[] | undefined {
-	if (ts.isClassDeclaration(statement)) return _getConstructorParams(statement, source, jsDocParams);
-	if (!ts.isFunctionDeclaration(statement)) return;
+	if (isClassDeclaration(statement)) return _getConstructorParams(statement, source, jsDocParams);
+	if (!isFunctionDeclaration(statement)) return;
 	const params = _buildParams(statement.parameters, source, jsDocParams);
 	return params.length ? params : undefined;
 }
@@ -386,22 +546,22 @@ function _getParams(
  * - A destructured (binding-pattern) param has no name of its own — its display name resolves as an "orphan" `@param` (one not matching any identifier param, in source order), else the rest element (`...options`), else a type-derived fallback (see `_getBindingName`). This keeps the Param column readable (`options`) while the signature still shows the full `{ … }`.
  */
 function _buildParams(
-	parameters: readonly ts.ParameterDeclaration[],
-	source: ts.SourceFile,
+	parameters: readonly ParameterDeclaration[],
+	source: SourceFile,
 	primaryJsDocParams: readonly DocumentationParam[] | undefined,
 	fallbackJsDocParams?: readonly DocumentationParam[] | undefined,
 ): DocumentationParam[] {
 	const params: DocumentationParam[] = [];
 	// Identifier (non-destructured) parameter names — used to spot "orphan" `@param` tags that name a destructured bag.
 	const named = new Set<string>();
-	for (const p of parameters) if (ts.isIdentifier(p.name)) named.add(p.name.getText(source));
+	for (const p of parameters) if (isIdentifier(p.name)) named.add(p.name.getText(source));
 	// Top-level `@param` names not matching any identifier parameter, in declared order (constructor's own first, then class-level), de-duplicated — these let an author name a destructured param (`@param options`). Sub-tags (`options.min`) are excluded.
 	const orphans: string[] = [];
 	for (const d of [...(primaryJsDocParams ?? []), ...(fallbackJsDocParams ?? [])])
 		if (!d.name.includes(".") && !named.has(d.name) && !orphans.includes(d.name)) orphans.push(d.name);
 	let orphan = 0;
 	for (const p of parameters) {
-		const name = ts.isIdentifier(p.name) ? p.name.getText(source) : (orphans[orphan++] ?? _getBindingName(p, source));
+		const name = isIdentifier(p.name) ? p.name.getText(source) : (orphans[orphan++] ?? _getBindingName(p, source));
 		const type = p.type?.getText(source);
 		const optional = !!p.questionToken || !!p.initializer;
 		const def = p.initializer?.getText(source);
@@ -425,10 +585,10 @@ function _buildParams(
  * - Otherwise falls back to a generic name read from the type — `props` for a `*Props` type (component props), else `options`.
  * - Callers resolve an explicit `@param` first (see `_buildParams`); this is only the fallback when none is given.
  */
-function _getBindingName(p: ts.ParameterDeclaration, source: ts.SourceFile): string {
+function _getBindingName(p: ParameterDeclaration, source: SourceFile): string {
 	const { name } = p;
-	if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name))
-		for (const el of name.elements) if (ts.isBindingElement(el) && el.dotDotDotToken && ts.isIdentifier(el.name)) return el.name.text;
+	if (isObjectBindingPattern(name) || isArrayBindingPattern(name))
+		for (const el of name.elements) if (isBindingElement(el) && el.dotDotDotToken && el.name && isIdentifier(el.name)) return el.name.text;
 	return p.type?.getText(source).replace(/<.*/s, "").endsWith("Props") ? "props" : "options";
 }
 
@@ -438,8 +598,8 @@ function _getBindingName(p: ts.ParameterDeclaration, source: ts.SourceFile): str
  * - Overloaded constructors contribute their parameters in source order, de-duplicated by identity (same as function overloads).
  */
 function _getConstructorParams(
-	statement: ts.ClassDeclaration,
-	source: ts.SourceFile,
+	statement: ClassDeclaration,
+	source: SourceFile,
 	classJsDocParams: readonly DocumentationParam[] | undefined,
 ): readonly DocumentationParam[] | undefined {
 	let params: readonly DocumentationParam[] | undefined;
@@ -454,17 +614,17 @@ function _getConstructorParams(
 
 /** Extract return entries — combines the signature return type with any `@returns` descriptions. */
 function _getReturns(
-	statement: ts.Statement,
-	source: ts.SourceFile,
+	statement: Statement,
+	source: SourceFile,
 	jsDocReturns: readonly DocumentationReturn[] | undefined,
 	name: string,
 ): readonly DocumentationReturn[] | undefined {
-	if (ts.isClassDeclaration(statement)) {
+	if (isClassDeclaration(statement)) {
 		// A constructor returns an instance of the class, including its generics (e.g. `ChoiceSchema<T>`).
 		const type = `${name}${_getTypeParamNames(statement, source)}`;
 		return [{ type, description: jsDocReturns?.[0]?.description }];
 	}
-	if (!ts.isFunctionDeclaration(statement)) return jsDocReturns;
+	if (!isFunctionDeclaration(statement)) return jsDocReturns;
 	const type = statement.type?.getText(source);
 	if (jsDocReturns?.length) {
 		// Merge: first entry gets the inferred type if it doesn't already have one.
@@ -483,31 +643,31 @@ function _getReturns(
  * - Members declared with the `declare` modifier are skipped — they're ambient type-only re-declarations, not new API.
  * - `static` methods are labelled `static method` so the docs site groups them in their own section, separate from instance `method`s, and their rendered signature is prefixed with the `static ` keyword.
  */
-function _getClassMembers(statement: ts.Statement, source: ts.SourceFile, className: string): DocumentationElement[] | undefined {
-	if (!ts.isClassDeclaration(statement) && !ts.isInterfaceDeclaration(statement)) return;
+function _getClassMembers(statement: Statement, source: SourceFile, className: string): DocumentationElement[] | undefined {
+	if (!isClassDeclaration(statement) && !isInterfaceDeclaration(statement)) return;
 	const members: DocumentationElement[] = [];
 
 	for (const member of statement.members) {
 		// Skip private, protected, and _-prefixed members.
-		const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+		const name = _getMemberName(member);
 		if (!name || name.startsWith("_")) continue;
-		const modifiers = ts.canHaveModifiers(member) ? ts.getModifiers(member) : undefined;
-		if (modifiers?.some(m => m.kind === ts.SyntaxKind.PrivateKeyword || m.kind === ts.SyntaxKind.ProtectedKeyword)) continue;
+		const modifiers = _getModifiers(member);
+		if (modifiers?.some(m => m.kind === SyntaxKind.PrivateKeyword || m.kind === SyntaxKind.ProtectedKeyword)) continue;
 		// Skip `override` members — the base class already documents them, so a subclass page lists only its newly-introduced API.
-		if (modifiers?.some(m => m.kind === ts.SyntaxKind.OverrideKeyword)) continue;
+		if (modifiers?.some(m => m.kind === SyntaxKind.OverrideKeyword)) continue;
 		// Skip `declare` members — ambient type-only re-declarations (e.g. a subclass narrowing an inherited property's type), not new API.
-		if (modifiers?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword)) continue;
+		if (modifiers?.some(m => m.kind === SyntaxKind.DeclareKeyword)) continue;
 
 		// `static` methods are grouped and labelled separately from instance methods (`static method`),
 		// and carry the `static ` keyword in their rendered signature.
-		const isStatic = modifiers?.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
+		const isStatic = modifiers?.some(m => m.kind === SyntaxKind.StaticKeyword);
 		const staticPrefix = isStatic ? "static " : "";
 
 		const memberJSDoc = _getJSDoc(member, source);
 		const content = _buildJSDocContent(memberJSDoc?.description, memberJSDoc?.unhandled);
 		const description = extractMarkdownProps(memberJSDoc?.description ?? "").description;
 
-		if (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) {
+		if (isMethodDeclaration(member) || isMethodSignatureDeclaration(member)) {
 			const params = member.parameters.map(p => p.getText(source)).join(", ");
 			const ret = member.type ? member.type.getText(source) : "void";
 			const signature = `${staticPrefix}${name}(${params}): ${ret}`;
@@ -555,24 +715,19 @@ interface JSDocResult {
 	unhandled?: string | undefined;
 }
 
-/** Nodes carry their parsed `/** *​/` blocks on this property — the compiler attaches them when the source is parsed with comments (`setParentNodes`). */
-interface NodeWithJSDoc {
-	jsDoc?: ts.JSDoc[] | undefined;
-}
-
 /**
  * Extract JSDoc from a node via the TypeScript compiler's parsed JSDoc AST.
  * - Reads the compiler's structured tags rather than re-scanning the raw comment text, so tags are only ever recognised at real tag positions — a `@kind`/`@param`/etc. mentioned inline in prose is left in the description, not parsed.
  * - Multi-line `@param` / `@returns` / `@throws` descriptions and `{Type}` expressions come through whole; `*` margins are already stripped.
- * - `@example` bodies are taken verbatim. Note the compiler treats any whitespace-led `@word` line as a new tag even inside a ``` fence, so an example must not contain a bare at-rule / decorator / pragma line on its own.
+ * - `@example` bodies are taken verbatim. The parser is markdown-fence-aware: an `@word` line inside a balanced triple-backtick fence stays part of the example rather than starting a new tag. The flip side: an unbalanced run of three-plus backticks anywhere in the comment opens a fence that swallows every following tag — never write a bare triple-backtick in docblock prose.
  * - `@see` is recognised only to discard it: it's a VS Code hover affordance (a link back to the docs site), never rendered into the page body.
  */
-function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefined {
+function _getJSDoc(node: Node, source: SourceFile): JSDocResult | undefined {
 	// The compiler attaches every leading `/** */` block here; the last one is the doc comment.
-	const jsDoc = (node as ts.Node & NodeWithJSDoc).jsDoc?.at(-1);
-	if (!jsDoc) return;
+	const jsDoc = node.jsDoc?.at(-1);
+	if (!jsDoc || !isJSDoc(jsDoc)) return;
 
-	const description = ts.getTextOfJSDocComment(jsDoc.comment)?.trim();
+	const description = getTextOfJSDocComment(jsDoc.comment)?.trim();
 
 	let kind: string | undefined;
 	let def: string | undefined;
@@ -583,18 +738,18 @@ function _getJSDoc(node: ts.Node, source: ts.SourceFile): JSDocResult | undefine
 	const unhandled: string[] = [];
 
 	for (const tag of jsDoc.tags ?? []) {
-		const comment = ts.getTextOfJSDocComment(tag.comment)?.trim();
-		if (ts.isJSDocParameterTag(tag)) {
+		const comment = getTextOfJSDocComment(tag.comment)?.trim();
+		if (isJSDocParameterTag(tag)) {
 			const name = tag.name.getText(source);
-			const type = tag.typeExpression?.type.getText(source);
+			const type = _getJSDocTypeText(tag.typeExpression, source);
 			if (name) params.push({ name, type: type || undefined, description: comment || undefined });
-		} else if (ts.isJSDocReturnTag(tag)) {
-			const type = tag.typeExpression?.type.getText(source);
+		} else if (isJSDocReturnTag(tag)) {
+			const type = _getJSDocTypeText(tag.typeExpression, source);
 			if (type || comment) returns.push({ type: type || undefined, description: comment || undefined });
-		} else if (ts.isJSDocThrowsTag(tag)) {
-			const type = tag.typeExpression?.type.getText(source);
+		} else if (isJSDocThrowsTag(tag)) {
+			const type = _getJSDocTypeText(tag.typeExpression, source);
 			if (type || comment) throws.push({ type: type || undefined, description: comment || undefined });
-		} else if (ts.isJSDocSeeTag(tag)) {
+		} else if (isJSDocSeeTag(tag)) {
 			// `@see` is a hover affordance only — strip it, never render it.
 		} else {
 			const name = tag.tagName.text;

--- a/modules/markup/rule/fenced.tsx
+++ b/modules/markup/rule/fenced.tsx
@@ -8,7 +8,7 @@ const FENCE = "`{3,}|~{3,}";
  * - Same as Markdown syntax.
  * - Start when we reach an opening fence on a new line.
  * - Stop when we reach a matching closing fence on a new line, or the end of the string.
- * - Closing fence must be exactly the same as the opening fence, and can be made of three or more "```" backticks, or three or more `~~~` tildes.
+ * - Closing fence must be exactly the same as the opening fence, and can be made of three or more backticks, or three or more `~~~` tildes.
  * - If there's no closing fence the code block will run to the end of the current string.
  * - Markdown-style four-space indent syntax is not supported (only fenced code since it's less confusing and more common).
  *

--- a/modules/ui/misc/Catcher.tsx
+++ b/modules/ui/misc/Catcher.tsx
@@ -9,7 +9,6 @@ import { Page } from "../page/Page.js";
 import type { ChildProps } from "../util/props.js";
 
 /**
-import { RetryButton, RetryContext } from "../button/RetryButton.js";
  * Props for a component that renders a caught error `reason`.
  *
  * @see https://shelving.cc/ui/ErrorProps

--- a/package.json
+++ b/package.json
@@ -15,13 +15,12 @@
 		"@types/bun": "^1.3.14",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"@typescript/native-preview": "^7.0.0-dev.20260706.1",
 		"firebase": "^12.15.0",
 		"react": "^19.3.0-canary-fef12a01-20260413",
 		"react-dom": "^19.3.0-canary-fef12a01-20260413",
 		"stylelint": "^17.14.0",
 		"stylelint-config-standard": "^40.0.0",
-		"typescript": "^5.9.3"
+		"typescript": "^7.0.2"
 	},
 	"peerDependencies": {
 		"@google-cloud/firestore": ">=7.0.0",
@@ -69,7 +68,7 @@
 	"scripts": {
 		"test": "bun run --parallel test:*",
 		"test:lint": "biome check .",
-		"test:type": "tsgo --noEmit",
+		"test:type": "tsc --noEmit",
 		"test:style": "stylelint \"modules/**/*.css\"",
 		"test:unit": "bun test ./modules --concurrent --only-failures",
 		"fix": "bun run --sequential fix:*",
@@ -80,7 +79,7 @@
 		"build": "bun run --sequential build:*",
 		"build:0:setup": "rm -rf ./dist && mkdir -p ./dist",
 		"build:1:copy": "cp package.json dist/package.json && cp LICENSE.md dist/LICENSE.md && cp README.md dist/README.md && cp .npmignore dist/.npmignore && cp -r modules/ui dist/ui",
-		"build:2:emit": "tsgo -p tsconfig.build.json",
+		"build:2:emit": "tsc -p tsconfig.build.json",
 		"build:3:syntax": "bun run ./dist/index.js",
 		"build:4:unit": "bun test ./dist/**/*.test.js --concurrent --only-failures --bail"
 	},


### PR DESCRIPTION
## What

Upgrades the repo to **TypeScript 7.0.2** (the native Go compiler) and ports the docs extractor to its new API, since TS 7 no longer ships the JS compiler API (`ts.createSourceFile`, `ts.isFunctionDeclaration`, etc. — the root export is now just a version stub).

- **`TypescriptExtractor`** now parses via `typescript/unstable/async`: a shared native compiler server backed by a virtual filesystem, spawned on demand, serialised through a queue, and closed after a short idle so callers never manage a lifecycle. (The `unstable/sync` API is unusable under Bun — it reaches into Node stream internals for its synchronous IPC channel.) AST walking uses `typescript/unstable/ast`, adapting to the renamed guards (`isPropertySignatureDeclaration`, `isGetAccessorDeclaration`, …), `modifiers` as a direct node property, property optionality via `postfixToken`, and JSDoc `{Type}` expressions wrapped in `JSDocTypeExpression`.
- **`FileExtractor.extractProps`** may now return a promise; `extract()` awaits it either way. `MarkupExtractor` stays sync.
- **Toolchain**: `@typescript/native-preview` (tsgo) is dropped — `typescript@7`'s own native `tsc` now runs `test:type` and `build:2:emit` (they're the same compiler).
- **Docblock fixes**: TS 7's JSDoc parser is markdown-fence-aware, so an *unbalanced* run of three-plus backticks in prose swallows every following tag. `FENCED_RULE`'s docblock hit exactly this (its `@example` / `@see` leaked into the page body); reworded. Also removed a stray `import` line that sat inside `ErrorProps`' docblock in `Catcher.tsx`.

## Verification

- `bun run test` green: lint, style, type check (native tsc 7.0.2), 1200 unit tests.
- `bun run build` green, including dist unit tests.
- `bun run docs:build` renders all **1898 pages**. The extracted `tree.json` was diffed against a `typescript@5.9.3` baseline build of `main`: byte-identical apart from the two fixed docblocks and the extractor's own updated docs. Zero `@see` leaks tree-wide.
- Parse cost is ~12ms/file on the shared server (~117ms once for spawn); full docs build takes ~35s, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EN9k7Pdt2pza4UGpSTfNwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN9k7Pdt2pza4UGpSTfNwf)_