### PR TITLE
fix: default meta root to the url's origin so routed apps work without an explicit root

### DIFF
--- a/modules/ui/app/App.md
+++ b/modules/ui/app/App.md
@@ -46,6 +46,8 @@ export function MyApp() {
 }
 ```
 
+**Setting a `root` URL on `<App>` is strongly recommended.** `root` is the base that site-absolute links and assets (`/favicon.png`, `/base.css`) resolve against, the `<base>` tag rendered by `<HTML>`, and the prefix `<Router>` strips when matching routes. When it's unset, merging a `url` into the meta context derives `root` from that URL's origin (e.g. `https://example.com/`) — a safe fallback for apps served from the domain root, but wrong for apps deployed under a sub-path, so set it explicitly whenever your app doesn't live at `/`.
+
 `<App>` accepts all `PossibleMeta` props (`app`, `root`, `url`, `title`, `language`, `tags`, etc.) and merges them into the context it provides to children. On mount it adds the theme class to `document.body`, which activates the CSS custom property tokens defined in `App.module.css`; on unmount it removes it.
 
 For a documentation site, hand an extracted tree to `<TreeApp>` instead — see the `shelving/extract` guide.

--- a/modules/ui/misc/MetaContext.test.tsx
+++ b/modules/ui/misc/MetaContext.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { RequiredError } from "shelving/error";
 import { createMeta, MetaContext, requireMetaURL } from "shelving/ui";
+import { requireURL } from "shelving/util/url";
 
 /** Render `requireMetaURL().path` from inside a component so its `use(MetaContext)` call is valid. */
 function Probe(): ReactNode {
@@ -38,8 +38,28 @@ describe("requireMetaURL", () => {
 		expect(html).toBe("/enquiry/loan");
 	});
 
+	test("defaults root to the url's origin when root is unset", () => {
+		const html = renderToStaticMarkup(
+			<MetaContext value={createMeta({ url: "http://x.com/enquiry/loan" })}>
+				<Probe />
+			</MetaContext>,
+		);
+		expect(html).toBe("/enquiry/loan");
+	});
+
 	test("throws RequiredError when url is unset", () => {
-		expect(() => renderToStaticMarkup(<Probe />)).toThrow(RequiredError);
+		expect(() => renderToStaticMarkup(<Probe />)).toThrow("Meta URL is required");
+	});
+
+	test("throws RequiredError when root is unset and was not derived", () => {
+		// Bypass `createMeta()` deliberately — merged meta always derives a root, so this backup check only fires for hand-built meta.
+		expect(() =>
+			renderToStaticMarkup(
+				<MetaContext value={{ url: requireURL("http://x.com/foo") }}>
+					<Probe />
+				</MetaContext>,
+			),
+		).toThrow("Meta root is required");
 	});
 
 	test("throws RequiredError when url and root are on different origins", () => {
@@ -49,6 +69,16 @@ describe("requireMetaURL", () => {
 					<Probe />
 				</MetaContext>,
 			),
-		).toThrow(RequiredError);
+		).toThrow("Meta URL and meta root must share a root");
+	});
+
+	test("throws RequiredError when url is outside the root's path", () => {
+		expect(() =>
+			renderToStaticMarkup(
+				<MetaContext value={createMeta({ root: "http://x.com/app/", url: "http://x.com/other" })}>
+					<Probe />
+				</MetaContext>,
+			),
+		).toThrow("Meta URL and meta root must share a root");
 	});
 });

--- a/modules/ui/misc/MetaContext.tsx
+++ b/modules/ui/misc/MetaContext.tsx
@@ -37,6 +37,7 @@ export function requireMeta(meta?: PossibleMeta): Meta {
  */
 export interface MetaURL extends Meta {
 	url: ImmutableURL;
+	root: ImmutableURL;
 	/** The path of `url` relative to `meta.root` (i.e. the _site-root-relative_ path). */
 	path: AbsolutePath;
 	/** The `?query` params of `url` extracted as a flat set of parameters. */
@@ -48,17 +49,18 @@ export interface MetaURL extends Meta {
  *
  * @param meta A set of new possible meta data to combine into the current meta context.
  * @param caller Function to attribute thrown `RequiredError`s to (defaults to `requireMetaURL`).
- * @returns A `Meta` object with a defined `url`, plus `path` and `params` properties combined in.
- * @throws RequiredError If the current meta has no `url`.
- * @throws RequiredError If the current meta `url` does not share an origin with the meta `root`.
+ * @returns A `Meta` object with a defined `url` and `root`, plus `path` and `params` properties combined in.
+ * @throws RequiredError If the current meta has no `url` or no `root`.
+ * @throws RequiredError If the current meta `url` and `root` do not share a root (different origin, or `url` outside `root`'s path).
  * @example const { path, params } = requireMetaURL();
  * @see https://shelving.cc/ui/requireMetaURL
  */
 export function requireMetaURL(meta?: PossibleMeta, caller: AnyCaller = requireMetaURL): MetaURL {
 	const { url, root, ...combined } = requireMeta(meta);
 	if (!url) throw new RequiredError("Meta URL is required", { received: url, caller });
+	if (!root) throw new RequiredError("Meta root is required", { received: root, caller });
 	const path = matchURLPrefix(url, root, caller);
-	if (!path) throw new RequiredError("Meta URL and meta root must share an origin", { url, root, caller });
+	if (!path) throw new RequiredError("Meta URL and meta root must share a root", { url, root, caller });
 	const params = getURIParams(url, caller);
 	return { ...combined, url, root, path, params };
 }

--- a/modules/ui/router/Navigation.md
+++ b/modules/ui/router/Navigation.md
@@ -6,7 +6,8 @@ The top-level navigation provider for a client-side app. It owns a single `Navig
 
 - Same-origin anchor clicks are intercepted automatically and turned into `forward()` calls. Add a `download` attribute to an anchor to opt out.
 - It listens for `popstate` so the store stays in sync with browser back/forward.
-- It initialises the store from the surrounding `<Meta>` url/base, so set those on an ancestor `<HTML>` / `<Page>`.
+- It initialises the store from the surrounding `<Meta>` url/base, so set those on an ancestor `<App>` / `<HTML>` / `<Page>`. In the browser the store falls back to `window.location.href` when no url is set.
+- The meta it publishes always has a `root` — when none is set anywhere, `root` defaults to the live URL's origin. Setting `root` explicitly on `<App>` / `<HTML>` is still strongly recommended, especially for apps served under a sub-path.
 - `<Router>` works with no `<Navigation>` at all (SSR, static rendering, tests) — `<Navigation>` is only what makes the URL *live* on the client.
 
 ## Usage

--- a/modules/ui/router/Navigation.test.tsx
+++ b/modules/ui/router/Navigation.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Navigation, requireMetaURL } from "shelving/ui";
+
+/** Render `requireMetaURL().path` from inside a component so its `use(MetaContext)` call is valid. */
+function Probe(): ReactNode {
+	return requireMetaURL().path;
+}
+
+describe("Navigation", () => {
+	test("publishes merged meta with a root derived from the url", () => {
+		const html = renderToStaticMarkup(
+			<Navigation url="http://x.com/a/b">
+				<Probe />
+			</Navigation>,
+		);
+		expect(html).toBe("/a/b");
+	});
+
+	test("resolves a relative url against an explicit root", () => {
+		const html = renderToStaticMarkup(
+			<Navigation root="http://x.com/app/" url="./sub">
+				<Probe />
+			</Navigation>,
+		);
+		expect(html).toBe("/sub");
+	});
+});

--- a/modules/ui/router/Navigation.tsx
+++ b/modules/ui/router/Navigation.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, useEffect } from "react";
 import { useInstance } from "../../react/useInstance.js";
 import { useStore } from "../../react/useStore.js";
 import { MetaContext, requireMeta } from "../misc/MetaContext.js";
-import type { PossibleMeta } from "../util/index.js";
+import { mergeMeta, type PossibleMeta } from "../util/index.js";
 import type { OptionalChildProps } from "../util/props.js";
 import { NavigationContext } from "./NavigationContext.js";
 import { NavigationStore } from "./NavigationStore.js";
@@ -19,7 +19,7 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
  * - Owns a single `NavigationStore` initialised from the surrounding `<Meta>` url/base.
  * - Intercepts same-origin anchor clicks (excluding `download` anchors) and turns them into `forward()` calls.
  * - Listens for `popstate` to sync the store with browser back/forward.
- * - Publishes the live URL via `<Meta url={…} params={…}>` so descendant `<Router>`s re-render on navigation.
+ * - Publishes the live URL into the `Meta` context via `mergeMeta()`, so descendant `<Router>`s re-render on navigation and merge invariants hold (e.g. `root` defaults to the live URL's origin when unset).
  *
  * Exactly one `<Navigation>` per app — nested routers share this single store.
  *
@@ -29,8 +29,8 @@ export interface NavigationProps extends PossibleMeta, OptionalChildProps {}
  * @see https://shelving.cc/ui/Navigation
  */
 export function Navigation({ children, ...meta }: NavigationProps): ReactElement {
-	const { url, root, ...merged } = requireMeta(meta);
-	const nav = useInstance(NavigationStore, url, root);
+	const current = requireMeta(meta);
+	const nav = useInstance(NavigationStore, current.url, current.root);
 	useStore(nav);
 
 	useEffect(() => {
@@ -63,7 +63,7 @@ export function Navigation({ children, ...meta }: NavigationProps): ReactElement
 
 	return (
 		<NavigationContext value={nav}>
-			<MetaContext value={{ url: nav.value, root, ...merged }}>{children}</MetaContext>
+			<MetaContext value={mergeMeta(current, { url: nav.value }, Navigation)}>{children}</MetaContext>
 		</NavigationContext>
 	);
 }

--- a/modules/ui/util/meta.test.ts
+++ b/modules/ui/util/meta.test.ts
@@ -60,4 +60,21 @@ describe("mergeMeta", () => {
 		expect(meta2.links?.icon?.href).toBe("http://x.com/favicon.png");
 		expect(meta2.links?.canonical?.href).toBe("http://x.com/page");
 	});
+
+	test("defaults root to the origin of the url when root is unset", () => {
+		const meta = createMeta({ url: "http://x.com/sub/page" });
+		expect(meta.url?.href).toBe("http://x.com/sub/page");
+		expect(meta.root?.href).toBe("http://x.com/");
+	});
+
+	test("keeps an explicit root instead of defaulting from the url", () => {
+		const meta = createMeta({ root: "http://x.com/app/", url: "http://x.com/app/page" });
+		expect(meta.root?.href).toBe("http://x.com/app/");
+	});
+
+	test("leaves root unset when url is also unset", () => {
+		const meta = createMeta({ title: "Title" });
+		expect(meta.root).toBeUndefined();
+		expect(meta.url).toBeUndefined();
+	});
 });

--- a/modules/ui/util/meta.ts
+++ b/modules/ui/util/meta.ts
@@ -4,7 +4,7 @@ import type { AnyCaller } from "../../util/function.js";
 import { type PossibleLink, requireLink } from "../../util/link.js";
 import type { Nullish } from "../../util/null.js";
 import { type ImmutableURI, type PossibleURI, type PossibleURIParams, withURIParams } from "../../util/uri.js";
-import { type ImmutableURL, type PossibleURL, requireURL } from "../../util/url.js";
+import { ImmutableURL, type PossibleURL, requireURL } from "../../util/url.js";
 
 /**
  * Set of named meta `<meta />` tags in `{ name: content }` format.
@@ -85,7 +85,7 @@ export interface Meta {
  * @see https://shelving.cc/ui/PossibleMeta
  */
 export interface PossibleMeta extends Omit<Meta, "root" | "url" | "links" | "scripts" | "modules" | "stylesheets"> {
-	/** Base URL for the app — accepts a string or `URL`, resolved with `requireURL()`. */
+	/** Base URL for the app — accepts a string or `URL`, resolved with `requireURL()`. Defaults to the origin of `url` when unset. */
 	readonly root?: PossibleURL | undefined;
 
 	/**
@@ -139,6 +139,7 @@ export function joinTitles(...titles: (string | undefined)[]): string {
  *
  * - `title` is merged with `joinTitles()`.
  * - `url` is resolved to an absolute URL, e.g. `./d/e/f` + `/a/b/c` becomes `https://d.com/a/b/c/d/e/f`
+ * - `root` defaults to the origin of the resolved `url` (e.g. `https://x.com/`) when not set explicitly, so merged meta with a `url` always has a `root`.
  * - `stylesheets` and `links` hrefs newly set in `meta2` are absolutified against the merged `url`/`root`, so they stay correct no matter where they are later rendered.
  *
  * @param meta1 The existing fully-resolved `Meta` to merge into.
@@ -151,8 +152,11 @@ export function joinTitles(...titles: (string | undefined)[]): string {
 export function mergeMeta(meta1: Meta, meta2: PossibleMeta, caller: AnyCaller = mergeMeta): Meta {
 	const title = joinTitles(meta2.title, meta1.title);
 
-	const root = mergeMetaURL(undefined, meta1.root, meta2.root, undefined, caller);
-	const url = mergeMetaURL(root, meta1.url, meta2.url, meta2.params, caller);
+	const explicitRoot = mergeMetaURL(undefined, meta1.root, meta2.root, undefined, caller);
+	const url = mergeMetaURL(explicitRoot, meta1.url, meta2.url, meta2.params, caller);
+
+	// A meta with a `url` must always have a `root` — only correct for apps served from the origin's `/`, so sub-path deployments must set `root` explicitly.
+	const root = explicitRoot ?? (url ? new ImmutableURL("/", url) : undefined);
 
 	return {
 		...meta1,


### PR DESCRIPTION
Using `<App>` with a `url` but no `root` made every `requireMetaURL()` consumer (`<Router>`, `<SidebarLayout>`, `<TreeBreadcrumbs>`, `<RouteCache>`) throw a misleading `RequiredError: Meta URL and meta root must share an origin`. The real cause was a missing `root`, not an origin mismatch: `matchURLPrefix()` returns `undefined` both when its base is missing and when origins genuinely differ, and `requireMetaURL()` reported every falsy result with the origin wording.

## Changes

- **`mergeMeta()` derives `root` from the resolved `url`'s origin** (e.g. `https://x.com/`) when no explicit root is set, so merged meta with a `url` always has a `root`. The default only applies when `url` resolved absolute — a relative `url` with no root still fails fast in `requireURL()` as before.
- **`requireMetaURL()` gains a backup `"Meta root is required"` check** for hand-built meta that bypasses the merge, and the mismatch error is reworded to `"must share a root"` — it also fires when the `url` falls outside the root's path prefix, so the origin-specific wording was wrong. `MetaURL` now guarantees `root` alongside `url`.
- **`<Navigation>` publishes its live-URL meta through `mergeMeta()`** instead of a hand-built object literal, so the root default (and any future merge invariants) also covers the `window.location.href` fallback — the exact path that produced the original error. With only `url` changing, every other merge branch short-circuits, so this costs nothing per render.
- **Docs**: `App.md` and `Navigation.md` now state that setting `root` explicitly is strongly recommended — the derived default is only correct for apps served from the domain root, so sub-path deployments must set it.

## Tests

- `mergeMeta`: root derived from url origin, explicit root preserved, root stays unset without a url.
- `requireMetaURL`: path derivation with defaulted root, `"Meta URL is required"`, `"Meta root is required"` (hand-built meta), and `"must share a root"` for both origin mismatch and url-outside-root-path.
- New `Navigation.test.tsx`: published meta routes correctly with a derived root, and relative urls resolve against an explicit root.

`bun run test` passes: lint, types, and 1227 unit tests. (Biome logs a pre-existing internal panic on `Dialog.tsx` that also occurs on `main`; lint still exits 0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMASYAkGsZiz3oJhuHWEKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMASYAkGsZiz3oJhuHWEKk)_