### PR TITLE
test: wait for the Firestore emulator to accept connections

### DIFF
--- a/modules/firebase/FirestoreProvider.test.ts
+++ b/modules/firebase/FirestoreProvider.test.ts
@@ -240,6 +240,17 @@ describe("FirestoreProvider (protocol)", () => {
 // Start one with: bun run test-firebase (or `firebase emulators:exec --only firestore --project shelving-test "bun test ./modules/firebase"`).
 const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST;
 if (EMULATOR_HOST) {
+	// Wait for the emulator to actually accept connections — it can report ready slightly before its socket binds, and a fetch that races it fails with instant connection resets.
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await fetch(`http://${EMULATOR_HOST}/`);
+			break;
+		} catch (thrown) {
+			if (attempt >= 100) throw new Error(`Firestore emulator at ${EMULATOR_HOST} is not accepting connections`, { cause: thrown });
+			await new Promise(resolve => setTimeout(resolve, 100));
+		}
+	}
+
 	const createProvider = () => new FirestoreProvider<string, Data>({ project: "shelving-test", host: `http://${EMULATOR_HOST}` });
 
 	testDBProvider("FirestoreProvider", createProvider, { realtime: false, transactions: true });

--- a/modules/firebase/README.md
+++ b/modules/firebase/README.md
@@ -58,3 +58,5 @@ bun run test:firebase
 ```
 
 This wraps `bun test ./modules/firebase` in `firebase emulators:exec`, which starts the emulator (requires Java 21+), sets `FIRESTORE_EMULATOR_HOST`, and shuts it down afterwards. Without that env var the emulator-backed tests don't register, so the offline suite stays green.
+
+The emulator host is pinned to `127.0.0.1` (not `localhost`) in `firebase.json`: the emulator's socket is IPv4-only, and Bun's `fetch` resolves `localhost` to `::1` without falling back to IPv4, which fails with `ECONNRESET`.


### PR DESCRIPTION
## Summary

Fixes the local `bun run test:firebase` failure on macOS, diagnosed as a **startup race**: `firebase emulators:exec` can launch the test script a beat before the emulator's Java socket actually binds. When that happens every request fails with an instant `ECONNRESET` and the whole suite burns through (in ~34ms) before the port opens. Diagnostics that confirmed it: with a long-running emulator, `curl` and `bun -e "fetch('http://127.0.0.1:8080/')"` both succeed on the same machine that failed under `emulators:exec`.

Fix: before registering the emulator-backed tests, poll the emulator endpoint until it responds (100ms interval, up to 10s), throwing one clear "emulator is not accepting connections" error if it never does. Free when the socket is already up — verified 41/41 against the emulator.

Also documents a second, separate finding in the firebase README: the emulator host must stay pinned to `127.0.0.1` (as `firebase.json` already does) because the emulator's socket is IPv4-only and Bun's `fetch` resolves `localhost` to `::1` **without falling back to IPv4** — unlike curl — so `localhost` fails with `ECONNRESET` even against a healthy emulator. That no-fallback behaviour may be worth reporting upstream to oven-sh/bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ujH4UcQivRqYVimsfLjbT

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujH4UcQivRqYVimsfLjbT)_