### PR TITLE
test: give password hashing tests explicit 30s timeouts

### DIFF
--- a/modules/util/crypto.test.ts
+++ b/modules/util/crypto.test.ts
@@ -10,7 +10,7 @@ describe("hashPassword()", () => {
 		expect(typeof hash).toBe("string");
 		expect(hash.length).toBeGreaterThan(10);
 		expect(hash).toMatch(/[a-zA-Z0-9-_]+\$[0-9]+\$[a-zA-Z0-9-_]+/);
-	});
+	}, 30000);
 	test("Fails for short password", async () => {
 		try {
 			await hashPassword("abc");
@@ -18,27 +18,27 @@ describe("hashPassword()", () => {
 		} catch (err) {
 			expect(err).toBeInstanceOf(ValueError);
 		}
-	});
+	}, 30000);
 });
 describe("verifyPassword()", () => {
 	test("Works correctly", async () => {
 		const hash = await hashPassword(PASSWORD);
 		const result = await verifyPassword(PASSWORD, hash);
 		expect(result).toBe(true);
-	});
+	}, 30000);
 	test("Fails for wrong password", async () => {
 		const hash = await hashPassword(PASSWORD);
 		const result = await verifyPassword("wrongpassword", hash);
 		expect(result).toBe(false);
-	});
+	}, 30000);
 	test("Fails for for empty password", async () => {
 		const hash = await hashPassword(PASSWORD);
 		const result = await verifyPassword("", hash);
 		expect(result).toBe(false);
-	});
+	}, 30000);
 	test("Fails for for long password", async () => {
 		const hash = await hashPassword(PASSWORD);
 		const result = await verifyPassword("", hash);
 		expect(result).toBe(false);
-	});
+	}, 30000);
 });


### PR DESCRIPTION
## Summary

Fixes the latest Release failure on main. The failing test was `verifyPassword() > Works correctly` — **not** the firebase tests: it timed out at bun's default 5s.

Cause: the crypto tests run PBKDF2 at the real 500k-iteration default (hash + verify ≈ 1M SHA-512 iterations per test, several concurrently), and since #288 `test:unit` shares the 2-core runner with the JVM-based Firestore emulator running in parallel under `test:firebase`. The added CPU contention pushed the hashing past 5s. (When `test:unit` fails, `bun run --parallel` SIGINTs `test:firebase`, which is why the job exited 130.)

Fix: explicit 30-second timeouts on the six hashing tests, keeping the default iteration count exercised rather than weakening the work factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ujH4UcQivRqYVimsfLjbT

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujH4UcQivRqYVimsfLjbT)_