### PR TITLE
fix: resolve meta links dropped by generator spread in mergeMetaLinks()

### DIFF
--- a/modules/ui/page/Head.test.tsx
+++ b/modules/ui/page/Head.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createMeta, Head, MetaContext } from "shelving/ui";
+
+describe("Head", () => {
+	test("emits a <link> element when links are set in context", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ root: "http://x.com/", url: "./", links: { icon: "/img/favicon.png" } })}>
+				<Head />
+			</MetaContext>,
+		);
+		expect(html).toContain('rel="icon"');
+		expect(html).toContain('href="http://x.com/img/favicon.png"');
+	});
+});

--- a/modules/ui/util/meta.test.ts
+++ b/modules/ui/util/meta.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { createMeta, mergeMeta, mergeMetaAssets, mergeMetaLinks } from "shelving/ui";
+import { requireURL } from "shelving/util/url";
+
+const ROOT = requireURL("http://x.com/app/");
+const URL = requireURL("http://x.com/app/sub/page");
+
+describe("mergeMetaLinks", () => {
+	test("returns resolved entries when current is unset", () => {
+		const links = mergeMetaLinks(undefined, { icon: "/img/favicon.png" }, ROOT, ROOT);
+		expect(links?.icon?.href).toBe("http://x.com/app/img/favicon.png");
+	});
+
+	test("merges next over current — new keys override, untouched keys survive", () => {
+		const current = mergeMetaLinks(undefined, { icon: "/old.png", canonical: "/page" }, ROOT, ROOT);
+		const links = mergeMetaLinks(current, { icon: "/new.png" }, ROOT, ROOT);
+		expect(links?.icon?.href).toBe("http://x.com/app/new.png");
+		expect(links?.canonical?.href).toBe("http://x.com/app/page");
+	});
+
+	test("skips nullish link values", () => {
+		const links = mergeMetaLinks(undefined, { icon: undefined, canonical: null }, ROOT, ROOT);
+		expect(links).toEqual({});
+	});
+
+	test("resolves relative hrefs against url and absolute hrefs against root", () => {
+		const links = mergeMetaLinks(undefined, { canonical: "./other", icon: "/favicon.png" }, URL, ROOT);
+		expect(links?.canonical?.href).toBe("http://x.com/app/sub/page/other");
+		expect(links?.icon?.href).toBe("http://x.com/app/favicon.png");
+	});
+
+	test("returns current unchanged when next is unset", () => {
+		const current = mergeMetaLinks(undefined, { icon: "/favicon.png" }, ROOT, ROOT);
+		expect(mergeMetaLinks(current, undefined, ROOT, ROOT)).toBe(current);
+	});
+});
+
+describe("mergeMetaAssets", () => {
+	test("resolves relative hrefs against url and absolute hrefs against root", () => {
+		const assets = mergeMetaAssets(undefined, ["./style.css", "/base.css"], URL, ROOT);
+		expect(assets?.map(({ href }) => href)).toEqual(["http://x.com/app/sub/page/style.css", "http://x.com/app/base.css"]);
+	});
+
+	test("appends next after current and skips nullish values", () => {
+		const current = mergeMetaAssets(undefined, ["/base.css"], ROOT, ROOT);
+		const assets = mergeMetaAssets(current, [undefined, "/extra.css", null], ROOT, ROOT);
+		expect(assets?.map(({ href }) => href)).toEqual(["http://x.com/app/base.css", "http://x.com/app/extra.css"]);
+	});
+});
+
+describe("mergeMeta", () => {
+	test("meta with links set produces non-empty resolved links", () => {
+		const meta = createMeta({ root: "http://x.com/", url: "./", links: { icon: "/img/favicon.png" } });
+		expect(meta.links?.icon?.href).toBe("http://x.com/img/favicon.png");
+	});
+
+	test("merges new links over existing resolved links", () => {
+		const meta1 = createMeta({ root: "http://x.com/", url: "./", links: { icon: "/favicon.png" } });
+		const meta2 = mergeMeta(meta1, { url: "./page", links: { canonical: "/page" } });
+		expect(meta2.links?.icon?.href).toBe("http://x.com/favicon.png");
+		expect(meta2.links?.canonical?.href).toBe("http://x.com/page");
+	});
+});

--- a/modules/ui/util/meta.ts
+++ b/modules/ui/util/meta.ts
@@ -239,7 +239,7 @@ export function mergeMetaLinks(
 	root: ImmutableURL | undefined,
 	caller: AnyCaller = mergeMetaLinks,
 ): MetaLinks | undefined {
-	return next ? { ...current, ..._yieldMetaLinkEntries(next, url, root, caller) } : current;
+	return next ? { ...current, ...Object.fromEntries(_yieldMetaLinkEntries(next, url, root, caller)) } : current;
 }
 function* _yieldMetaLinkEntries(
 	links: PossibleMetaLinks,


### PR DESCRIPTION
Fixes #264

## Problem

`mergeMetaLinks()` spread a generator object directly into an object literal. Object spread copies own enumerable properties, not iterable values, so the generator body never ran and every `next` link was silently discarded — `<App links={{ icon: "/img/favicon.png" }}>` rendered no `<link>` element at all.

## Fix

Consume the generator with `Object.fromEntries()` before spreading (`modules/ui/util/meta.ts`), matching how the sibling `mergeMetaAssets()` already materialises its generator with `Array.from()`.

## Tests

Added the tests requested in the issue:

- `modules/ui/util/meta.test.ts`:
  - `mergeMetaLinks()` with `current = undefined` and one new link returns the resolved entry (the exact case that previously returned `{}`).
  - Merging `next` over `current` — new keys override, untouched keys survive.
  - Nullish link values are skipped.
  - Relative hrefs resolve against `url` and absolute hrefs against `root`, for both `mergeMetaLinks()` and `mergeMetaAssets()`.
  - `mergeMeta()` / `createMeta()` integration — a `PossibleMeta` with `links` set produces a `Meta` with non-empty resolved `links`.
- `modules/ui/page/Head.test.tsx`: `<Head>` render test asserting a `<link rel="icon">` element is emitted when `links` is set in `MetaContext`.

All checks pass: 1210 unit tests, lint, and typecheck.

## Not included

The related nit in the issue about `_renderLink` hardcoding `type="image/x-icon"` / `text/css` in `Head.tsx` is left as-is — it's flagged as separate/adjacent in the issue and worth its own decision on how the type should be derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqmBe1VRde6mAy8vufyDPA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqmBe1VRde6mAy8vufyDPA)_