### PR TITLE
fix: accept readonly arrays in UI component children props

### DIFF
--- a/modules/ui/block/List.tsx
+++ b/modules/ui/block/List.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement, ReactNode } from "react";
+import type { ImmutableArray } from "../../util/array.js";
 import { type BlockVariants, getBlockClass } from "../style/Block.js";
 import { type GapVariants, getGapClass } from "../style/Gap.js";
 import { getClass, getModuleClass } from "../util/css.js";
@@ -13,8 +14,8 @@ const LIST_UNORDERED_CLASS = getModuleClass(LIST_CSS, "unordered");
  * @see https://shelving.cc/ui/ListProps
  */
 export interface ListProps extends GapVariants, BlockVariants {
-	children: ReactNode[];
-	ordered?: boolean;
+	readonly children: ImmutableArray<ReactNode>;
+	readonly ordered?: boolean | undefined;
 }
 
 /**

--- a/modules/ui/input/Popover.tsx
+++ b/modules/ui/input/Popover.tsx
@@ -15,7 +15,7 @@ import styles from "./Popover.module.css";
  *
  * @see https://shelving.cc/ui/PopoverChildren
  */
-export type PopoverChildren = [
+export type PopoverChildren = readonly [
 	/**
 	 * First child of the <Popover> is element that activates the popover.
 	 * - Should be a `<Button>` or `<Input>` that activates or provides the children.

--- a/modules/ui/menu/Menu.tsx
+++ b/modules/ui/menu/Menu.tsx
@@ -52,7 +52,7 @@ export interface MenuItemProps extends ClickableProps {
 	 * The first child becomes the link label (rendered inside the `<a>`).
 	 * - Any additional children form the submenu — only rendered when this item is "proud" (an ancestor of the current page). The caller is responsible for wrapping the submenu in a nested `<Menu>` if it wants the CSS `.menu .menu` descendant rules to apply.
 	 */
-	readonly children: ReactNode | [ReactNode, ...ReactNode[]];
+	readonly children: ReactNode | readonly [ReactNode, ...ReactNode[]];
 }
 
 /**


### PR DESCRIPTION
`List` typed its `children` as mutable `ReactNode[]`, which rejected `readonly` arrays — e.g. passing a `readonly string[]` into `<List>` failed to typecheck. This fixes that and sweeps `modules/ui` for the same pattern.

## Changes

- **`List`** — `children` is now `ImmutableArray<ReactNode>` (the module's convention for readonly array props), and both props gained the `readonly` / explicit `| undefined` treatment per `AGENTS.md` Types conventions.
- **`PopoverChildren`** — now a `readonly` tuple. This covers `Popover`, `ButtonPopover`, and `ButtonInputPopover`, which all share the type.
- **`MenuItemProps`** — the `[ReactNode, ...ReactNode[]]` branch of `children` is now a `readonly` tuple.

Other candidates checked and found already fine: `Mapper`'s `children` uses the `Iterable`-based `Elements` type, the `docs/` and `input/` components already use `ImmutableArray<T>`, and `Mapper`'s internal mutable `ReactNode[]` is a local accumulator, not a prop.

## Testing

- `bun run test:type` — passes
- `bun run test:unit` — 1210 pass, 0 fail
- `bun run test:lint` — no new diagnostics (the pre-existing Biome internal panic on `modules/ui/dialog/Dialog.tsx` occurs on a clean tree too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mphjvCjD5SsWm2VpWM3kF

---
_Generated by [Claude Code](https://claude.ai/code/session_011mphjvCjD5SsWm2VpWM3kF)_