### PR TITLE
Disable GitHub Actions detection in test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"test:lint": "biome check .",
 		"test:type": "tsc --noEmit",
 		"test:style": "stylelint \"modules/**/*.css\"",
-		"test:unit": "bun test ./modules --concurrent --only-failures",
+		"test:unit": "GITHUB_ACTIONS=false bun test ./modules --concurrent --only-failures",
 		"fix": "bun run --sequential fix:*",
 		"fix:0:lint": "biome check --write .",
 		"fix:1:style": "stylelint \"modules/**/*.css\" --fix",
@@ -76,7 +76,7 @@
 		"build:1:copy": "cp package.json dist/package.json && cp LICENSE.md dist/LICENSE.md && cp README.md dist/README.md && cp .npmignore dist/.npmignore && cp -r modules/ui dist/ui",
 		"build:2:emit": "tsc -p tsconfig.build.json",
 		"build:3:syntax": "bun run ./dist/index.js",
-		"build:4:unit": "bun test ./dist/**/*.test.js --concurrent --only-failures --bail"
+		"build:4:unit": "GITHUB_ACTIONS=false bun test ./dist/**/*.test.js --concurrent --only-failures --bail"
 	},
 	"sideEffects": [
 		"*.css"


### PR DESCRIPTION
## Summary
Set `GITHUB_ACTIONS=false` environment variable when running unit tests to ensure consistent test behavior across local and CI environments.

## Changes
- Updated `test:unit` script to set `GITHUB_ACTIONS=false` before running bun tests
- Updated `build:4:unit` script to set `GITHUB_ACTIONS=false` before running bun tests

## Details
This change ensures that test execution behaves consistently regardless of whether tests are run locally or in a GitHub Actions CI environment. By explicitly disabling the GitHub Actions detection, we prevent any environment-specific test behavior that might be triggered by the presence of the `GITHUB_ACTIONS` environment variable.

https://claude.ai/code/session_01KMddyF3TsQS7wEczczvc9u