### PR TITLE
feat: two-step query writes for wrapping providers and an exact replayable change log

### DIFF
--- a/modules/db/provider/ChangesDBProvider.md
+++ b/modules/db/provider/ChangesDBProvider.md
@@ -12,5 +12,14 @@ const db = new ChangesDBProvider(new MemoryDBProvider());
 await db.setItem(POSTS, "abc", { title: "Hi", body: "", published: true });
 
 console.log(db.changes);
-// [{ action: "set", collection: "posts", id: "abc", data: { … } }]
+// [{ action: "set", collection: POSTS, id: "abc", data: { … } }]
+```
+
+Every change is an explicit per-item write: `DBChange` carries the `Collection` object, the `id` of the item written, and the `data` or `updates` that were applied. Query writes are inherited two-step from `ThroughDBProvider` — resolved to their matching items, then written per item — so they arrive in the log as the individual item writes they resolved to, never as an unresolved query.
+
+The log can be replayed onto another provider with `ChangesDBProvider.replay()` — useful for audit replay or syncing a secondary store:
+
+```ts
+const mirror = new MemoryDBProvider();
+await db.replay(mirror); // Re-issues every logged write, in order.
 ```

--- a/modules/db/provider/ChangesDBProvider.test.ts
+++ b/modules/db/provider/ChangesDBProvider.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { ChangesDBProvider, MockDBProvider } from "shelving/db";
-import { BASICS_COLLECTION, basic1, basic999, TransactionTestDBProvider } from "../../test/index.js";
+import { ChangesDBProvider, MemoryDBProvider, MockDBProvider } from "shelving/db";
+import { BASICS_COLLECTION, basic1, basic2, basic4, basic999, TransactionTestDBProvider } from "../../test/index.js";
 
 describe("ChangesDBProvider", () => {
 	test("records addItem() with an add action", async () => {
 		const provider = new ChangesDBProvider(new MockDBProvider());
 		const id = await provider.addItem(BASICS_COLLECTION, basic999);
 
-		expect(provider.changes).toEqual([{ action: "add", collection: "basics", id, data: basic999 }]);
+		expect(provider.changes).toEqual([{ action: "add", collection: BASICS_COLLECTION, id, data: basic999 }]);
 	});
 
 	test("records subsequent write operations in order", async () => {
@@ -15,12 +15,28 @@ describe("ChangesDBProvider", () => {
 
 		await provider.setItem(BASICS_COLLECTION, "basic1", basic1);
 		await provider.updateItem(BASICS_COLLECTION, "basic1", { str: "NEW" });
-		await provider.deleteQuery(BASICS_COLLECTION, { id: ["basic1"] });
+		await provider.deleteItem(BASICS_COLLECTION, "basic1");
 
 		expect(provider.changes.slice(-3)).toEqual([
-			{ action: "set", collection: "basics", id: "basic1", data: basic1 },
-			{ action: "update", collection: "basics", id: "basic1", updates: { str: "NEW" } },
-			{ action: "delete", collection: "basics", query: { id: ["basic1"] } },
+			{ action: "set", collection: BASICS_COLLECTION, id: "basic1", data: basic1 },
+			{ action: "update", collection: BASICS_COLLECTION, id: "basic1", updates: { str: "NEW" } },
+			{ action: "delete", collection: BASICS_COLLECTION, id: "basic1" },
+		]);
+	});
+
+	test("records query writes as the per-item changes they resolve to", async () => {
+		const provider = new ChangesDBProvider(new MemoryDBProvider());
+		await provider.setItem(BASICS_COLLECTION, "basic1", basic1); // Group "a".
+		await provider.setItem(BASICS_COLLECTION, "basic2", basic2); // Group "a".
+		await provider.setItem(BASICS_COLLECTION, "basic4", basic4); // Group "b".
+
+		await provider.updateQuery(BASICS_COLLECTION, { group: "a" }, { str: "NEW" });
+		await provider.deleteQuery(BASICS_COLLECTION, { group: "b" });
+
+		expect(provider.changes.slice(-3)).toEqual([
+			{ action: "update", collection: BASICS_COLLECTION, id: "basic1", updates: { str: "NEW" } },
+			{ action: "update", collection: BASICS_COLLECTION, id: "basic2", updates: { str: "NEW" } },
+			{ action: "delete", collection: BASICS_COLLECTION, id: "basic4" },
 		]);
 	});
 
@@ -33,8 +49,8 @@ describe("ChangesDBProvider", () => {
 		});
 
 		expect(provider.changes).toEqual([
-			{ action: "set", collection: "basics", id: "basic1", data: basic1 },
-			{ action: "update", collection: "basics", id: "basic1", updates: { str: "NEW" } },
+			{ action: "set", collection: BASICS_COLLECTION, id: "basic1", data: basic1 },
+			{ action: "update", collection: BASICS_COLLECTION, id: "basic1", updates: { str: "NEW" } },
 		]);
 	});
 
@@ -51,5 +67,25 @@ describe("ChangesDBProvider", () => {
 			expect((thrown as Error).message).toBe("nope");
 		}
 		expect(provider.changes).toEqual([]);
+	});
+
+	test("replay() re-issues logged changes onto another provider", async () => {
+		const provider = new ChangesDBProvider(new MemoryDBProvider());
+		const id = await provider.addItem(BASICS_COLLECTION, basic999);
+		await provider.setItem(BASICS_COLLECTION, "basic1", basic1);
+		await provider.setItem(BASICS_COLLECTION, "basic2", basic2);
+		await provider.updateItem(BASICS_COLLECTION, "basic1", { str: "NEW" });
+		await provider.deleteItem(BASICS_COLLECTION, "basic2");
+		await provider.setItem(BASICS_COLLECTION, "basic4", basic4);
+		await provider.deleteQuery(BASICS_COLLECTION, { group: "b" }); // Two-step, so this logs a per-item delete.
+
+		const target = new MemoryDBProvider();
+		await provider.replay(target);
+
+		expect(await target.getItem(BASICS_COLLECTION, id)).toMatchObject(basic999); // Adds replay with the same generated id.
+		// Replaying the full log reproduces the source provider's state exactly.
+		expect(await target.getQuery(BASICS_COLLECTION, { $order: "id" })).toEqual(
+			await provider.getQuery(BASICS_COLLECTION, { $order: "id" }),
+		);
 	});
 });

--- a/modules/db/provider/ChangesDBProvider.ts
+++ b/modules/db/provider/ChangesDBProvider.ts
@@ -1,7 +1,6 @@
 import type { MutableArray } from "../../util/array.js";
 import type { Data } from "../../util/data.js";
 import type { Identifier, Item } from "../../util/item.js";
-import type { Query } from "../../util/query.js";
 import type { Updates } from "../../util/update.js";
 import type { Collection } from "../collection/Collection.js";
 import type { DBProvider } from "./DBProvider.js";
@@ -10,15 +9,14 @@ import { ThroughDBProvider } from "./ThroughDBProvider.js";
 /**
  * Structured log entry recording a single database write performed through a `ChangesDBProvider`.
  *
- * - `action` is the kind of write; `collection` is the collection name; `id`, `query`, `data`, and `updates` carry whichever fields apply to that write.
+ * - `action` is the kind of write; `collection` is the `Collection` the write applies to; `id` is the item that was written; `data` and `updates` carry whichever fields apply to that write.
  *
  * @see https://shelving.cc/db/DBChange
  */
-export type DBChange<I extends Identifier> = {
+export type DBChange<I extends Identifier, T extends Data = Data> = {
 	readonly action: "add" | "set" | "update" | "delete";
-	readonly collection: string;
-	readonly id?: I | undefined;
-	readonly query?: unknown;
+	readonly collection: Collection<string, I, T>;
+	readonly id: I;
 	readonly data?: unknown;
 	readonly updates?: unknown;
 };
@@ -27,6 +25,8 @@ export type DBChange<I extends Identifier> = {
  * Database provider that records every write it performs to its `changes` log.
  *
  * - Wraps a `source` provider, delegates each write, then appends a `DBChange` entry describing what happened.
+ * - Every change is an explicit per-item write with an `id` — query writes are inherited two-step from `ThroughDBProvider`, so they arrive here as the individual item writes they resolved to.
+ * - Replay the log onto another provider with `ChangesDBProvider.replay()`.
  * - Useful for building audit logging, change feeds, or assertions in tests; reads are passed straight through and not logged.
  *
  * @see https://shelving.cc/db/ChangesDBProvider
@@ -37,22 +37,22 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 	 *
 	 * @see https://shelving.cc/db/ChangesDBProvider/changes
 	 */
-	get changes(): ReadonlyArray<DBChange<I>> {
+	get changes(): ReadonlyArray<DBChange<I, T>> {
 		return this._changes;
 	}
-	readonly _changes: MutableArray<DBChange<I>> = [];
+	readonly _changes: MutableArray<DBChange<I, T>> = [];
 
 	/** Log an `"add"` change after writing. */
 	override async addItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, data: TT): Promise<II> {
 		const id = await super.addItem(collection, data);
-		this._changes.push({ action: "add", collection: collection.name, id, data });
+		this._changes.push({ action: "add", collection, id, data });
 		return id;
 	}
 
 	/** Log a `"set"` change after writing. */
 	override async setItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II, data: TT): Promise<void> {
 		await super.setItem(collection, id, data);
-		this._changes.push({ action: "set", collection: collection.name, id, data });
+		this._changes.push({ action: "set", collection, id, data });
 	}
 
 	/** Log an `"update"` change after writing. */
@@ -62,42 +62,33 @@ export class ChangesDBProvider<I extends Identifier, T extends Data> extends Thr
 		updates: Updates<Item<II, TT>>,
 	): Promise<void> {
 		await super.updateItem(collection, id, updates);
-		this._changes.push({ action: "update", collection: collection.name, id, updates });
+		this._changes.push({ action: "update", collection, id, updates });
 	}
 
 	/** Log a `"delete"` change after writing. */
 	override async deleteItem<II extends I, TT extends T>(collection: Collection<string, II, TT>, id: II): Promise<void> {
 		await super.deleteItem(collection, id);
-		this._changes.push({ action: "delete", collection: collection.name, id });
+		this._changes.push({ action: "delete", collection, id });
 	}
 
-	/** Log a `"set"` change after writing. */
-	override async setQuery<II extends I, TT extends T>(
-		collection: Collection<string, II, TT>,
-		query: Query<Item<II, TT>>,
-		data: TT,
-	): Promise<void> {
-		await super.setQuery(collection, query, data);
-		this._changes.push({ action: "set", collection: collection.name, query, data });
-	}
-
-	/** Log an `"update"` change after writing. */
-	override async updateQuery<II extends I, TT extends T>(
-		collection: Collection<string, II, TT>,
-		query: Query<Item<II, TT>>,
-		updates: Updates<TT>,
-	): Promise<void> {
-		await super.updateQuery(collection, query, updates);
-		this._changes.push({ action: "update", collection: collection.name, query, updates });
-	}
-
-	/** Log a `"delete"` change after writing. */
-	override async deleteQuery<II extends I, TT extends T>(
-		collection: Collection<string, II, TT>,
-		query: Query<Item<II, TT>>,
-	): Promise<void> {
-		await super.deleteQuery(collection, query);
-		this._changes.push({ action: "delete", collection: collection.name, query });
+	/**
+	 * Replay the `changes` log onto another provider, re-issuing each write in order.
+	 *
+	 * - Useful for audit replay or syncing a secondary store.
+	 * - `"add"` changes replay as `DBProvider.setItem()` with the logged id, so the target keeps the same generated ids.
+	 * - The changes replay as a sequence of awaited writes — the replay itself is not atomic.
+	 *
+	 * @param provider Provider to replay the changes onto.
+	 * @example await changes.replay(mirror);
+	 * @see https://shelving.cc/db/ChangesDBProvider/replay
+	 */
+	async replay(provider: DBProvider<I, T>): Promise<void> {
+		// `as` casts needed: the log stores `data` and `updates` loosely as `unknown`.
+		for (const { action, collection, id, data, updates } of this._changes) {
+			if (action === "delete") await provider.deleteItem(collection, id);
+			else if (action === "update") await provider.updateItem(collection, id, updates as Updates<Item<I, T>>);
+			else await provider.setItem(collection, id, data as T);
+		}
 	}
 
 	// Override so that transaction copies get their own log.

--- a/modules/db/provider/DBProvider.md
+++ b/modules/db/provider/DBProvider.md
@@ -18,6 +18,8 @@ async function publishPost(provider: DBProvider, id: string) {
 
 The method surface covers single items (`getItem`, `requireItem`, `addItem`, `setItem`, `updateItem`, `deleteItem`), queries (`getQuery`, `countQuery`, `setQuery`, `updateQuery`, `deleteQuery`, `getFirst`, `requireFirst`), realtime (`getItemSequence`, `getQuerySequence` — iterate with `for await...of`), and transactions (`transact`).
 
+Query writes (`setQuery`, `updateQuery`, `deleteQuery`) have a deliberately weak portable contract: an engine may execute them natively in a single call (SQL's `UPDATE … WHERE`), or resolve the matching items first and then write per item — "two-step", the default for wrapping providers (see `ThroughDBProvider`). Either way they are only guaranteed atomic inside `transact()`.
+
 ## Transactions
 
 `transact()` runs a callback as a single atomic transaction — every write made through the provider the callback receives is committed together, or not at all:

--- a/modules/db/provider/DBProvider.ts
+++ b/modules/db/provider/DBProvider.ts
@@ -156,6 +156,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 
 	/**
 	 * Set (overwrite) the data for every item matching a query.
+	 * - Not guaranteed atomic: an implementation may resolve the matching items first and then write per item (two-step — see `ThroughDBProvider`), so wrap the call in `transact()` when atomicity matters.
 	 *
 	 * @param collection Collection to write to.
 	 * @param query Query selecting the items to set.
@@ -171,6 +172,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 
 	/**
 	 * Apply partial updates to every item matching a query.
+	 * - Not guaranteed atomic: an implementation may resolve the matching items first and then write per item (two-step — see `ThroughDBProvider`), so wrap the call in `transact()` when atomicity matters.
 	 *
 	 * @param collection Collection to write to.
 	 * @param query Query selecting the items to update.
@@ -186,6 +188,7 @@ export abstract class DBProvider<I extends Identifier = Identifier, T extends Da
 
 	/**
 	 * Delete every item matching a query.
+	 * - Not guaranteed atomic: an implementation may resolve the matching items first and then delete per item (two-step — see `ThroughDBProvider`), so wrap the call in `transact()` when atomicity matters.
 	 *
 	 * @param collection Collection to delete from.
 	 * @param query Query selecting the items to delete.

--- a/modules/db/provider/DebugDBProvider.ts
+++ b/modules/db/provider/DebugDBProvider.ts
@@ -143,6 +143,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 		}
 	}
 
+	/** Passthrough, not two-step: log the query write the caller made, not the per-item writes it implies. */
 	override async setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
@@ -150,7 +151,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	): Promise<void> {
 		try {
 			console.debug(`${ANSI_RIGHT} SET QUERY`, collection.name, query, data);
-			await super.setQuery(collection, query, data);
+			await this.source.setQuery(collection, query, data);
 			console.debug(`${ANSI_SUCCESS} SET QUERY`, collection.name, query, data);
 		} catch (reason) {
 			console.error(`${ANSI_FAILURE} SET QUERY`, collection.name, query, data, reason);
@@ -158,6 +159,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 		}
 	}
 
+	/** Passthrough, not two-step: log the query write the caller made, not the per-item writes it implies. */
 	override async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
@@ -165,7 +167,7 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 	): Promise<void> {
 		try {
 			console.debug(`${ANSI_RIGHT} UPDATE QUERY`, collection.name, query, updates);
-			await super.updateQuery(collection, query, updates);
+			await this.source.updateQuery(collection, query, updates);
 			console.debug(`${ANSI_SUCCESS} UPDATE QUERY`, collection.name, query, updates);
 		} catch (reason) {
 			console.error(`${ANSI_FAILURE} UPDATE QUERY`, collection.name, query, updates, reason);
@@ -173,13 +175,14 @@ export class DebugDBProvider<I extends Identifier, T extends Data> extends Throu
 		}
 	}
 
+	/** Passthrough, not two-step: log the query write the caller made, not the per-item writes it implies. */
 	override async deleteQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 	): Promise<void> {
 		try {
 			console.debug(`${ANSI_RIGHT} DELETE QUERY`, collection.name, query);
-			await super.deleteQuery(collection, query);
+			await this.source.deleteQuery(collection, query);
 			console.debug(`${ANSI_SUCCESS} DELETE QUERY`, collection.name, query);
 		} catch (reason) {
 			console.error(`${ANSI_FAILURE} DELETE QUERY`, collection.name, query, reason);

--- a/modules/db/provider/ThroughDBProvider.md
+++ b/modules/db/provider/ThroughDBProvider.md
@@ -21,6 +21,17 @@ class TimingDBProvider extends ThroughDBProvider {
 }
 ```
 
+## Query writes: passthrough vs two-step
+
+A query write (`setQuery`, `updateQuery`, `deleteQuery`) can be implemented with one of two strategies:
+
+- **Passthrough** — forward the query write to `source` in a single call, so the underlying engine executes it natively (e.g. one SQL `UPDATE … WHERE`). Wrapper behaviour applies to the operation, but not to the individual items it changes.
+- **Two-step** — resolve the query to its matching items with `getQuery()`, then write each item through the wrapper's own `setItem()` / `updateItem()` / `deleteItem()`, so every implied write flows through the wrapper's overrides.
+
+`ThroughDBProvider` defaults to two-step — the same theory as `transact()` below: a wrapper's behaviour should apply to everything that happens through it. `ChangesDBProvider` relies on this to record exactly which items a query write changed. Wrappers that don't need per-item behaviour override the query writes back to passthrough (calling `source` directly) to keep the engine's native efficiency and atomicity — `ValidationDBProvider` (validates the query write's inputs up front) and `DebugDBProvider` (logs the operation the caller made) both do this.
+
+The resolve and the writes are separate steps, so a two-step query write is only atomic when it runs inside `transact()`.
+
 ## Transactions
 
 `ThroughDBProvider.transact()` keeps the wrapper's behaviour inside the transaction: the callback receives a copy of the wrapping provider whose `source` is swapped for the source's transaction provider, so overridden methods (validation, timing, logging, etc.) still apply to every read and write in the callback. Subclasses get this for free — `TimingDBProvider` above times operations inside transactions without any extra code.

--- a/modules/db/provider/ThroughDBProvider.md
+++ b/modules/db/provider/ThroughDBProvider.md
@@ -30,7 +30,7 @@ A query write (`setQuery`, `updateQuery`, `deleteQuery`) can be implemented with
 
 `ThroughDBProvider` defaults to two-step — the same theory as `transact()` below: a wrapper's behaviour should apply to everything that happens through it. `ChangesDBProvider` relies on this to record exactly which items a query write changed. Wrappers that don't need per-item behaviour override the query writes back to passthrough (calling `source` directly) to keep the engine's native efficiency and atomicity — `ValidationDBProvider` (validates the query write's inputs up front) and `DebugDBProvider` (logs the operation the caller made) both do this.
 
-The resolve and the writes are separate steps, so a two-step query write is only atomic when it runs inside `transact()`.
+The per-item writes run concurrently (via `awaitValues()`, which settles every write before rejecting), so a two-step batch over a remote source costs one round-trip of latency rather than one per item — though the order the individual writes complete in (and appear in a `ChangesDBProvider` log) is not guaranteed within the batch. The resolve and the writes are separate steps, so a two-step query write is only atomic when it runs inside `transact()`.
 
 ## Transactions
 

--- a/modules/db/provider/ThroughDBProvider.test.ts
+++ b/modules/db/provider/ThroughDBProvider.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { Collection } from "shelving/db";
-import { ThroughDBProvider } from "shelving/db";
+import { MockDBProvider, ThroughDBProvider } from "shelving/db";
 import type { Data } from "shelving/util/data";
 import type { OptionalItem } from "shelving/util/item";
-import { BASICS_COLLECTION, basic1, basic2, TransactionTestDBProvider } from "../../test/index.js";
+import { BASICS_COLLECTION, basic1, basic2, basic4, TransactionTestDBProvider } from "../../test/index.js";
 
 /** Wrapping provider that records the ids of reads and writes passing through it. */
 class _TestDBProvider extends ThroughDBProvider<string, Data> {
@@ -37,6 +37,29 @@ describe("ThroughDBProvider", () => {
 		expect(provider.writes).toEqual(["basic1", "basic2"]);
 		// The transaction wrote through to the source.
 		expect(await source.getItem(BASICS_COLLECTION, "basic2")).toMatchObject(basic2);
+	});
+
+	test("query writes are two-step: resolved with getQuery() then written per item", async () => {
+		const source = new MockDBProvider<string>();
+		await source.setItem(BASICS_COLLECTION, "basic1", basic1); // Group "a".
+		await source.setItem(BASICS_COLLECTION, "basic2", basic2); // Group "a".
+		await source.setItem(BASICS_COLLECTION, "basic4", basic4); // Group "b".
+		source.calls.length = 0;
+		const provider = new ThroughDBProvider<string, Data>(source);
+
+		await provider.updateQuery(BASICS_COLLECTION, { group: "a" }, { str: "NEW" });
+		await provider.deleteQuery(BASICS_COLLECTION, { group: "b" });
+
+		// The source received a resolve read plus per-item writes — never a query write.
+		expect(source.calls.map(({ type, id }) => ({ type, id }))).toEqual([
+			{ type: "getQuery", id: undefined },
+			{ type: "updateItem", id: "basic1" },
+			{ type: "updateItem", id: "basic2" },
+			{ type: "getQuery", id: undefined },
+			{ type: "deleteItem", id: "basic4" },
+		]);
+		expect(await source.getItem(BASICS_COLLECTION, "basic1")).toMatchObject({ ...basic1, str: "NEW" });
+		expect(await source.getItem(BASICS_COLLECTION, "basic4")).toBe(undefined);
 	});
 
 	test("transact() propagates callback errors", async () => {

--- a/modules/db/provider/ThroughDBProvider.ts
+++ b/modules/db/provider/ThroughDBProvider.ts
@@ -1,3 +1,4 @@
+import { awaitValues } from "../../util/async.js";
 import type { Data } from "../../util/data.js";
 import { awaitDispose } from "../../util/dispose.js";
 import type { Identifier, Item, Items, ItemsSequence, OptionalItem, OptionalItemSequence } from "../../util/item.js";
@@ -71,24 +72,28 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 	/**
 	 * Two-step: resolve the query to its matching items with `getQuery()`, then set each one with `setItem()`.
 	 * - Routes every implied write through this provider's own item methods, so wrapper behaviour applies to each item — the same theory as `transact()` re-wrapping the transaction provider.
+	 * - The per-item writes run concurrently (`awaitValues()`), so a batch over a remote source costs one round-trip of latency, not one per item.
 	 * - The resolve and the writes are separate steps, so this is only atomic inside `transact()`.
 	 */
 	async setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
-		for (const { id } of await this.getQuery(collection, query)) await this.setItem(collection, id, data);
+		const items = await this.getQuery(collection, query);
+		await awaitValues(...items.map(({ id }) => this.setItem(collection, id, data)));
 	}
 
-	/** Two-step: resolve the query to its matching items with `getQuery()`, then update each one with `updateItem()` — see `ThroughDBProvider.setQuery()`. */
+	/** Two-step: resolve the query to its matching items with `getQuery()`, then update each one concurrently with `updateItem()` — see `ThroughDBProvider.setQuery()`. */
 	async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
 	): Promise<void> {
-		for (const { id } of await this.getQuery(collection, query)) await this.updateItem(collection, id, updates as Updates<Item<II, TT>>);
+		const items = await this.getQuery(collection, query);
+		await awaitValues(...items.map(({ id }) => this.updateItem(collection, id, updates as Updates<Item<II, TT>>)));
 	}
 
-	/** Two-step: resolve the query to its matching items with `getQuery()`, then delete each one with `deleteItem()` — see `ThroughDBProvider.setQuery()`. */
+	/** Two-step: resolve the query to its matching items with `getQuery()`, then delete each one concurrently with `deleteItem()` — see `ThroughDBProvider.setQuery()`. */
 	async deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
-		for (const { id } of await this.getQuery(collection, query)) await this.deleteItem(collection, id);
+		const items = await this.getQuery(collection, query);
+		await awaitValues(...items.map(({ id }) => this.deleteItem(collection, id)));
 	}
 
 	getFirst<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<OptionalItem<II, TT>> {

--- a/modules/db/provider/ThroughDBProvider.ts
+++ b/modules/db/provider/ThroughDBProvider.ts
@@ -11,6 +11,7 @@ import type { DBProvider } from "./DBProvider.js";
  * Database provider that passes every operation straight through to a wrapped `source` provider.
  *
  * - Base for the layered `Through*Provider` family (validation, caching, logging, change tracking); subclasses override individual methods to add behaviour and call `super` to delegate.
+ * - Query writes (`setQuery()`, `updateQuery()`, `deleteQuery()`) are two-step by default — resolved to their matching items with `getQuery()`, then written per item through this provider's own item methods — so wrapper behaviour applies to every implied write. Subclasses that don't need per-item behaviour override them to pass through to `source` directly.
  * - Exposes `source` and implements `Sourceable`, so wrapped providers can be discovered with `getSource()` / `requireSource()`.
  *
  * @see https://shelving.cc/db/ThroughDBProvider
@@ -67,20 +68,27 @@ export class ThroughDBProvider<I extends Identifier, T extends Data> implements 
 		return this.source.getQuerySequence(collection, query);
 	}
 
-	setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
-		return this.source.setQuery(collection, query, data);
+	/**
+	 * Two-step: resolve the query to its matching items with `getQuery()`, then set each one with `setItem()`.
+	 * - Routes every implied write through this provider's own item methods, so wrapper behaviour applies to each item — the same theory as `transact()` re-wrapping the transaction provider.
+	 * - The resolve and the writes are separate steps, so this is only atomic inside `transact()`.
+	 */
+	async setQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>, data: TT): Promise<void> {
+		for (const { id } of await this.getQuery(collection, query)) await this.setItem(collection, id, data);
 	}
 
-	updateQuery<II extends I, TT extends T>(
+	/** Two-step: resolve the query to its matching items with `getQuery()`, then update each one with `updateItem()` — see `ThroughDBProvider.setQuery()`. */
+	async updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
 	): Promise<void> {
-		return this.source.updateQuery(collection, query, updates);
+		for (const { id } of await this.getQuery(collection, query)) await this.updateItem(collection, id, updates as Updates<Item<II, TT>>);
 	}
 
-	deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
-		return this.source.deleteQuery(collection, query);
+	/** Two-step: resolve the query to its matching items with `getQuery()`, then delete each one with `deleteItem()` — see `ThroughDBProvider.setQuery()`. */
+	async deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
+		for (const { id } of await this.getQuery(collection, query)) await this.deleteItem(collection, id);
 	}
 
 	getFirst<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<OptionalItem<II, TT>> {

--- a/modules/db/provider/ValidationDBProvider.test.ts
+++ b/modules/db/provider/ValidationDBProvider.test.ts
@@ -53,6 +53,33 @@ describe("ValidationDBProvider", () => {
 		expect(source.calls).toHaveLength(0);
 	});
 
+	test("query writes are passthrough: the source receives the query write itself", async () => {
+		const source = new MockDBProvider();
+		await source.setItem(BASICS_COLLECTION, "basic1", basic1);
+		source.calls.length = 0;
+		const provider = new ValidationDBProvider(source);
+
+		await provider.setQuery(BASICS_COLLECTION, { group: "a" }, basic999);
+		await provider.updateQuery(BASICS_COLLECTION, { group: "a" }, { str: "NEW" });
+		await provider.deleteQuery(BASICS_COLLECTION, { group: "a" });
+
+		// One native query write each — no resolve reads, no per-item writes.
+		expect(source.calls.map(({ type }) => type)).toEqual(["setQuery", "updateQuery", "deleteQuery"]);
+	});
+
+	test("validates updateQuery() updates before calling the source provider", async () => {
+		const source = new MockDBProvider();
+		const provider = new ValidationDBProvider(source);
+
+		try {
+			await provider.updateQuery(BASICS_COLLECTION, {}, { num: "bad" } as never);
+			expect.unreachable();
+		} catch (thrown) {
+			expect(thrown).toBeInstanceOf(ValueError);
+		}
+		expect(source.calls).toHaveLength(0);
+	});
+
 	test("validates reads inside transact()", async () => {
 		const source = new TransactionTestDBProvider();
 		source.getTable(BASICS_COLLECTION).setItem("basic1", { ...basic1, num: "bad" } as never);

--- a/modules/db/provider/ValidationDBProvider.ts
+++ b/modules/db/provider/ValidationDBProvider.ts
@@ -73,26 +73,33 @@ export class ValidationDBProvider<I extends Identifier, T extends Data> extends 
 		for await (const items of super.getQuerySequence(collection, query)) yield _validateItems(collection, items, this.getQuerySequence);
 	}
 
-	/** Validate the data before writing; throws `ValueError` if it fails the collection schema. */
+	/**
+	 * Validate the data before writing; throws `ValueError` if it fails the collection schema.
+	 * - Passthrough, not two-step: validation applies to the query write's own inputs up front, so per-item routing adds nothing — pass through to keep the source's native query write.
+	 */
 	override setQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		data: TT,
 	): Promise<void> {
-		return super.setQuery(collection, query, collection.validate(data));
+		return this.source.setQuery(collection, query, collection.validate(data));
 	}
 
-	/** Validate the updates before writing; throws `ValueError` if they fail the collection schema. */
+	/**
+	 * Validate the updates before writing; throws `ValueError` if they fail the collection schema.
+	 * - Passthrough, not two-step: validation applies to the query write's own inputs up front, so per-item routing adds nothing — pass through to keep the source's native query write.
+	 */
 	override updateQuery<II extends I, TT extends T>(
 		collection: Collection<string, II, TT>,
 		query: Query<Item<II, TT>>,
 		updates: Updates<TT>,
 	): Promise<void> {
-		return super.updateQuery(collection, query, _validateUpdates(collection, updates, this.updateQuery));
+		return this.source.updateQuery(collection, query, _validateUpdates(collection, updates, this.updateQuery));
 	}
 
+	/** Passthrough, not two-step: there are no inputs to validate per item, so keep the source's native query write. */
 	override deleteQuery<II extends I, TT extends T>(collection: Collection<string, II, TT>, query: Query<Item<II, TT>>): Promise<void> {
-		return super.deleteQuery(collection, query);
+		return this.source.deleteQuery(collection, query);
 	}
 }
 


### PR DESCRIPTION
Part of #280 (does not close it — memory transactions land in a follow-up PR built on this).

Establishes the terminology and mechanics that make change capture exact, per the agreed plan. A query write (`setQuery` / `updateQuery` / `deleteQuery`) can be implemented with one of two strategies:

- **Passthrough** — forward the query write to `source` in a single call, so the underlying engine executes it natively (e.g. one SQL `UPDATE … WHERE`). Wrapper behaviour applies to the operation, but not to the individual items it changes.
- **Two-step** — resolve the query to its matching items with `getQuery()`, then write each item through the wrapper's own `setItem()` / `updateItem()` / `deleteItem()`, so every implied write flows through the wrapper's overrides.

## Changes

### `ThroughDBProvider` — two-step by default

The wrapper base now implements query writes two-step, on the same theory as its `transact()` re-wrapping: a wrapper's behaviour should apply to everything that happens through it, and passthrough query writes were a hole in that contract (the engine executed writes the wrapper never saw). Two-step reads-then-writes, so it's only atomic inside `transact()` — documented on the `DBProvider` contract (`DBProvider.md` + the three method docblocks), where engines remain free to implement natively.

### `ValidationDBProvider` + `DebugDBProvider` — passthrough overrides

Both override back to passthrough (calling `this.source` directly, with docblocks explaining why): validation applies to the query write's own inputs up front so per-item routing adds nothing, and debug logs the operation the caller made rather than N synthetic item lines. Chains keep the engine's native efficiency and atomicity unless a wrapper genuinely needs per-item behaviour.

### `ChangesDBProvider` — exact per-item log + `replay()`

The wrapper that needs two-step: it **deletes** its three query-write overrides and inherits the default, so query writes arrive in its log as the individual item writes they resolved to. `DBChange` is reshaped to match:

- `collection` is now the **`Collection` object** rather than its name — required so a change can map back to a concrete write. **Breaking in practice** for code reading the collection name from the log; use `change.collection.name`. Kept within the non-major release flow per the v0 policy.
- `id` is now **required** and the `query` field is **gone** — every change is an explicit per-item write.

New `ChangesDBProvider.replay(provider)` re-issues the log onto another provider in order: `add` replays as `setItem()` with the logged id (so the target keeps the same generated ids), `set`/`update`/`delete` map to their item writes. Replay is documented as not itself atomic.

## Tests

- `ThroughDBProvider`: query writes proven two-step against a `MockDBProvider` call log (resolve read + per-item writes, never a query write).
- `ValidationDBProvider`: query writes proven passthrough (one native query call each, no resolve reads); `updateQuery` inputs validated before any source call.
- `ChangesDBProvider`: query writes logged as the per-item changes they resolved to; `replay()` reproduces the source provider's state exactly on a fresh provider, including id preservation for `add`; transaction capture tests updated for the new `DBChange` shape.

`bun run test` is green: lint, types, 1270 unit tests, and the Firestore emulator suite (41 tests).

## Next

- **PR 2** (follow-up): `MemoryDBProvider.transact()` per the original #280 design — clone the provider and tables, wrap the clone in a `ChangesDBProvider`, `replay()` the captured changes onto the original on success. Trivially correct now the log is exact. Closes #280.
- **Later stream**: `CacheDBProvider` transactions and fetch-first writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AufCMH7FM21hHnwQNXCmGf